### PR TITLE
Typo error, s/synax/syntax

### DIFF
--- a/documentation/index.html.erb
+++ b/documentation/index.html.erb
@@ -844,7 +844,7 @@ Expressions
     <p>
       Sometimes you'd like to pass a block comment through to the generated
       JavaScript. For example, when you need to embed a licensing header at
-      the top of a file. Block comments, which mirror the synax for heredocs,
+      the top of a file. Block comments, which mirror the syntax for heredocs,
       are preserved in the generated code.
     </p>
     <%= code_for('block_comment') %>


### PR DESCRIPTION
Just a small typo in the docs, and a great chance to try out github's new edit functionality, which seemed appropriate to try in this instance.
