### PR TITLE
Potential fix for #1313: Extends and constructor lead to disappearing pro

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -405,7 +405,7 @@ exports.Value = class Value extends Base
   # Unfold a soak into an `If`: `a?.b` -> `a.b if a?`
   unfoldSoak: (o) ->
     return @unfoldedSoak if @unfoldedSoak?
-    result = do => 
+    result = do =>
       if ifn = @base.unfoldSoak o
         Array::push.apply ifn.body.properties, @properties
         return ifn
@@ -857,7 +857,11 @@ exports.Class = class Class extends Base
     if not @ctor
       @ctor = new Code
       @ctor.body.push new Call 'super', [new Splat new Literal 'arguments'] if @parent
-      @body.expressions.unshift @ctor
+    else
+      for e,i in @body.expressions
+        if e == @ctor
+          @body.expressions.splice i, 1
+    @body.expressions.unshift @ctor
     @ctor.ctor     = @ctor.name = name
     @ctor.klass    = null
     @ctor.noReturn = yes

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -439,11 +439,18 @@ test "`new` works against bare function", ->
 
 
 test "a subclass should be able to set its constructor to an external function", ->
-  
+
   ctor = ->
     @val = 1
   class A
   class B extends A
     constructor: ctor
-    
+
   eq (new B).val, 1
+
+test "a property appears before the constructor", ->
+  class A
+  class B extends A
+    foo: 1
+    constructor: ->
+  eq (new B).foo, 1


### PR DESCRIPTION
This is one way to solve issue #1313.  We always move the constructor so it appears first, with any "extend" second, and then all the prototype additions safely later.

But this subtly changes some semantics -- see the failing unit test "variables in constructor bodies are correctly scoped".  It's not really that we're breaking scope, but we're silently reordering assignments.

I don't see a way to fix the bug without breaking this, but maybe someone else will.
