### PR TITLE
Fix splices for newer node versions

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1170,19 +1170,25 @@
       return new Op(this.context.slice(0, -1), left, new Assign(rite, this.value, '=')).compile(o);
     };
     Assign.prototype.compileSplice = function(o) {
-      var from, name, plus, range, to, val;
+      var excl, from, name, range, to, val;
       range = this.variable.properties.pop().range;
       name = this.variable.compile(o);
-      plus = range.exclusive ? '' : ' + 1';
+      excl = range.exclusive;
       from = range.from ? range.from.compile(o) : '0';
       if (!range.to) {
         to = "" + name + ".length";
       }
       if (!to) {
         if (range.from && range.from.isSimpleNumber() && range.to.isSimpleNumber()) {
-          to = (+range.to.compile(o)) - +from + +plus;
+          to = +range.to.compile(o) - +from;
+          if (!excl) {
+            to += 1;
+          }
         } else {
-          to = range.to.compile(o) + ' - ' + from + plus;
+          to = range.to.compile(o) + ' - ' + from;
+          if (!excl) {
+            to += ' + 1';
+          }
         }
       }
       val = this.value.compile(o);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -949,14 +949,16 @@ exports.Assign = class Assign extends Base
   compileSplice: (o) ->
     {range} = @variable.properties.pop()
     name    = @variable.compile o
-    plus    = if range.exclusive then '' else ' + 1'
+    excl    = range.exclusive
     from    = if range.from then range.from.compile(o) else '0'
     to      = "#{name}.length" unless range.to
     unless to
       if range.from and range.from.isSimpleNumber() and range.to.isSimpleNumber()
-        to = (+range.to.compile(o)) - +from + +plus
+        to = +range.to.compile(o) - +from
+        to += 1 unless excl
       else
-        to = range.to.compile(o) + ' - ' + from + plus
+        to = range.to.compile(o) + ' - ' + from
+        to += ' + 1' unless excl
     val = @value.compile(o)
     "[].splice.apply(#{name}, [#{from}, #{to}].concat(#{val}))"
 


### PR DESCRIPTION
An implicit cast of +" + 1" was being done. It was a pretty hack method of trying to do two things with one value before, whereas now it actually uses two different values for adding 1 and for appending " + 1".
