### PR TITLE
Fix REPL in Node v0.3.6 (readline bug)

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -78,7 +78,14 @@
     return _results;
   };
   process.on('uncaughtException', error);
-  repl = readline.createInterface(stdin, stdout, autocomplete);
+  if (readline.createInterface.length === 3) {
+    repl = readline.createInterface(stdin, stdout, autocomplete);
+  } else {
+    repl = readline.createInterface(stdin, autocomplete);
+    stdin.on('data', function(buffer) {
+      return repl.write(buffer);
+    });
+  }
   repl.setPrompt('coffee> ');
   repl.on('close', function() {
     return stdin.destroy();

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -77,7 +77,12 @@ getPropertyNames = (obj) ->
 process.on 'uncaughtException', error
 
 # Create the REPL by listening to **stdin**.
-repl = readline.createInterface stdin, stdout, autocomplete
+if readline.createInterface.length == 3
+  repl = readline.createInterface stdin, stdout, autocomplete
+else
+  repl = readline.createInterface stdin, autocomplete
+  stdin.on 'data',   (buffer) -> repl.write buffer
+
 repl.setPrompt 'coffee> '
 repl.on  'close',  -> stdin.destroy()
 repl.on  'line',   run


### PR DESCRIPTION
Scratching my own itch, the coffee-script repl breaks in node v0.3.6 (current latest). The readline interface now expects (in, out, complete), where the coffee-script repl passes (stdio, complete). This leads to a broken repl. I patched this in my fork.

This is untested in prior versions of Node. Since readline isn't even documented on the Node.js website, I'm guessing the API is a moving target, so it may not be worth pulling this in. But if you like, here it is.
