### PR TITLE
Use `require.main` instead of loop to get main module

### DIFF
--- a/lib/coffee-script.js
+++ b/lib/coffee-script.js
@@ -48,9 +48,7 @@
     var Module, mainModule;
     mainModule = require.main;
     mainModule.filename = process.argv[1] = options.filename ? fs.realpathSync(options.filename) : '.';
-    if (mainModule.moduleCache) {
-      mainModule.moduleCache = {};
-    }
+    mainModule.moduleCache && (mainModule.moduleCache = {});
     if (process.binding('natives').module) {
       Module = require('module').Module;
       mainModule.paths = Module._nodeModulePaths(path.dirname(options.filename));

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -61,7 +61,7 @@ exports.run = (code, options) ->
       if options.filename then fs.realpathSync(options.filename) else '.'
 
   # Clear the module cache.
-  mainModule.moduleCache = {} if mainModule.moduleCache
+  mainModule.moduleCache and= {}
 
   # Assign paths for node_modules loading
   if process.binding('natives').module


### PR DESCRIPTION
No behavior changes here; just replacing 3 lines with 1. `require.main` is apparently the canonical way of getting the main module, even though it isn't currently mentioned in the Node docs. (See https://github.com/joyent/node/issues/997)

Also changing the variable name from `root` to the less ambiguous `mainModule`.
