### PR TITLE
Timestamps in coffee watch mode

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,5 +1,5 @@
 (function() {
-  var ALL_SWITCHES, BANNER, CoffeeScript, DEPRECATED_SWITCHES, EventEmitter, SWITCHES, compileOptions, compileScript, compileScripts, compileStdio, exec, fs, helpers, lint, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, sources, spawn, usage, version, watch, writeJs, _ref;
+  var ALL_SWITCHES, BANNER, CoffeeScript, DEPRECATED_SWITCHES, EventEmitter, SWITCHES, compileOptions, compileScript, compileScripts, compileStdio, exec, fs, helpers, lint, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, sources, spawn, toTimestamp, usage, version, watch, writeJs, _ref;
   fs = require('fs');
   path = require('path');
   helpers = require('./helpers');
@@ -94,8 +94,11 @@
     }
     return _results;
   };
-  compileScript = function(file, input, base) {
+  compileScript = function(file, input, base, prefix) {
     var o, options, req, t, task, _i, _len, _ref;
+    if (prefix == null) {
+      prefix = 'Compiled';
+    }
     o = opts;
     options = compileOptions(file);
     if (o.require) {
@@ -124,7 +127,7 @@
         if (o.print) {
           return printLine(t.output.trim());
         } else if (o.compile) {
-          return writeJs(t.file, t.output, base);
+          return writeJs(t.file, t.output, base, prefix);
         } else if (o.lint) {
           return lint(t.file, t.output);
         }
@@ -162,16 +165,15 @@
       if (curr.size === prev.size && curr.mtime.getTime() === prev.mtime.getTime()) {
         return;
       }
-      printLine("Change detected at " + curr.mtime + ":");
       return fs.readFile(source, function(err, code) {
         if (err) {
           throw err;
         }
-        return compileScript(source, code.toString(), base);
+        return compileScript(source, code.toString(), base, "" + (toTimestamp(curr.mtime)) + " Recompiled");
       });
     });
   };
-  writeJs = function(source, js, base) {
+  writeJs = function(source, js, base, prefix) {
     var baseDir, compile, dir, filename, jsPath, srcDir;
     filename = path.basename(source, path.extname(source)) + '.js';
     srcDir = path.dirname(source);
@@ -186,7 +188,7 @@
         if (err) {
           return printLine(err.message);
         } else if (opts.compile && opts.watch) {
-          return printLine("Compiled " + source);
+          return printLine("" + prefix + " " + source);
         }
       });
     };
@@ -222,6 +224,19 @@
       return _results;
     }();
     return printLine(strings.join(' '));
+  };
+  toTimestamp = function(d) {
+    var pad;
+    pad = function(x) {
+      var str;
+      str = '' + x;
+      if (str.length === 1) {
+        return "0" + str;
+      } else {
+        return str;
+      }
+    };
+    return ("" + (d.getFullYear()) + "-" + (pad(d.getMonth() + 1)) + "-" + (pad(d.getDate())) + " ") + d.toTimeString().slice(0, 8);
   };
   parseOptions = function() {
     var o;


### PR DESCRIPTION
See [issue 877](https://github.com/jashkenas/coffee-script/issues#issue/887).

Current:

```
Compiled a.coffee
Compiled a.coffee
```

With the patch:

```
Compiled a.coffee
2010-12-02 13:39:18 Recompiled a.coffee
```

There are two small improvements here. First, the timestamps themselves, as requested by rmatta, which may provide useful documentation to some users. Second, I think it's very nice (both aesthetically and functionally) to distinguish the initial compilation from additional recompiles triggered by watch mode.
