### PR TITLE
fixes #1157: when compiling multiple scripts, compile them if at least on

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -78,7 +78,7 @@
               fs.readFile(source, function(err, code) {
                 if (opts.join) {
                   contents[sources.indexOf(source)] = code.toString();
-                  if (helpers.compact(contents).length === sources.length) {
+                  if (helpers.compact(contents).length > 0) {
                     return compileJoin();
                   }
                 } else {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -86,7 +86,7 @@ compileScripts = ->
             fs.readFile source, (err, code) ->
               if opts.join
                 contents[sources.indexOf source] = code.toString()
-                compileJoin() if helpers.compact(contents).length is sources.length
+                compileJoin() if helpers.compact(contents).length > 0
               else
                 compileScript(source, code.toString(), base)
             watch source, base if opts.watch and not opts.join


### PR DESCRIPTION
fixes #1157: when compiling multiple scripts, compile them if at least one of them isn't empty
