### PR TITLE
Updated for npm 1.0: the -g option installs to the global npm bin directory

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,7 @@
   sudo bin/cake install
 
   Or, if you have the Node Package Manager installed:
-  npm install coffee-script
+  npm install -g coffee-script
 
   Compile a script:
   coffee /path/to/script.coffee


### PR DESCRIPTION
Updated for npm 1.0: the -g option installs to the global npm bin directory.

Without -g, the bin is created in node-modules/.bin/coffee, which isn't expected to be in the path. This is not equivalent to cake install /usr/local/bin where it installs by default in /usr/local/bin, which is expected to be in the path.
