### PR TITLE
Refactor helpers

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -1,5 +1,5 @@
 fs            = require 'fs'
-{helpers}     = require './lib/helpers'
+helpers       = require './lib/helpers'
 CoffeeScript  = require './lib/coffee-script'
 {spawn, exec} = require 'child_process'
 path          = require 'path'

--- a/bin/cake
+++ b/bin/cake
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 var path = require('path');
-var fs = require('fs');
-var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
+var fs   = require('fs');
+var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
-require(lib + '/helpers').helpers.extend(global, require('sys'));
+require(lib + '/helpers').extend(global, require('sys'));
 require(lib + '/cake').run();

--- a/bin/coffee
+++ b/bin/coffee
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 var path = require('path');
-var fs = require('fs');
-var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
+var fs   = require('fs');
+var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
-require(lib + '/helpers').helpers.extend(global, require('sys'));
+require(lib + '/helpers').extend(global, require('sys'));
 require(lib + '/command').run();

--- a/lib/cake.js
+++ b/lib/cake.js
@@ -2,7 +2,7 @@
   var CoffeeScript, fs, helpers, missingTask, oparse, options, optparse, path, printTasks, switches, tasks;
   fs = require('fs');
   path = require('path');
-  helpers = require('./helpers').helpers;
+  helpers = require('./helpers');
   optparse = require('./optparse');
   CoffeeScript = require('./coffee-script');
   tasks = {};

--- a/lib/command.js
+++ b/lib/command.js
@@ -4,8 +4,7 @@
   path = require('path');
   optparse = require('./optparse');
   CoffeeScript = require('./coffee-script');
-  _ref = require('./helpers');
-  helpers = _ref.helpers;
+  helpers = require('./helpers');
   _ref = require('child_process');
   spawn = _ref.spawn;
   exec = _ref.exec;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,6 @@
 (function() {
-  var extend, helpers, indexOf;
-  helpers = (exports.helpers = {});
-  indexOf = (helpers.indexOf = Array.indexOf || (Array.prototype.indexOf ? function(array, item, from) {
+  var extend, indexOf;
+  indexOf = (exports.indexOf = Array.indexOf || (Array.prototype.indexOf ? function(array, item, from) {
     return array.indexOf(item, from);
   } : function(array, item, from) {
     var _len, _ref, index, other;
@@ -14,18 +13,18 @@
     }
     return -1;
   }));
-  helpers.include = function(list, value) {
+  exports.include = function(list, value) {
     return 0 <= indexOf(list, value);
   };
-  helpers.starts = function(string, literal, start) {
+  exports.starts = function(string, literal, start) {
     return literal === string.substr(start, literal.length);
   };
-  helpers.ends = function(string, literal, back) {
+  exports.ends = function(string, literal, back) {
     var ll;
     ll = literal.length;
     return literal === string.substr(string.length - ll - (back || 0), ll);
   };
-  helpers.compact = function(array) {
+  exports.compact = function(array) {
     var _i, _len, _ref, _result, item;
     _result = []; _ref = array;
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
@@ -36,7 +35,7 @@
     }
     return _result;
   };
-  helpers.count = function(string, letter) {
+  exports.count = function(string, letter) {
     var num, pos;
     num = (pos = 0);
     while (0 < (pos = 1 + string.indexOf(letter, pos))) {
@@ -44,10 +43,10 @@
     }
     return num;
   };
-  helpers.merge = function(options, overrides) {
+  exports.merge = function(options, overrides) {
     return extend(extend({}, options), overrides);
   };
-  extend = (helpers.extend = function(object, properties) {
+  extend = (exports.extend = function(object, properties) {
     var _ref, key, val;
     _ref = properties;
     for (key in _ref) {
@@ -56,10 +55,10 @@
     }
     return object;
   });
-  helpers.flatten = function(array) {
+  exports.flatten = function(array) {
     return array.concat.apply([], array);
   };
-  helpers.del = function(obj, key) {
+  exports.del = function(obj, key) {
     var val;
     val = obj[key];
     delete obj[key];

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -3,7 +3,7 @@
   var __slice = Array.prototype.slice;
   _ref = require('./rewriter');
   Rewriter = _ref.Rewriter;
-  _ref = require('./helpers').helpers;
+  _ref = require('./helpers');
   include = _ref.include;
   count = _ref.count;
   starts = _ref.starts;

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -10,7 +10,7 @@
   };
   _ref = require('./scope');
   Scope = _ref.Scope;
-  _ref = require('./helpers').helpers;
+  _ref = require('./helpers');
   compact = _ref.compact;
   flatten = _ref.flatten;
   merge = _ref.merge;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1,7 +1,7 @@
 (function() {
   var CoffeeScript, helpers, readline, repl, run, stdio;
   CoffeeScript = require('./coffee-script');
-  helpers = require('./helpers').helpers;
+  helpers = require('./helpers');
   readline = require('readline');
   stdio = process.openStdin();
   helpers.extend(global, {

--- a/lib/rewriter.js
+++ b/lib/rewriter.js
@@ -1,7 +1,7 @@
 (function() {
   var BALANCED_PAIRS, EXPRESSION_CLOSE, EXPRESSION_END, EXPRESSION_START, IMPLICIT_BLOCK, IMPLICIT_CALL, IMPLICIT_END, IMPLICIT_FUNC, INVERSES, LINEBREAKS, Rewriter, SINGLE_CLOSERS, SINGLE_LINERS, _i, _len, _ref, _result, include, pair;
   var __hasProp = Object.prototype.hasOwnProperty;
-  _ref = require('./helpers').helpers;
+  _ref = require('./helpers');
   include = _ref.include;
   exports.Rewriter = (function() {
     Rewriter = function() {};

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,7 +1,7 @@
 (function() {
   var Scope, _ref, extend;
   var __hasProp = Object.prototype.hasOwnProperty;
-  _ref = require('./helpers').helpers;
+  _ref = require('./helpers');
   extend = _ref.extend;
   exports.Scope = (function() {
     Scope = function(parent, expressions, method) {

--- a/src/cake.coffee
+++ b/src/cake.coffee
@@ -9,7 +9,7 @@
 # External dependencies.
 fs           = require 'fs'
 path         = require 'path'
-helpers      = require('./helpers').helpers
+helpers      = require './helpers'
 optparse     = require './optparse'
 CoffeeScript = require './coffee-script'
 

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -9,7 +9,7 @@ fs             = require 'fs'
 path           = require 'path'
 optparse       = require './optparse'
 CoffeeScript   = require './coffee-script'
-{helpers}      = require './helpers'
+helpers        = require './helpers'
 {spawn, exec}  = require 'child_process'
 {EventEmitter} = require 'events'
 

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -2,10 +2,8 @@
 # the **Lexer**, **Rewriter**, and the **Nodes**. Merge objects, flatten
 # arrays, count characters, that sort of thing.
 
-helpers = exports.helpers = {}
-
 # Cross-engine indexOf, so that JScript can join the party.
-indexOf = helpers.indexOf = Array.indexOf or
+indexOf = exports.indexOf = Array.indexOf or
   if Array::indexOf
     (array, item, from) -> array.indexOf item, from
   else
@@ -16,22 +14,22 @@ indexOf = helpers.indexOf = Array.indexOf or
       -1
 
 # Does a list include a value?
-helpers.include = (list, value) -> 0 <= indexOf list, value
+exports.include = (list, value) -> 0 <= indexOf list, value
 
 # Peek at the beginning of a given string to see if it matches a sequence.
-helpers.starts = (string, literal, start) ->
+exports.starts = (string, literal, start) ->
   literal is string.substr start, literal.length
 
 # Peek at the end of a given string to see if it matches a sequence.
-helpers.ends = (string, literal, back) ->
+exports.ends = (string, literal, back) ->
   ll = literal.length
   literal is string.substr string.length - ll - (back or 0), ll
 
 # Trim out all falsy values from an array.
-helpers.compact = (array) -> item for item in array when item
+exports.compact = (array) -> item for item in array when item
 
 # Count the number of occurences of a character in a string.
-helpers.count = (string, letter) ->
+exports.count = (string, letter) ->
   num = pos = 0
   num++ while 0 < pos = 1 + string.indexOf letter, pos
   num
@@ -39,22 +37,22 @@ helpers.count = (string, letter) ->
 # Merge objects, returning a fresh copy with attributes from both sides.
 # Used every time `BaseNode#compile` is called, to allow properties in the
 # options hash to propagate down the tree without polluting other branches.
-helpers.merge = (options, overrides) ->
+exports.merge = (options, overrides) ->
   extend (extend {}, options), overrides
 
 # Extend a source object with the properties of another object (shallow copy).
 # We use this to simulate Node's deprecated `process.mixin`
-extend = helpers.extend = (object, properties) ->
+extend = exports.extend = (object, properties) ->
   (object[key] = val) for all key, val of properties
   object
 
 # Return a flattened version of an array (nonrecursive).
 # Handy for getting a list of `children` from the nodes.
-helpers.flatten = (array) -> array.concat.apply [], array
+exports.flatten = (array) -> array.concat.apply [], array
 
 # Delete a key from an object, returning the value. Useful when a node is
 # looking for a particular method in an options hash.
-helpers.del = (obj, key) ->
+exports.del = (obj, key) ->
   val =  obj[key]
   delete obj[key]
   val

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -10,7 +10,7 @@
 {Rewriter} = require './rewriter'
 
 # Import the helpers we need.
-{include, count, starts, compact} = require('./helpers').helpers
+{include, count, starts, compact} = require './helpers'
 
 # The Lexer Class
 # ---------------

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -6,7 +6,7 @@
 {Scope} = require './scope'
 
 # Import the helpers we plan to use.
-{compact, flatten, merge, del, include, indexOf, starts, ends} = require('./helpers').helpers
+{compact, flatten, merge, del, include, indexOf, starts, ends} = require './helpers'
 
 #### BaseNode
 

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -6,7 +6,7 @@
 
 # Require the **coffee-script** module to get access to the compiler.
 CoffeeScript = require './coffee-script'
-helpers      = require('./helpers').helpers
+helpers      = require './helpers'
 readline     = require 'readline'
 
 # Start by opening up **stdio**.

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -6,7 +6,7 @@
 # parentheses, balance incorrect nestings, and generally clean things up.
 
 # Import the helpers we need.
-{include} = require('./helpers').helpers
+{include} = require './helpers'
 
 # The **Rewriter** class is used by the [Lexer](lexer.html), directly against
 # its internal array of tokens.

--- a/src/scope.coffee
+++ b/src/scope.coffee
@@ -6,7 +6,7 @@
 # with the outside.
 
 # Import the helpers we plan to use.
-{extend} = require('./helpers').helpers
+{extend} = require './helpers'
 
 exports.Scope = class Scope
 

--- a/test/test_helpers.coffee
+++ b/test/test_helpers.coffee
@@ -1,5 +1,5 @@
 { indexOf, include, starts, ends, compact, count, merge, extend, flatten, del
-} = require('../lib/helpers').helpers
+} = require '../lib/helpers'
 
 array = [0..4]
 


### PR DESCRIPTION
Because they
- don't have test.
- define unused variables.
- are wrapped in a redundant namespace.
- have some quirks e.g.:
  - `count` is slow because it uses our `indexOf` (which happens to work) instead of the native one.
  - `extend` collects values into an array which is never used.
  - `flatten` has wrong description.
  - etc.
