### PR TITLE
allow multiple --nodejs arguments without forking repeatedly

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -235,10 +235,13 @@
     };
   };
   forkNode = function() {
-    var args, nodeArgs;
-    nodeArgs = opts.nodejs.split(/\s+/);
+    var args, idx, nodeArgs;
     args = process.argv.slice(1);
-    args.splice(args.indexOf('--nodejs'), 2);
+    nodeArgs = [];
+    while ((idx = args.indexOf('--nodejs')) > -1) {
+      nodeArgs = nodeArgs.concat(args.splice(idx, 2)[1].split(/\s+/));
+    }
+    console.dir(nodeArgs.concat(args));
     return spawn(process.execPath, nodeArgs.concat(args), {
       cwd: process.cwd(),
       env: process.env,

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -183,16 +183,16 @@ compileOptions = (fileName) -> {fileName, bare: opts.bare}
 # Start up a new Node.js instance with the arguments in `--nodejs` passed to
 # the `node` binary, preserving the other options.
 forkNode = ->
-  nodeArgs = opts.nodejs.split /\s+/
   args     = process.argv[1..]
-  args.splice args.indexOf('--nodejs'), 2
+  nodeArgs = []
+  while (idx = args.indexOf '--nodejs') > -1
+    nodeArgs = nodeArgs.concat args.splice(idx,2)[1].split(/\s+/)
   spawn process.execPath, nodeArgs.concat(args),
     cwd:        process.cwd()
     env:        process.env
     customFds:  [0, 1, 2]
 
-# Print the `--help` usage message and exit. Deprecated switches are not
-# shown.
+# Print the `--help` usage message and exit.
 usage = ->
   printLine (new optparse.OptionParser SWITCHES, BANNER).help()
   process.exit 0


### PR DESCRIPTION
This small commit allows for one to use the `--nodejs` argument of coffee more than once. This allows one to alias coffee as `coffee --node --debug` and still pass the alias additional node arguments through the use of additional `--nodejs` flags: `coffee-alias --nodejs "--whatever-node -wants"`. This also allows one to pass separate node arguments in separate, unquoted coffee arguments rather than quoting them and concatenating them together. This makes it easier for automated programs to call a list of node arguments.

More justification:
- `coffee -b -b` sets `-b` flag twice -- no unintended consequences from using the flag more than once
- `coffee -o ~ -o .` sets `output` flag twice, allowing one to specify default output dir in an alias and override it on specific command-line invocations
