### PR TITLE
Fixing unavailability of `global` properties on REPL

### DIFF
--- a/lib/coffee-script.js
+++ b/lib/coffee-script.js
@@ -75,15 +75,13 @@
         require: require,
         module: {
           exports: {}
-        },
-        global: {}
+        }
       };
       for (g in global) {
-        sandbox.global[g] = global[g];
+        sandbox[g] = global[g];
       }
-      sandbox.global.global = sandbox.global;
-      sandbox.global.root = sandbox.global;
-      sandbox.global.GLOBAL = sandbox.global;
+      sandbox.global = sandbox;
+      sandbox.global.global = sandbox.global.root = sandbox.global.GLOBAL = sandbox;
     }
     sandbox.__filename = options.filename || 'eval';
     sandbox.__dirname = path.dirname(sandbox.__filename);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -21,15 +21,13 @@
       require: require,
       module: {
         exports: {}
-      },
-      global: {}
+      }
     };
     for (g in global) {
-      sandbox.global[g] = global[g];
+      sandbox[g] = global[g];
     }
-    sandbox.global.global = sandbox.global;
-    sandbox.global.root = sandbox.global;
-    sandbox.global.GLOBAL = sandbox.global;
+    sandbox.global = sandbox;
+    sandbox.global.global = sandbox.global.root = sandbox.global.GLOBAL = sandbox;
     return function(buffer) {
       var code, val;
       code = backlog += '\n' + buffer.toString();

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -85,11 +85,9 @@ exports.eval = (code, options = {}) ->
     sandbox =
       require: require
       module : { exports: {} }
-      global : {}
-    sandbox.global[g] = global[g] for g of global
-    sandbox.global.global = sandbox.global
-    sandbox.global.root   = sandbox.global
-    sandbox.global.GLOBAL = sandbox.global
+    sandbox[g] = global[g] for g of global
+    sandbox.global = sandbox
+    sandbox.global.global = sandbox.global.root = sandbox.global.GLOBAL = sandbox
   sandbox.__filename = options.filename || 'eval'
   sandbox.__dirname  = path.dirname sandbox.__filename
   js = compile "_=(#{code.trim()})", options

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -35,11 +35,9 @@ run = do ->
   sandbox =
     require: require
     module : { exports: {} }
-    global : {}
-  sandbox.global[g] = global[g] for g of global
-  sandbox.global.global = sandbox.global
-  sandbox.global.root   = sandbox.global
-  sandbox.global.GLOBAL = sandbox.global
+  sandbox[g] = global[g] for g of global
+  sandbox.global = sandbox
+  sandbox.global.global = sandbox.global.root = sandbox.global.GLOBAL = sandbox
   (buffer) ->
     code = backlog += '\n' + buffer.toString()
     if code[code.length - 1] is '\\'


### PR DESCRIPTION
On the current master, `process`, `setInterval`, and several other globals are unavailable (except as `global.process`, `global.setInterval`, etc.). I tracked the cause down to [commit 63ce244359688ac348e9](https://github.com/jashkenas/coffee-script/commit/63ce244359688ac348e95878f0c189e5c331b5ec). (The previous commit had the opposite problem: `process` was available, `global.process` wasn't.)

The problem is that the REPL runs in the context of an object called `sandbox`, and `sandbox.global` is something else—so `global` isn't the global context. The solution is to make

```
coffee> this is global
```

be `true`, as it is in the Node REPL. This commit sets `sandbox.global` to `sandbox` itself.

Overall, I'm totally psyched about the new REPL. Thanks for the good work, Michael.
