### PR TITLE
Set process.argv[1] to the name of the script being run

### DIFF
--- a/lib/coffee-script.js
+++ b/lib/coffee-script.js
@@ -47,7 +47,7 @@
     while (root.parent) {
       root = root.parent;
     }
-    root.filename = options.filename ? fs.realpathSync(options.filename) : '.';
+    root.filename = process.argv[1] = options.filename ? fs.realpathSync(options.filename) : '.';
     if (root.moduleCache) {
       root.moduleCache = {};
     }
@@ -59,7 +59,7 @@
   };
   exports.eval = function(code, options) {
     var __dirname, __filename;
-    __filename = module.filename = options.filename;
+    __filename = module.filename = process.argv[1] = options.filename;
     __dirname = path.dirname(__filename);
     return eval(compile(code, options));
   };

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -58,7 +58,9 @@ exports.run = (code, options) ->
   while root.parent
     root = root.parent
   # Set the filename.
-  root.filename = if options.filename then fs.realpathSync(options.filename) else '.'
+  root.filename = process.argv[1] =
+      if options.filename then fs.realpathSync(options.filename) else '.'
+  
   # Clear the module cache.
   root.moduleCache = {} if root.moduleCache
   # Compile.
@@ -70,7 +72,7 @@ exports.run = (code, options) ->
 # Compile and evaluate a string of CoffeeScript (in a Node.js-like environment).
 # The CoffeeScript REPL uses this to run the input.
 exports.eval = (code, options) ->
-  __filename = module.filename = options.filename
+  __filename = module.filename = process.argv[1] = options.filename
   __dirname  = path.dirname __filename
   eval compile code, options
 


### PR DESCRIPTION
This is a fix for [issue 1087](https://github.com/jashkenas/coffee-script/issues/1087).

Quite simply, `process.argv[1]` should equal `__filename` (the name of the script being run); but currently, only `__filename` is being set. So if you run `coffee foo.coffee`, then `__filename` is `foo.coffee` but `process.argv[1]` is the location of `coffee`. With this patch, `process.argv[1]` should always equal `__filename`.

This makes the behavior of

```
coffee foo.coffee
```

more consistent with that of

```
coffee -c foo.coffee
node foo.js
```
