### PR TITLE
(at least partial) node 0.3 compliance

### DIFF
--- a/bin/cake
+++ b/bin/cake
@@ -4,5 +4,5 @@ var path = require('path');
 var fs   = require('fs');
 var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
-require(lib + '/helpers').extend(global, require('sys'));
+require(lib + '/helpers').extend(global, require(/^0\.[012]/.test(process.version) ? 'sys' : 'util'));
 require(lib + '/cake').run();

--- a/bin/coffee
+++ b/bin/coffee
@@ -4,5 +4,5 @@ var path = require('path');
 var fs   = require('fs');
 var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
-require(lib + '/helpers').extend(global, require('sys'));
+require(lib + '/helpers').extend(global, require(/^0\.[012]/.test(process.version) ? 'sys' : 'util'));
 require(lib + '/command').run();


### PR DESCRIPTION
They have replaced the `sys` module with the `util` module. Users of node 0.3+ will receive deprecation notices with every run of `cake` or `coffee` without this fix. A safe fallback to `sys` for users of node <0.3 is provided as well.
