### PR TITLE
Fix node_modules requires from interpreted .coffee files

### DIFF
--- a/lib/coffee-script.js
+++ b/lib/coffee-script.js
@@ -42,7 +42,7 @@
     }
   };
   exports.run = function(code, options) {
-    var root;
+    var Module, root;
     root = module;
     while (root.parent) {
       root = root.parent;
@@ -50,6 +50,10 @@
     root.filename = process.argv[1] = options.filename ? fs.realpathSync(options.filename) : '.';
     if (root.moduleCache) {
       root.moduleCache = {};
+    }
+    if (process.binding('natives').module) {
+      Module = require('module').Module;
+      root.paths = Module._nodeModulePaths(path.dirname(options.filename));
     }
     if (path.extname(root.filename) !== '.coffee' || require.extensions) {
       return root._compile(compile(code, options), root.filename);

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -60,9 +60,15 @@ exports.run = (code, options) ->
   # Set the filename.
   root.filename = process.argv[1] =
       if options.filename then fs.realpathSync(options.filename) else '.'
-  
+
   # Clear the module cache.
   root.moduleCache = {} if root.moduleCache
+
+  # Assign paths for node_modules loading
+  if process.binding('natives').module
+    {Module} = require 'module'
+    root.paths = Module._nodeModulePaths path.dirname options.filename
+
   # Compile.
   if path.extname(root.filename) isnt '.coffee' or require.extensions
     root._compile compile(code, options), root.filename


### PR DESCRIPTION
Node v0.4 added a bunch of magic to automatically require packages from `node_modules` directories.

Due to the way `CoffeeScript.run` evals files, it doesn't work correctly for interpreted code. Everything works as expected if you just compile and run the pure `.js`.

```
# paths.js
console.log(module.paths)

$ node paths.js
[ '/Users/josh/Desktop/node_modules',
  '/Users/josh/node_modules',
  '/Users/node_modules',
  '/node_modules' ]
```

`module.paths` is correctly set to the current directory's `node_modules` hierarchy.

But if you try the same on a coffee file,

```
# paths.coffee
console.log module.paths

$ coffee paths.coffee
[ '/usr/local/lib/node_modules/coffee-script/bin/node_modules',
  '/usr/local/lib/node_modules/coffee-script/node_modules',
  '/usr/local/lib/node_modules' ]
```

The paths are relative to the `coffee` binary rather than the file you are executing.

This affects `Cakefile`s as well.

The fix is to mimic node's `Module.load` more accurately. [Module.prototype.load](https://github.com/joyent/node/blob/master/lib/module.js#L335) definition.
