### PR TITLE
Accept --no-wrap as deprecated

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,5 +1,5 @@
 (function() {
-  var BANNER, CoffeeScript, EventEmitter, SWITCHES, _ref, compileOptions, compileScript, compileScripts, compileStdio, exec, fs, helpers, lint, optionParser, optparse, opts, parseOptions, path, printTokens, sources, spawn, usage, version, watch, writeJs;
+  var ALL_SWITCHES, BANNER, CoffeeScript, DEPRECATED_SWITCHES, EventEmitter, SWITCHES, _ref, compileOptions, compileScript, compileScripts, compileStdio, exec, fs, helpers, lint, optionParser, optparse, opts, parseOptions, path, printTokens, sources, spawn, usage, version, watch, writeJs;
   fs = require('fs');
   path = require('path');
   optparse = require('./optparse');
@@ -11,6 +11,8 @@
   global.CoffeeScript = CoffeeScript;
   BANNER = 'coffee compiles CoffeeScript source files into JavaScript.\n\nUsage:\n  coffee path/to/script.coffee';
   SWITCHES = [['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-o', '--output [DIR]', 'set the directory for compiled JavaScript'], ['-w', '--watch', 'watch scripts for changes, and recompile'], ['-p', '--print', 'print the compiled JavaScript to stdout'], ['-l', '--lint', 'pipe the compiled JavaScript through JSLint'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-e', '--eval', 'compile a string from the command line'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-b', '--bare', 'compile without the top-level function wrapper'], ['-t', '--tokens', 'print the tokens that the lexer produces'], ['-n', '--nodes', 'print the parse tree that Jison produces'], ['-v', '--version', 'display CoffeeScript version'], ['-h', '--help', 'display this help message']];
+  DEPRECATED_SWITCHES = [['--no-wrap', 'compile without the top-level function wrapper']];
+  ALL_SWITCHES = SWITCHES.concat(DEPRECATED_SWITCHES);
   opts = {};
   sources = [];
   optionParser = null;
@@ -197,21 +199,22 @@
   };
   parseOptions = function() {
     var o;
-    optionParser = new optparse.OptionParser(SWITCHES, BANNER);
+    optionParser = new optparse.OptionParser(ALL_SWITCHES, BANNER);
     o = opts = optionParser.parse(process.argv.slice(2));
     o.compile || (o.compile = !!o.output);
     o.run = !(o.compile || o.print || o.lint);
     o.print = !!(o.print || (o.eval || o.stdio && o.compile));
-    return sources = o.arguments;
+    sources = o.arguments;
+    return opts['no-wrap'] ? console.log('--no-wrap is deprecated; please use --bare instead.\n') : void 0;
   };
   compileOptions = function(fileName) {
     return {
       fileName: fileName,
-      bare: opts.bare
+      bare: opts.bare || opts['no-wrap']
     };
   };
   usage = function() {
-    console.log(optionParser.help());
+    console.log((new optparse.OptionParser(SWITCHES)).help());
     return process.exit(0);
   };
   version = function() {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -43,6 +43,13 @@ SWITCHES = [
   ['-h', '--help',            'display this help message']
 ]
 
+# Switches that are still supported, but will cause a warning message.
+DEPRECATED_SWITCHES = [
+  ['--no-wrap',               'compile without the top-level function wrapper']
+]
+
+ALL_SWITCHES = SWITCHES.concat DEPRECATED_SWITCHES
+
 # Top-level objects shared by all the functions.
 opts         = {}
 sources      = []
@@ -173,19 +180,22 @@ printTokens = (tokens) ->
 # Use the [OptionParser module](optparse.html) to extract all options from
 # `process.argv` that are specified in `SWITCHES`.
 parseOptions = ->
-  optionParser  = new optparse.OptionParser SWITCHES, BANNER
+  optionParser  = new optparse.OptionParser ALL_SWITCHES, BANNER
   o = opts      = optionParser.parse process.argv.slice 2
   o.compile     or=  !!o.output
   o.run         = not (o.compile or o.print or o.lint)
   o.print       = !!  (o.print or (o.eval or o.stdio and o.compile))
   sources       = o.arguments
+  if opts['no-wrap']
+    console.log '--no-wrap is deprecated; please use --bare instead.\n'
 
 # The compile-time options to pass to the CoffeeScript compiler.
-compileOptions = (fileName) -> {fileName, bare: opts.bare}
+compileOptions = (fileName) -> {fileName, bare: opts.bare or opts['no-wrap']}
 
-# Print the `--help` usage message and exit.
+# Print the `--help` usage message and exit. Deprecated switches are not
+# shown.
 usage = ->
-  console.log optionParser.help()
+  console.log (new optparse.OptionParser SWITCHES).help()
   process.exit 0
 
 # Print the `--version` message and exit.


### PR DESCRIPTION
Currently, 0.9.4 accepts `--no-wrap` and not `-b`/`--bare`, while master accepts `-b`/`--bare` and not `--no-wrap`. This has led some users to be frustrated, as their tools (e.g. editor bundles) use `--no-wrap`.

The patch I'm submitting allows `coffee` to accept `--no-wrap`, with a warning. If you call `coffee -h`, `--no-wrap` isn't mentioned. This will allow for a much smoother transition and give people time to update their tools; `--no-wrap` can easily be removed altogether in future versions.
