### PR TITLE
Add connect-coffee and middleman to resource list

### DIFF
--- a/documentation/index.html.erb
+++ b/documentation/index.html.erb
@@ -1028,7 +1028,18 @@ Expressions
       <li>
         <b>jnicklas</b>'s <a href="http://github.com/jnicklas/bistro_car">BistroCar</a>
         &mdash; a plugin that serves and bundles CoffeeScript from within your
-        Rails application.
+        Rails 2 application.
+      </li>
+      <li>
+        <b>sutto</b>'s <a href="http://github.com/Sutto/barista">Barista</a>
+        &mdash; a successor to BistroCar that integrates well with
+        <a href="http://documentcloud.github.com/jammit">Jammit</a> and Rails 3.
+      </li>
+      <li>
+        <b>TrevorBurnham</b>'s <a href="http://github.com/TrevorBurnham/connect-coffee">connect-coffee</a>
+        &mdash; a <a href="http://senchalabs.github.com/connect/">Connect</a> middleware
+        that compiles CoffeeScript to JavaScript transparently. Connect is the standard
+        for Node.js web servers, making connect-coffee compatible with Zappa and others.
       </li>
       <li>
         <b>dsc</b>'s <a href="http://github.com/dsc/coffeecup">CoffeeCup</a>
@@ -1036,9 +1047,10 @@ Expressions
         on-demand during development.
       </li>
       <li>
-        <b>sutto</b>'s <a href="http://github.com/Sutto/barista">Barista</a>
-        &mdash; a BistroCar alternative that integrates well with
-        <a href="http://documentcloud.github.com/jammit">Jammit</a> and Rails 3.
+        <b>tdreyno</b>'s <a href="http://github.com/tdreyno/middleman">Middleman</a>
+        &mdash; a tool built on Sinatra that serves lives Haml, Sass and CoffeeScript
+        during development, then compiles, concatenates and minifies them for you
+        when you're ready to deploy.
       </li>
       <li>
         <b>inem</b> and <b>gerad</b>'s <a href="http://github.com/gerad/coffee-haml-filter">coffee-haml-filter</a>


### PR DESCRIPTION
Two additions to the resource list in this patch to the documentation ERB. (I couldn't get the doc build to work on my system—my apologies.)

Of course, it may be high time the resources section of CoffeeScript.org get moved to the wiki, for easier maintenance and what-not. Couldn't hurt to sort the resources into subcategories, maybe alphabetize them... What do y'all think?
