### PR TITLE
fileName clobbered when requiring file and binding to compile event.

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -95,14 +95,14 @@
     return _d;
   };
   compileScript = function(file, input, base) {
-    var _d, _e, _f, o, options, t, task;
+    var _d, _e, _f, o, options, req, t, task;
     o = opts;
     options = compileOptions(file);
     if (o.require) {
       _e = o.require;
       for (_d = 0, _f = _e.length; _d < _f; _d++) {
-        file = _e[_d];
-        require(helpers.starts(file, '.') ? fs.realpathSync(file) : file);
+        req = _e[_d];
+        require(helpers.starts(req, '.') ? fs.realpathSync(req) : req);
       }
     }
     try {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -96,7 +96,7 @@ compileScript = (file, input, base) ->
   o = opts
   options = compileOptions file
   if o.require
-    require(if helpers.starts(file, '.') then fs.realpathSync(file) else file) for file in o.require
+    require(if helpers.starts(req, '.') then fs.realpathSync(req) else req) for req in o.require
   try
     t = task = {file, input, options}
     CoffeeScript.emit 'compile', task


### PR DESCRIPTION
Take this case for instance:

```
# file: require.coffee
sys = require 'sys'
CoffeeScript.on 'compile', (task) ->
  sys.debug task.fileName
```

then used such as:

```
coffee --require require.coffee other.coffee
```

will produce something like `DEBUG: require.coffee`. A temporary work around is to access `task.options.fileName` in the event handler. The [cause](http://github.com/jashkenas/coffee-script/blob/9290e508c69ad20f2b02a30a986592e70cc733e0/src/command.coffee#L99) is a bad variable name in the task which overrides the filename.

The fix is attached.
