### PR TITLE
Set `process.execPath` correctly when running .coffee files

### DIFF
--- a/bin/coffee
+++ b/bin/coffee
@@ -4,4 +4,4 @@ var path = require('path');
 var fs   = require('fs');
 var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
-require(lib + '/command').run(__filename);
+require(lib + '/command').run();

--- a/lib/command.js
+++ b/lib/command.js
@@ -20,7 +20,7 @@
   sources = [];
   contents = [];
   optionParser = null;
-  exports.run = function(coffeePath) {
+  exports.run = function() {
     parseOptions();
     if (opts.nodejs) {
       return forkNode();
@@ -51,7 +51,7 @@
     }
     process.ARGV = process.argv = process.argv.slice(0, 2).concat(opts.literals);
     process.argv[0] = 'coffee';
-    process.execPath = coffeePath;
+    process.execPath = process.mainModule.filename;
     return compileScripts();
   };
   compileScripts = function() {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -53,7 +53,7 @@ optionParser = null
 # Run `coffee` by parsing passed options and determining what action to take.
 # Many flags cause us to divert before compiling anything. Flags passed after
 # `--` will be passed verbatim to your script as arguments in `process.argv`
-exports.run = (coffeePath) ->
+exports.run = ->
   parseOptions()
   return forkNode()                      if opts.nodejs
   return usage()                         if opts.help
@@ -67,7 +67,7 @@ exports.run = (coffeePath) ->
     opts.literals = sources.splice(1).concat opts.literals
   process.ARGV = process.argv = process.argv.slice(0, 2).concat opts.literals
   process.argv[0] = 'coffee'
-  process.execPath = coffeePath
+  process.execPath = process.mainModule.filename
   compileScripts()
 
 # Asynchronously read in each CoffeeScript in a list of source files and


### PR DESCRIPTION
Issue #1303 set `process.argv[0]` to `coffee`. However, `process.execPath` still gives the absolute path of `node`, not `coffee`. This patch corrects that by using the value of `__filename` from `coffee` as `process.execPath` when running a `.coffee` file.
