### PR TITLE
Set process.argv[0] to 'coffee' when using `coffee foo.coffee`

### DIFF
--- a/lib/coffee-script.js
+++ b/lib/coffee-script.js
@@ -66,6 +66,7 @@
   };
   exports.eval = function(code, options) {
     var __dirname, __filename;
+    process.argv[0] = 'coffee';
     __filename = module.filename = process.argv[1] = options.filename;
     __dirname = path.dirname(__filename);
     return eval(compile(code, options));

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -82,6 +82,7 @@ exports.run = (code, options) ->
 # Compile and evaluate a string of CoffeeScript (in a Node.js-like environment).
 # The CoffeeScript REPL uses this to run the input.
 exports.eval = (code, options) ->
+  process.argv[0] = 'coffee'
   __filename = module.filename = process.argv[1] = options.filename
   __dirname  = path.dirname __filename
   eval compile code, options


### PR DESCRIPTION
As discussed at #1301 (and several other issues Michael linked to from there), the current behavior of `process.argv` is to preserve `'node'` as the first array value. I wasn't convinced that this mattered when the issue was first raised, but I've since come around. The very **purpose** of `argv` is that it tells you how to run the current program; if you run

```
coffee foo.coffee
```

and `process.argv` is

```
['node', 'foo.coffee']
```

then you can't do that. It's internally inconsistent, and in practical terms, it means you can't use raw `coffee` files with libraries like multi-node (see #1283) and Cluster, which use `process.argv` to fork processes. Granted, it's a good practice to compile to JS before deployment in such an environment, but there are circumstances under which using `coffee` files directly is much more convenient. I see no advantage to the current behavior.
