### PR TITLE
Heredoc indentation detector ignores blank lines

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -395,7 +395,7 @@
       if (!(options.herecomment)) {
         while ((match = HEREDOC_INDENT.exec(doc)) !== null) {
           attempt = (typeof (_ref2 = match[2]) !== "undefined" && _ref2 !== null) ? match[2] : match[3];
-          if (!(typeof indent !== "undefined" && indent !== null) || attempt.length < indent.length) {
+          if (!(typeof indent !== "undefined" && indent !== null) || (0 < attempt.length) && (attempt.length < indent.length)) {
             indent = attempt;
           }
         }

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -323,7 +323,7 @@ exports.Lexer = class Lexer
     unless options.herecomment
       while (match = HEREDOC_INDENT.exec(doc)) isnt null
         attempt = if match[2]? then match[2] else match[3]
-        indent = attempt if not indent? or attempt.length < indent.length
+        indent = attempt if not indent? or 0 < attempt.length < indent.length
     indent or= ''
     doc = doc.replace(new RegExp("^" + indent, 'gm'), '')
     return doc if options.herecomment

--- a/test/test_heredocs.coffee
+++ b/test/test_heredocs.coffee
@@ -79,3 +79,12 @@ ok b is "basic heredoc \#{val}\non two lines"
 
 a = '''here's an apostrophe'''
 ok a is "here's an apostrophe"
+
+
+# The indentation detector ignores blank lines without trailing whitespace
+a = """
+    one
+    two
+
+    """
+ok a is "one\ntwo\n"


### PR DESCRIPTION
This makes it possible to insert trailing newlines in an indented heredoc when your editor is configured to strip trailing whitespace.
