### PR TITLE
fixes bug mentioned by @satyr in #1108

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1662,13 +1662,15 @@
     Op.prototype.compileExistence = function(o) {
       var fst, ref;
       if (this.first.isComplex()) {
-        ref = o.scope.freeVariable('ref');
-        fst = new Parens(new Assign(new Literal(ref), this.first));
+        ref = new Literal(o.scope.freeVariable('ref'));
+        fst = new Parens(new Assign(ref, this.first));
       } else {
         fst = this.first;
-        ref = fst.compile(o);
+        ref = fst;
       }
-      return new Existence(fst).compile(o) + (" ? " + ref + " : " + (this.second.compile(o, LEVEL_LIST)));
+      return new If(new Existence(fst), ref, {
+        type: 'if'
+      }).addElse(this.second).compile(o);
     };
     Op.prototype.compileUnary = function(o) {
       var op, parts;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1301,12 +1301,12 @@ exports.Op = class Op extends Base
 
   compileExistence: (o) ->
     if @first.isComplex()
-      ref = o.scope.freeVariable 'ref'
-      fst = new Parens new Assign new Literal(ref), @first
+      ref = new Literal o.scope.freeVariable 'ref'
+      fst = new Parens new Assign ref, @first
     else
       fst = @first
-      ref = fst.compile o
-    new Existence(fst).compile(o) + " ? #{ref} : #{ @second.compile o, LEVEL_LIST }"
+      ref = fst
+    new If(new Existence(fst), ref, type: 'if').addElse(@second).compile o
 
   # Compile a unary **Op**.
   compileUnary: (o) ->

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -229,6 +229,10 @@ test "destructuring assignment against an expression", ->
   eq a, y
   eq b, z
 
+test "bracket insertion when necessary", ->
+  [a] = [0] ? [1]
+  eq a, 0
+
 # for implicit destructuring assignment in comprehensions, see the comprehension tests
 
 test "destructuring assignment with context (@) properties", ->


### PR DESCRIPTION
As mentioned by @satyr in #1108: `[v] = a ? b` must compile to
    v = (typeof a != "undefined" && a !== null ? a : b)[0]
and not to:
    v = typeof a != "undefined" && a !== null ? a : b[0]
