### PR TITLE
Cakefile: install verbosely; symlink with ln -n

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -44,18 +44,17 @@ task 'install', 'install CoffeeScript into /usr/local (or --prefix)', (options) 
   lib  = "#{base}/lib/coffee-script"
   bin  = "#{base}/bin"
   node = "~/.node_libraries/coffee-script"
-  console.log   "Installing CoffeeScript to #{lib}"
-  console.log   "Linking to #{node}"
-  console.log   "Linking 'coffee' to #{bin}/coffee"
   exec([
-    "mkdir -p #{lib} #{bin}"
-    "cp -rf bin lib LICENSE README package.json src #{lib}"
-    "ln -sf #{lib}/bin/coffee #{bin}/coffee"
-    "ln -sf #{lib}/bin/cake #{bin}/cake"
-    "mkdir -p ~/.node_libraries"
-    "ln -sf #{lib}/lib #{node}"
+    "mkdir -pv #{lib} #{bin}"
+    "cp -rfv bin lib LICENSE README package.json src #{lib}"
+    "ln -sfv #{lib}/bin/coffee #{bin}/coffee"
+    "ln -sfv #{lib}/bin/cake #{bin}/cake"
+    "mkdir -pv ~/.node_libraries"
+    "ln -sfnv #{lib}/lib #{node}"
   ].join(' && '), (err, stdout, stderr) ->
-    if err then console.log stderr.trim() else log 'done', green
+    console.log stdout.trim() if stdout
+    console.log stderr.trim() if stderr
+    throw err    if err
   )
 
 


### PR DESCRIPTION
Congrats on version 1.0.0!  Here's a patch to improve "bin/cake install":

```
Cakefile: install verbosely; symlink with ln -n

Without the -n option, ln will place a symlink inside the
~/.node_libraries/coffee-script directory if it exists already, rather
than overwriting the existing symlink.
```

I think installing verbosely is more common, and I personally like it a lot better if I can see where my stuff gets installed.

I thought about interspersing the commands with

```
"echo --- Installing CoffeeScript to #{lib} ---"
"echo --- Linking binaries into #{bin} ---"
"echo --- Linking library into #{node} ---"
```

but since the verbose output of mkdir, cp and ln might go to either stdout or stderr (you never know), we can't be sure that the echo output actually intersperses properly (unless we do 2>&1 redirects, but that's too cute).
