### PR TITLE
Remove the useless property access from for-of

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1648,8 +1648,8 @@
         return n instanceof CodeNode;
       });
       scope = o.scope;
-      name = (this.name && this.name.compile(o)) || scope.freeVariable('i');
-      index = this.index && this.index.compile(o);
+      name = this.name == null ? undefined : this.name.compile(o);
+      index = this.index == null ? undefined : this.index.compile(o);
       if (name && !this.pattern && (range || !codeInBody)) {
         scope.find(name, {
           immediate: true
@@ -1665,13 +1665,13 @@
       }
       ivar = (function() {
         if (codeInBody) {
-          return scope.freeVariable('i');
+          return null;
         } else if (range) {
           return name;
         } else {
-          return index || scope.freeVariable('i');
+          return index;
         }
-      })();
+      })() || scope.freeVariable('i');
       varPart = '';
       guardPart = '';
       body = Expressions.wrap([this.body]);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1380,12 +1380,13 @@ exports.ForNode = class ForNode extends BaseNode
     source        = if range then @source.base else @source
     codeInBody    = @body.contains (n) -> n instanceof CodeNode
     scope         = o.scope
-    name          = (@name and @name.compile(o)) or scope.freeVariable 'i'
-    index         = @index and @index.compile o
+    name          = @name ?.compile o
+    index         = @index?.compile o
     scope.find(name,  immediate: yes) if name and not @pattern and (range or not codeInBody)
     scope.find(index, immediate: yes) if index
     rvar          = scope.freeVariable 'result' unless topLevel
-    ivar          = if codeInBody then scope.freeVariable 'i' else if range then name else index or scope.freeVariable 'i'
+    ivar          = (if codeInBody then null else if range then name else index) or
+                    scope.freeVariable 'i'
     varPart       = ''
     guardPart     = ''
     body          = Expressions.wrap([@body])


### PR DESCRIPTION
```
$ bin/coffee --no-wrap -pe 'k for all k of o'
var _i, _ref, k;
_ref = o;
for (k in _ref) {
  _i = _ref[k];
  k
}
```

Note the `_i`.
