### PR TITLE
Splat arguments are not scoped correctly

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1316,6 +1316,9 @@
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         param = _ref[_i];
         if (param.splat) {
+          if (param.name.value) {
+            o.scope.add(param.name.value, 'var');
+          }
           splats = new Assign(new Value(new Arr((function() {
             var _i, _len, _ref, _results;
             _ref = this.params;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1055,6 +1055,7 @@ exports.Code = class Code extends Base
     vars   = []
     exprs  = []
     for param in @params when param.splat
+      o.scope.add param.name.value, 'var' if param.name.value
       splats = new Assign new Value(new Arr(p.asReference o for p in @params)),
                           new Value new Literal 'arguments'
       break

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -280,6 +280,12 @@ test "passing splats to functions", ->
   arrayEq [2..6], others
   eq 7, last
 
+test "splat variables are local to the function", ->
+  outer = "x"
+  clobber = (avar, outer...) -> outer
+  clobber "foo", "bar"
+  eq "x", outer
+
 #894: Splatting against constructor-chained functions.
 x = null
 class Foo


### PR DESCRIPTION
Function arguments declared as splats, e.g. `-> (splat...)` do not get declared with `var` in the compiled function body if the parent scope contains a binding for that name. This means that invoking a function with splat args can clobber variables in the parent scope.

This patch fixes this, though I'd like feedback on whether I'm using the internal API properly -- I've only just started using Coffee.
