### PR TITLE
Slim down npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+*.coffee
+*.html
+.DS_Store
+.git*
+Cakefile
+documentation/
+examples/
+extras/
+raw/
+src/
+test/


### PR DESCRIPTION
coffee-script 0.9.6 unpacks to 8.7M! Looks like a ton of docs and nonessential files are being packaged.

This ignore config brings the package down to 336K.
