### PR TITLE
Extending support to node v0.2.5

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,5 +1,5 @@
 (function() {
-  var BANNER, CoffeeScript, EventEmitter, SWITCHES, compileJoin, compileOptions, compileScript, compileScripts, compileStdio, contents, exec, forkNode, fs, helpers, lint, loadRequires, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, sources, spawn, usage,  version, watch, writeJs, _ref;
+  var BANNER, CoffeeScript, EventEmitter, SWITCHES, compileJoin, compileOptions, compileScript, compileScripts, compileStdio, contents, exec, forkNode, fs, helpers, lint, loadRequires, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, sources, spawn, usage, version, watch, writeJs, _ref;
   fs = require('fs');
   path = require('path');
   helpers = require('./helpers');

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -7,7 +7,6 @@
 # External dependencies.
 fs             = require 'fs'
 path           = require 'path'
-util           = require 'util'
 helpers        = require './helpers'
 optparse       = require './optparse'
 CoffeeScript   = require './coffee-script'
@@ -164,7 +163,7 @@ writeJs = (source, js, base) ->
     js = ' ' if js.length <= 0
     fs.writeFile jsPath, js, (err) ->
       if err then printLine err.message
-      else if opts.compile and opts.watch then util.log "compiled #{source}"
+      else if opts.compile and opts.watch then console.log "compiled #{source}"
   path.exists dir, (exists) ->
     if exists then compile() else exec "mkdir -p #{dir}", compile
 


### PR DESCRIPTION
Removed dependency on the `util` module so that coffee-script will work on node version 0.2.5.
