### PR TITLE
#910: add support for --node flag to pass arguments to node

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,5 +1,6 @@
 (function() {
-  var ALL_SWITCHES, BANNER, CoffeeScript, DEPRECATED_SWITCHES, EventEmitter, SWITCHES, compileOptions, compileScript, compileScripts, compileStdio, exec, fs, helpers, lint, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, sources, spawn, usage, util, version, watch, writeJs, _ref;
+  var ALL_SWITCHES, BANNER, CoffeeScript, DEPRECATED_SWITCHES, EventEmitter, SWITCHES, compileOptions, compileScript, compileScripts, compileStdio, exec, execl, fs, helpers, lint, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, sources, spawn, usage, util, version, watch, writeJs, _ref;
+  var __slice = Array.prototype.slice;
   fs = require('fs');
   path = require('path');
   util = require('util');
@@ -16,7 +17,7 @@
     return process.binding('stdio').writeError(line + '\n');
   };
   BANNER = 'Usage: coffee [options] path/to/script.coffee';
-  SWITCHES = [['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-o', '--output [DIR]', 'set the directory for compiled JavaScript'], ['-w', '--watch', 'watch scripts for changes, and recompile'], ['-p', '--print', 'print the compiled JavaScript to stdout'], ['-l', '--lint', 'pipe the compiled JavaScript through JSLint'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-e', '--eval', 'compile a string from the command line'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-b', '--bare', 'compile without the top-level function wrapper'], ['-t', '--tokens', 'print the tokens that the lexer produces'], ['-n', '--nodes', 'print the parse tree that Jison produces'], ['-v', '--version', 'display CoffeeScript version'], ['-h', '--help', 'display this help message']];
+  SWITCHES = [['--node [ARGS]', 'pass arguments through to the node binary'], ['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-o', '--output [DIR]', 'set the directory for compiled JavaScript'], ['-w', '--watch', 'watch scripts for changes, and recompile'], ['-p', '--print', 'print the compiled JavaScript to stdout'], ['-l', '--lint', 'pipe the compiled JavaScript through JSLint'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-e', '--eval', 'compile a string from the command line'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-b', '--bare', 'compile without the top-level function wrapper'], ['-t', '--tokens', 'print the tokens that the lexer produces'], ['-n', '--nodes', 'print the parse tree that Jison produces'], ['-v', '--version', 'display CoffeeScript version'], ['-h', '--help', 'display this help message']];
   DEPRECATED_SWITCHES = [['--no-wrap', 'compile without the top-level function wrapper']];
   ALL_SWITCHES = SWITCHES.concat(DEPRECATED_SWITCHES);
   opts = {};
@@ -25,6 +26,9 @@
   exports.run = function() {
     var flags, separator;
     parseOptions();
+    if (opts.node) {
+      return execl();
+    }
     if (opts.help) {
       return usage();
     }
@@ -241,6 +245,32 @@
       fileName: fileName,
       bare: opts.bare || opts['no-wrap']
     };
+  };
+  execl = function() {
+    var args, files, flags, idx, name, nodeArgs, value;
+    nodeArgs = opts.node.split(/\s+/);
+    files = opts.arguments;
+    flags = [];
+    args = [];
+    if ((idx = files.indexOf('--')) > -1) {
+      flags = ['--'].concat(__slice.call(files.slice(idx + 1)));
+      [].splice.apply(files, [idx, files.length].concat([]));
+    }
+    for (name in opts) {
+      value = opts[name];
+      if (!value || (name === 'node' || name === 'run' || name === 'arguments')) {
+        continue;
+      }
+      args.push('--' + name);
+      if (value !== true) {
+        args.push(value);
+      }
+    }
+    return spawn(process.execPath, __slice.call(nodeArgs).concat([process.argv[1]], __slice.call(args), __slice.call(files), __slice.call(flags)), {
+      cwd: process.cwd(),
+      env: process.env,
+      customFds: [0, 1, 2]
+    });
   };
   usage = function() {
     printLine((new optparse.OptionParser(SWITCHES, BANNER)).help());


### PR DESCRIPTION
Usage as follows: `coffee --print -e --node "--debug -v --whatever" --lint -b`

`--node` argument takes a string containing an argument list to be passed to node and can be placed anywhere in coffee's argument list.

Documentation will have to be written, I have neither the time nor the patience for that right now.
