### PR TITLE
Named classes

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -4,7 +4,7 @@
   Rewriter = require('./rewriter').Rewriter;
   _ref = require('./helpers'), include = _ref.include, count = _ref.count, starts = _ref.starts, compact = _ref.compact, last = _ref.last;
   exports.Lexer = (function() {
-    Lexer = function() {};
+    Lexer = (function() { function Lexer() {} return Lexer; })();
     Lexer.prototype.tokenize = function(code, options) {
       var o;
       code = code.replace(/\r/g, '').replace(/\s+$/, '');

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -20,10 +20,10 @@
     return this;
   };
   exports.BaseNode = (function() {
-    BaseNode = function() {
+    BaseNode = (function() { function BaseNode() {
       this.tags = {};
       return this;
-    };
+    } return BaseNode; })();
     BaseNode.prototype.compile = function(o) {
       var closure, code, top;
       this.options = o ? merge(o) : {};
@@ -159,11 +159,11 @@
     return BaseNode;
   })();
   exports.Expressions = (function() {
-    Expressions = function(nodes) {
+    Expressions = (function() { function Expressions(nodes) {
       Expressions.__super__.constructor.call(this);
       this.expressions = compact(flatten(nodes || []));
       return this;
-    };
+    } return Expressions; })();
     __extends(Expressions, BaseNode);
     Expressions.prototype["class"] = 'Expressions';
     Expressions.prototype.children = ['expressions'];
@@ -244,11 +244,11 @@
     return new Expressions(nodes);
   };
   exports.LiteralNode = (function() {
-    LiteralNode = function(_arg) {
+    LiteralNode = (function() { function LiteralNode(_arg) {
       this.value = _arg;
       LiteralNode.__super__.constructor.call(this);
       return this;
-    };
+    } return LiteralNode; })();
     __extends(LiteralNode, BaseNode);
     LiteralNode.prototype["class"] = 'LiteralNode';
     LiteralNode.prototype.makeReturn = function() {
@@ -272,11 +272,11 @@
     return LiteralNode;
   })();
   exports.ReturnNode = (function() {
-    ReturnNode = function(_arg) {
+    ReturnNode = (function() { function ReturnNode(_arg) {
       this.expression = _arg;
       ReturnNode.__super__.constructor.call(this);
       return this;
-    };
+    } return ReturnNode; })();
     __extends(ReturnNode, BaseNode);
     ReturnNode.prototype["class"] = 'ReturnNode';
     ReturnNode.prototype.isStatement = YES;
@@ -300,13 +300,13 @@
     return ReturnNode;
   })();
   exports.ValueNode = (function() {
-    ValueNode = function(_arg, _arg2) {
+    ValueNode = (function() { function ValueNode(_arg, _arg2) {
       this.properties = _arg2;
       this.base = _arg;
       ValueNode.__super__.constructor.call(this);
       this.properties || (this.properties = []);
       return this;
-    };
+    } return ValueNode; })();
     __extends(ValueNode, BaseNode);
     ValueNode.prototype["class"] = 'ValueNode';
     ValueNode.prototype.children = ['base', 'properties'];
@@ -429,11 +429,11 @@
     return ValueNode;
   }).call(this);
   exports.CommentNode = (function() {
-    CommentNode = function(_arg) {
+    CommentNode = (function() { function CommentNode(_arg) {
       this.comment = _arg;
       CommentNode.__super__.constructor.call(this);
       return this;
-    };
+    } return CommentNode; })();
     __extends(CommentNode, BaseNode);
     CommentNode.prototype["class"] = 'CommentNode';
     CommentNode.prototype.isStatement = YES;
@@ -444,7 +444,7 @@
     return CommentNode;
   })();
   exports.CallNode = (function() {
-    CallNode = function(variable, _arg, _arg2) {
+    CallNode = (function() { function CallNode(variable, _arg, _arg2) {
       this.exist = _arg2;
       this.args = _arg;
       CallNode.__super__.constructor.call(this);
@@ -453,7 +453,7 @@
       this.variable = this.isSuper ? null : variable;
       this.args || (this.args = []);
       return this;
-    };
+    } return CallNode; })();
     __extends(CallNode, BaseNode);
     CallNode.prototype["class"] = 'CallNode';
     CallNode.prototype.children = ['variable', 'args'];
@@ -593,12 +593,12 @@
     return CallNode;
   })();
   exports.ExtendsNode = (function() {
-    ExtendsNode = function(_arg, _arg2) {
+    ExtendsNode = (function() { function ExtendsNode(_arg, _arg2) {
       this.parent = _arg2;
       this.child = _arg;
       ExtendsNode.__super__.constructor.call(this);
       return this;
-    };
+    } return ExtendsNode; })();
     __extends(ExtendsNode, BaseNode);
     ExtendsNode.prototype["class"] = 'ExtendsNode';
     ExtendsNode.prototype.children = ['child', 'parent'];
@@ -610,13 +610,13 @@
     return ExtendsNode;
   })();
   exports.AccessorNode = (function() {
-    AccessorNode = function(_arg, tag) {
+    AccessorNode = (function() { function AccessorNode(_arg, tag) {
       this.name = _arg;
       AccessorNode.__super__.constructor.call(this);
       this.prototype = tag === 'prototype' ? '.prototype' : '';
       this.soakNode = tag === 'soak';
       return this;
-    };
+    } return AccessorNode; })();
     __extends(AccessorNode, BaseNode);
     AccessorNode.prototype["class"] = 'AccessorNode';
     AccessorNode.prototype.children = ['name'];
@@ -630,11 +630,11 @@
     return AccessorNode;
   })();
   exports.IndexNode = (function() {
-    IndexNode = function(_arg) {
+    IndexNode = (function() { function IndexNode(_arg) {
       this.index = _arg;
       IndexNode.__super__.constructor.call(this);
       return this;
-    };
+    } return IndexNode; })();
     __extends(IndexNode, BaseNode);
     IndexNode.prototype["class"] = 'IndexNode';
     IndexNode.prototype.children = ['index'];
@@ -650,14 +650,14 @@
     return IndexNode;
   })();
   exports.RangeNode = (function() {
-    RangeNode = function(_arg, _arg2, tag) {
+    RangeNode = (function() { function RangeNode(_arg, _arg2, tag) {
       this.to = _arg2;
       this.from = _arg;
       RangeNode.__super__.constructor.call(this);
       this.exclusive = tag === 'exclusive';
       this.equals = this.exclusive ? '' : '=';
       return this;
-    };
+    } return RangeNode; })();
     __extends(RangeNode, BaseNode);
     RangeNode.prototype["class"] = 'RangeNode';
     RangeNode.prototype.children = ['from', 'to'];
@@ -740,11 +740,11 @@
     return RangeNode;
   })();
   exports.SliceNode = (function() {
-    SliceNode = function(_arg) {
+    SliceNode = (function() { function SliceNode(_arg) {
       this.range = _arg;
       SliceNode.__super__.constructor.call(this);
       return this;
-    };
+    } return SliceNode; })();
     __extends(SliceNode, BaseNode);
     SliceNode.prototype["class"] = 'SliceNode';
     SliceNode.prototype.children = ['range'];
@@ -761,11 +761,11 @@
     return SliceNode;
   })();
   exports.ObjectNode = (function() {
-    ObjectNode = function(props) {
+    ObjectNode = (function() { function ObjectNode(props) {
       ObjectNode.__super__.constructor.call(this);
       this.objects = (this.properties = props || []);
       return this;
-    };
+    } return ObjectNode; })();
     __extends(ObjectNode, BaseNode);
     ObjectNode.prototype["class"] = 'ObjectNode';
     ObjectNode.prototype.children = ['properties'];
@@ -813,12 +813,12 @@
     return ObjectNode;
   })();
   exports.ArrayNode = (function() {
-    ArrayNode = function(_arg) {
+    ArrayNode = (function() { function ArrayNode(_arg) {
       this.objects = _arg;
       ArrayNode.__super__.constructor.call(this);
       this.objects || (this.objects = []);
       return this;
-    };
+    } return ArrayNode; })();
     __extends(ArrayNode, BaseNode);
     ArrayNode.prototype["class"] = 'ArrayNode';
     ArrayNode.prototype.children = ['objects'];
@@ -849,7 +849,7 @@
     return ArrayNode;
   })();
   exports.ClassNode = (function() {
-    ClassNode = function(_arg, _arg2, _arg3) {
+    ClassNode = (function() { function ClassNode(_arg, _arg2, _arg3) {
       this.properties = _arg3;
       this.parent = _arg2;
       this.variable = _arg;
@@ -857,7 +857,7 @@
       this.properties || (this.properties = []);
       this.returns = false;
       return this;
-    };
+    } return ClassNode; })();
     __extends(ClassNode, BaseNode);
     ClassNode.prototype["class"] = 'ClassNode';
     ClassNode.prototype.children = ['variable', 'parent', 'properties'];
@@ -919,6 +919,7 @@
         }
         props.push(prop);
       }
+      constructor.className = className.match(/[\w\d\$_]+$/);
       if (me) {
         constructor.body.unshift(literal("" + (me) + " = this"));
       }
@@ -933,13 +934,13 @@
     return ClassNode;
   })();
   exports.AssignNode = (function() {
-    AssignNode = function(_arg, _arg2, _arg3) {
+    AssignNode = (function() { function AssignNode(_arg, _arg2, _arg3) {
       this.context = _arg3;
       this.value = _arg2;
       this.variable = _arg;
       AssignNode.__super__.constructor.call(this);
       return this;
-    };
+    } return AssignNode; })();
     __extends(AssignNode, BaseNode);
     AssignNode.prototype.METHOD_DEF = /^(?:(\S+)\.prototype\.)?([$A-Za-z_][$\w]*)$/;
     AssignNode.prototype["class"] = 'AssignNode';
@@ -1056,7 +1057,7 @@
     return AssignNode;
   })();
   exports.CodeNode = (function() {
-    CodeNode = function(_arg, _arg2, tag) {
+    CodeNode = (function() { function CodeNode(_arg, _arg2, tag) {
       this.body = _arg2;
       this.params = _arg;
       CodeNode.__super__.constructor.call(this);
@@ -1067,12 +1068,12 @@
         this.context = 'this';
       }
       return this;
-    };
+    } return CodeNode; })();
     __extends(CodeNode, BaseNode);
     CodeNode.prototype["class"] = 'CodeNode';
     CodeNode.prototype.children = ['params', 'body'];
     CodeNode.prototype.compileNode = function(o) {
-      var _i, _len, _ref2, _ref3, _result, code, empty, func, i, param, params, sharedScope, splat, top, value;
+      var _i, _len, _ref2, _ref3, _result, close, code, empty, func, i, open, param, params, sharedScope, splat, top, value;
       sharedScope = del(o, 'sharedScope');
       top = del(o, 'top');
       o.scope = sharedScope || new Scope(o.scope, this.body, this);
@@ -1124,8 +1125,10 @@
         param = params[_i];
         (o.scope.parameter(param));
       }
+      open = this.className ? ("(function() { function " + (this.className) + "(") : "function(";
+      close = this.className ? ("} return " + (this.className) + "; })()") : "}";
       code = this.body.expressions.length ? ("\n" + (this.body.compileWithDeclarations(o)) + "\n") : '';
-      func = ("function(" + (params.join(', ')) + ") {" + (code) + (code && this.tab) + "}");
+      func = ("" + (open) + (params.join(', ')) + ") {" + (code) + (code && this.tab) + (close));
       if (this.bound) {
         return ("(" + (utility('bind')) + "(" + (func) + ", " + (this.context) + "))");
       }
@@ -1138,14 +1141,14 @@
     return CodeNode;
   })();
   exports.ParamNode = (function() {
-    ParamNode = function(_arg, _arg2, _arg3) {
+    ParamNode = (function() { function ParamNode(_arg, _arg2, _arg3) {
       this.splat = _arg3;
       this.attach = _arg2;
       this.name = _arg;
       ParamNode.__super__.constructor.call(this);
       this.value = literal(this.name);
       return this;
-    };
+    } return ParamNode; })();
     __extends(ParamNode, BaseNode);
     ParamNode.prototype["class"] = 'ParamNode';
     ParamNode.prototype.children = ['name'];
@@ -1166,14 +1169,14 @@
     return ParamNode;
   })();
   exports.SplatNode = (function() {
-    SplatNode = function(name) {
+    SplatNode = (function() { function SplatNode(name) {
       SplatNode.__super__.constructor.call(this);
       if (!(name.compile)) {
         name = literal(name);
       }
       this.name = name;
       return this;
-    };
+    } return SplatNode; })();
     __extends(SplatNode, BaseNode);
     SplatNode.prototype["class"] = 'SplatNode';
     SplatNode.prototype.children = ['name'];
@@ -1236,7 +1239,7 @@
     return SplatNode;
   }).call(this);
   exports.WhileNode = (function() {
-    WhileNode = function(condition, opts) {
+    WhileNode = (function() { function WhileNode(condition, opts) {
       WhileNode.__super__.constructor.call(this);
       if (((opts != null) ? opts.invert : undefined)) {
         if (condition instanceof OpNode) {
@@ -1247,7 +1250,7 @@
       this.condition = condition;
       this.guard = ((opts != null) ? opts.guard : undefined);
       return this;
-    };
+    } return WhileNode; })();
     __extends(WhileNode, BaseNode);
     WhileNode.prototype["class"] = 'WhileNode';
     WhileNode.prototype.children = ['condition', 'guard', 'body'];
@@ -1292,7 +1295,7 @@
     return WhileNode;
   })();
   exports.OpNode = (function() {
-    OpNode = function(_arg, _arg2, _arg3, flip) {
+    OpNode = (function() { function OpNode(_arg, _arg2, _arg3, flip) {
       this.second = _arg3;
       this.first = _arg2;
       this.operator = _arg;
@@ -1309,7 +1312,7 @@
         this.second.tags.operation = true;
       }
       return this;
-    };
+    } return OpNode; })();
     __extends(OpNode, BaseNode);
     OpNode.prototype.CONVERSIONS = {
       '==': '===',
@@ -1408,12 +1411,12 @@
     return OpNode;
   })();
   exports.InNode = (function() {
-    InNode = function(_arg, _arg2) {
+    InNode = (function() { function InNode(_arg, _arg2) {
       this.array = _arg2;
       this.object = _arg;
       InNode.__super__.constructor.call(this);
       return this;
-    };
+    } return InNode; })();
     __extends(InNode, BaseNode);
     InNode.prototype["class"] = 'InNode';
     InNode.prototype.children = ['object', 'array'];
@@ -1451,14 +1454,14 @@
     return InNode;
   })();
   exports.TryNode = (function() {
-    TryNode = function(_arg, _arg2, _arg3, _arg4) {
+    TryNode = (function() { function TryNode(_arg, _arg2, _arg3, _arg4) {
       this.ensure = _arg4;
       this.recovery = _arg3;
       this.error = _arg2;
       this.attempt = _arg;
       TryNode.__super__.constructor.call(this);
       return this;
-    };
+    } return TryNode; })();
     __extends(TryNode, BaseNode);
     TryNode.prototype["class"] = 'TryNode';
     TryNode.prototype.children = ['attempt', 'recovery', 'ensure'];
@@ -1485,11 +1488,11 @@
     return TryNode;
   })();
   exports.ThrowNode = (function() {
-    ThrowNode = function(_arg) {
+    ThrowNode = (function() { function ThrowNode(_arg) {
       this.expression = _arg;
       ThrowNode.__super__.constructor.call(this);
       return this;
-    };
+    } return ThrowNode; })();
     __extends(ThrowNode, BaseNode);
     ThrowNode.prototype["class"] = 'ThrowNode';
     ThrowNode.prototype.children = ['expression'];
@@ -1501,11 +1504,11 @@
     return ThrowNode;
   })();
   exports.ExistenceNode = (function() {
-    ExistenceNode = function(_arg) {
+    ExistenceNode = (function() { function ExistenceNode(_arg) {
       this.expression = _arg;
       ExistenceNode.__super__.constructor.call(this);
       return this;
-    };
+    } return ExistenceNode; })();
     __extends(ExistenceNode, BaseNode);
     ExistenceNode.prototype["class"] = 'ExistenceNode';
     ExistenceNode.prototype.children = ['expression'];
@@ -1518,11 +1521,11 @@
     return ExistenceNode;
   })();
   exports.ParentheticalNode = (function() {
-    ParentheticalNode = function(_arg) {
+    ParentheticalNode = (function() { function ParentheticalNode(_arg) {
       this.expression = _arg;
       ParentheticalNode.__super__.constructor.call(this);
       return this;
-    };
+    } return ParentheticalNode; })();
     __extends(ParentheticalNode, BaseNode);
     ParentheticalNode.prototype["class"] = 'ParentheticalNode';
     ParentheticalNode.prototype.children = ['expression'];
@@ -1552,7 +1555,7 @@
     return ParentheticalNode;
   })();
   exports.ForNode = (function() {
-    ForNode = function(_arg, source, _arg2, _arg3) {
+    ForNode = (function() { function ForNode(_arg, source, _arg2, _arg3) {
       var _ref2;
       this.index = _arg3;
       this.name = _arg2;
@@ -1573,7 +1576,7 @@
       }
       this.returns = false;
       return this;
-    };
+    } return ForNode; })();
     __extends(ForNode, BaseNode);
     ForNode.prototype["class"] = 'ForNode';
     ForNode.prototype.children = ['body', 'source', 'guard'];
@@ -1691,7 +1694,7 @@
     return ForNode;
   })();
   exports.SwitchNode = (function() {
-    SwitchNode = function(_arg, _arg2, _arg3) {
+    SwitchNode = (function() { function SwitchNode(_arg, _arg2, _arg3) {
       this.otherwise = _arg3;
       this.cases = _arg2;
       this.subject = _arg;
@@ -1699,7 +1702,7 @@
       this.tags.subjectless = !this.subject;
       this.subject || (this.subject = literal('true'));
       return this;
-    };
+    } return SwitchNode; })();
     __extends(SwitchNode, BaseNode);
     SwitchNode.prototype["class"] = 'SwitchNode';
     SwitchNode.prototype.children = ['subject', 'cases', 'otherwise'];
@@ -1748,7 +1751,7 @@
     return SwitchNode;
   })();
   exports.IfNode = (function() {
-    IfNode = function(_arg, _arg2, _arg3) {
+    IfNode = (function() { function IfNode(_arg, _arg2, _arg3) {
       this.tags = _arg3;
       this.body = _arg2;
       this.condition = _arg;
@@ -1763,7 +1766,7 @@
       this.elseBody = null;
       this.isChain = false;
       return this;
-    };
+    } return IfNode; })();
     __extends(IfNode, BaseNode);
     IfNode.prototype["class"] = 'IfNode';
     IfNode.prototype.children = ['condition', 'body', 'elseBody', 'assigner'];

--- a/lib/optparse.js
+++ b/lib/optparse.js
@@ -1,11 +1,11 @@
 (function() {
   var LONG_FLAG, MULTI_FLAG, OPTIONAL, OptionParser, SHORT_FLAG, buildRule, buildRules, normalizeArguments;
   exports.OptionParser = (function() {
-    OptionParser = function(rules, banner) {
+    OptionParser = (function() { function OptionParser(rules, banner) {
       this.banner = banner;
       this.rules = buildRules(rules);
       return this;
-    };
+    } return OptionParser; })();
     OptionParser.prototype.parse = function(args) {
       var _i, _len, _len2, _ref, arg, i, isOption, matchedRule, options, rule, value;
       options = {

--- a/lib/rewriter.js
+++ b/lib/rewriter.js
@@ -1,7 +1,7 @@
 (function() {
   var BALANCED_PAIRS, EXPRESSION_CLOSE, EXPRESSION_END, EXPRESSION_START, IMPLICIT_BLOCK, IMPLICIT_CALL, IMPLICIT_END, IMPLICIT_FUNC, INVERSES, LINEBREAKS, SINGLE_CLOSERS, SINGLE_LINERS, _i, _len, _ref, include, left, rite;
   include = require('./helpers').include;
-  exports.Rewriter = function() {};
+  exports.Rewriter = (function() { function Rewriter() {} return Rewriter; })();
   exports.Rewriter.prototype.rewrite = function(_arg) {
     this.tokens = _arg;
     this.adjustComments();

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -3,7 +3,7 @@
   var __hasProp = Object.prototype.hasOwnProperty;
   _ref = require('./helpers'), extend = _ref.extend, last = _ref.last;
   exports.Scope = (function() {
-    Scope = function(_arg, _arg2, _arg3) {
+    Scope = (function() { function Scope(_arg, _arg2, _arg3) {
       this.method = _arg3;
       this.expressions = _arg2;
       this.parent = _arg;
@@ -17,7 +17,7 @@
         Scope.root = this;
       }
       return this;
-    };
+    } return Scope; })();
     Scope.root = null;
     Scope.prototype.startLevel = function() {
       return this.garbage.push([]);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -819,6 +819,7 @@ exports.ClassNode = class ClassNode extends BaseNode
         prop   = new AssignNode(val, func)
       props.push prop
 
+    constructor.className = className.match /[\w\d\$_]+$/
     constructor.body.unshift literal "#{me} = this" if me
     construct = @idt() + (new AssignNode(@variable, constructor)).compile(merge o, {sharedScope: constScope}) + ';'
     props     = if !props.empty() then '\n' + props.compile(o)                     else ''
@@ -983,8 +984,10 @@ exports.CodeNode = class CodeNode extends BaseNode
     params = (param.compile(o) for param in params)
     @body.makeReturn() unless empty
     (o.scope.parameter(param)) for param in params
+    open = if @className then "(function() { function #{@className}(" else "function("
+    close = if @className then "} return #{@className}; })()" else "}"
     code = if @body.expressions.length then "\n#{ @body.compileWithDeclarations(o) }\n" else ''
-    func = "function(#{ params.join(', ') }) {#{code}#{ code and @tab }}"
+    func = "#{open}#{ params.join(', ') }) {#{code}#{ code and @tab }#{close}"
     return "(#{utility 'bind'}(#{func}, #{@context}))" if @bound
     if top then "(#{func})" else func
 


### PR DESCRIPTION
This _should_ allow us to have classes with a `name` property that corresponds to the actual class name without causing the weird IE scoping error. It's listed [here](http://kangax.github.com/nfe/#alt-solution) as a solution, but I haven't actually tested it, so it'd be swell if someone could give that a go.

Note that we could do this for all of our functions, but things would get overly complicated way too quickly with the extra closure that this solution uses, and that's not really in the spirit of Coffeescript.
