### PR TITLE
Issue#1014 `arguments` in ranged array

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -785,7 +785,7 @@
           _results = [];
           for (var _i = _ref = +this.fromNum, _ref2 = +this.toNum; _ref <= _ref2 ? _i <= _ref2 : _i >= _ref2; _ref <= _ref2 ? _i += 1 : _i -= 1){ _results.push(_i); }
           return _results;
-        }).call(this);
+        }).apply(this,arguments);
         if (this.exclusive) {
           range.pop();
         }
@@ -804,7 +804,7 @@
         body = "var " + vars + "; " + clause + " " + i + " <" + this.equals + " " + this.toVar + " : " + i + " >" + this.equals + " " + this.toVar + "; " + clause + " " + i + " += 1 : " + i + " -= 1";
       }
       post = "{ " + result + ".push(" + i + "); }\n" + idt + "return " + result + ";\n" + o.indent;
-      return "(function() {" + pre + "\n" + idt + "for (" + body + ")" + post + "}).call(this)";
+      return "(function() {" + pre + "\n" + idt + "for (" + body + ")" + post + "}).apply(this,arguments)";
     };
     return Range;
   })();

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -651,7 +651,7 @@ exports.Range = class Range extends Base
       clause = "#{@fromVar} <= #{@toVar} ?"
       body   = "var #{vars}; #{clause} #{i} <#{@equals} #{@toVar} : #{i} >#{@equals} #{@toVar}; #{clause} #{i} += 1 : #{i} -= 1"
     post   = "{ #{result}.push(#{i}); }\n#{idt}return #{result};\n#{o.indent}"
-    "(function() {#{pre}\n#{idt}for (#{body})#{post}}).call(this)"
+    "(function() {#{pre}\n#{idt}for (#{body})#{post}}).apply(this,arguments)"
 
 #### Slice
 

--- a/test/range_literals.coffee
+++ b/test/range_literals.coffee
@@ -74,3 +74,29 @@ test "large ranges are generated with looping constructs", ->
   up = [0...100]
   eq 100, (len = up.length)
   eq  99, up[len - 1]
+
+test "#1014 slices with arguments object", ->
+  useArg0AtEnd = ->
+    ary = -> [0..arguments[0]]
+    ary 9
+  arg0End = useArg0AtEnd()
+
+  useArg0AtStart = ->
+    ary = -> [arguments[0]..9]
+    ary 0
+  arg0Start = useArg0AtStart()
+
+  useArgs0And1 = ->
+    ary = -> [arguments[0]..arguments[1]]
+    ary 0,9
+  args0And1 = useArgs0And1()
+
+  useArg0FromOuter = ->
+    ary = -> [arguments[0]..9]
+    ary(arguments[0])
+  arg0FromOuter = useArg0FromOuter(0)
+
+  arrayEq arg0End       , shared
+  arrayEq arg0Start     , shared
+  arrayEq args0And1     , shared
+  arrayEq arg0FromOuter , shared


### PR DESCRIPTION
Addresses #1014 https://github.com/jashkenas/coffee-script/issues/#issue/1014 **"`arguments` in ranged array bug"** @satyr  dug up:

```
seq = -> [1..arguments[0]]
console.log seq 3
[] # returns an empty array instead of the expected [ 1, 2, 3 ]
```

The above code should have output `[ 1, 2, 3 ]`, not an empty array.

The issue was that `arguments` weren't being sent to the lambda that wrapped the array. I just edited `nodes.coffee > compileArray` method to output `apply(this,arguments)` instead of `call(this)`

Thanks Michael :)
