### PR TITLE
coffee -s does not work

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -137,7 +137,7 @@
       return buffer ? code += buffer.toString() : void 0;
     });
     return stdin.on('end', function() {
-      return compileScript('stdio', code);
+      return compileScript(null, code);
     });
   };
   watch = function(source, base) {


### PR DESCRIPTION
Here is a fix for coffee -s which broke because a nonexisting file name 'stdio' was passed to compileScript().

It would be really nice to have a test for this, but I wasn't sure if there is a way to test stdin from cake, probably not.
