### PR TITLE
Allow underscores in number literals

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -125,7 +125,7 @@
         return 0;
       }
       number = match[0];
-      this.token('NUMBER', number);
+      this.token('NUMBER', number.replace(/_/g, ''));
       return number.length;
     };
     Lexer.prototype.stringToken = function() {
@@ -603,7 +603,7 @@
   RESERVED = ['case', 'default', 'function', 'var', 'void', 'with', 'do', 'const', 'let', 'enum', 'export', 'import', 'native', '__hasProp', '__extends', '__slice'];
   JS_FORBIDDEN = JS_KEYWORDS.concat(RESERVED);
   IDENTIFIER = /^([$A-Za-z_][$\w]*)([^\n\S]*:(?!:))?/;
-  NUMBER = /^0x[\da-f]+|^(?:\d+(\.\d+)?|\.\d+)(?:e[+-]?\d+)?/i;
+  NUMBER = /^0x[\da-f][\da-f_]*|^(?:\d*[\d_]+(\.\d[\d_]*)?|\.\d[\d_]*)(?:e[+-]?\d[\d_]*)?/i;
   HEREDOC = /^("""|''')([\s\S]*?)(?:\n[^\n\S]*)?\1/;
   OPERATOR = /^(?:[-=]>|[-+*\/%<>&|^!?=]=|>>>=?|([-+:])\1|([&|<>])\2=?|\?\.|\.{3})/;
   WHITESPACE = /^[^\n\S]+/;

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -138,7 +138,7 @@ exports.Lexer = class Lexer
   numberToken: ->
     return 0 unless match = NUMBER.exec @chunk
     number = match[0]
-    @token 'NUMBER', number
+    @token 'NUMBER', number.replace(/_/g, '')
     number.length
 
   # Matches strings, including multi-line strings. Ensures that quotation marks
@@ -539,8 +539,8 @@ IDENTIFIER = /// ^
 ///
 
 NUMBER     = ///
-  ^ 0x[\da-f]+ |                              # hex
-  ^ (?: \d+(\.\d+)? | \.\d+ ) (?:e[+-]?\d+)?  # decimal
+  ^ 0x[\da-f][\da-f_]* |                                         # hex
+  ^ (?: \d*[\d_]+(\.\d[\d_]*)? | \.\d[\d_]* ) (?:e[+-]?\d[\d_]*)?  # decimal
 ///i
 
 HEREDOC    = /// ^ ("""|''') ([\s\S]*?) (?:\n[^\n\S]*)? \1 ///

--- a/test/test_literals.coffee
+++ b/test/test_literals.coffee
@@ -13,7 +13,20 @@ value = .25 + .75
 ok value is 1
 value = 0.0 + -.25 - -.75 + 0.0
 ok value is 0.5
+value = 500_000 + 40_000 + 3_000
+ok value is 543000
+# value = 0.000_5 - 0.000_4
+# ok value is 0.0001
+# value = 25E6
+# ok value is 25_000_000
 
+# Hex number literals.
+value = 0x10
+ok value is 16
+value = 0xf
+ok value is 15
+value = 0x1_000
+ok value is Math.pow(16, 3)
 
 # Can call methods directly on numbers.
 4.valueOf() is 4


### PR DESCRIPTION
Background: [issue 632](https://github.com/jashkenas/coffee-script/issues/issue/632) (raised again independently as [issue 857](https://github.com/jashkenas/coffee-script/issues/issue/857)).

I see this as a "why not?" feature addition; a handful of folks really want it, and it won't affect anyone else, except to the extend that they might have to figure out what `1_000` means when reading someone else's code (a question immediately answered by the JavaScript output). Let's get it in before 1.0.
