### PR TITLE
Fixes issue 908

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1549,7 +1549,7 @@
       var code, fst, shared, _ref;
       _ref = this.first.second.cache(o), this.first.second = _ref[0], shared = _ref[1];
       fst = this.first.compile(o, LEVEL_OP);
-      if (this.first.unwrap() instanceof Op && this.first.isChainable() && fst.charAt(0) === '(') {
+      if (this.first.unwrap() instanceof Op && this.first.isChainable() && fst.charAt(0) === '(' && fst.charAt(fst.length - 1) === ')') {
         fst = fst.slice(1, -1);
       }
       code = "" + fst + " " + (this.invert ? '&&' : '||') + " " + (shared.compile(o)) + " " + this.operator + " " + (this.second.compile(o, LEVEL_OP));

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1228,7 +1228,8 @@ exports.Op = class Op extends Base
   compileChain: (o) ->
     [@first.second, shared] = @first.second.cache o
     fst = @first.compile o, LEVEL_OP
-    fst = fst.slice 1, -1 if @first.unwrap() instanceof Op and @first.isChainable() and fst.charAt(0) is '('
+    # TODO: find a way to make this next line a proper check or remove it entirely and deal with extra parens
+    fst = fst.slice 1, -1 if @first.unwrap() instanceof Op and @first.isChainable() and fst.charAt(0) is '(' and fst.charAt(fst.length-1) is ')'
     code = "#{fst} #{if @invert then '&&' else '||'} #{ shared.compile o } #{@operator} #{ @second.compile o, LEVEL_OP }"
     "(#{code})"
 


### PR DESCRIPTION
... for now. I still need someone more knowledgeable than myself to take a look at line 1232 of `src/nodes.coffee` and come up with the right logic for stripping parens... or figure out how to not generate them in the first place. But for now this fixes that issue. If a similar issue comes up, line 1232 can be removed entirely and we can just deal with extra parens floating around.
