### PR TITLE
Making `-c` and `-o` flags orthogonal

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -127,7 +127,7 @@
         CoffeeScript.emit('success', task);
         if (o.print) {
           return printLine(t.output.trim());
-        } else if (o.compile || o.output) {
+        } else if (o.recompile) {
           return writeJs(t.file, t.output, base);
         } else if (o.lint) {
           return lint(t.file, t.output);
@@ -204,7 +204,7 @@
       return fs.writeFile(jsPath, js, function(err) {
         if (err) {
           return printLine(err.message);
-        } else if ((opts.compile || opts.output) && opts.watch) {
+        } else if (opts.watch && opts.recompile) {
           return printLine("" + ((new Date).toLocaleTimeString()) + " - compiled " + source);
         }
       });
@@ -251,7 +251,8 @@
       printLine('--join with --watch is not supported');
       return false;
     }
-    o.run = !(o.compile || o.output || o.print || o.lint);
+    o.recompile = o.compile || o.output;
+    o.run = !(o.recompile || o.print || o.lint);
     o.print = !!(o.print || (o.eval || o.stdio && o.compile));
     sources = o.arguments;
     return true;

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -111,7 +111,7 @@ compileScript = (file, input, base) ->
       t.output = CoffeeScript.compile t.input, t.options
       CoffeeScript.emit 'success', task
       if o.print          then printLine t.output.trim()
-      else if o.compile or o.output   then writeJs t.file, t.output, base
+      else if o.recompile then writeJs t.file, t.output, base
       else if o.lint      then lint t.file, t.output
   catch err
     CoffeeScript.emit 'failure', err, task
@@ -167,7 +167,7 @@ writeJs = (source, js, base) ->
     fs.writeFile jsPath, js, (err) ->
       if err
         printLine err.message
-      else if (opts.compile or opts.output) and opts.watch
+      else if opts.watch and opts.recompile
         printLine "#{(new Date).toLocaleTimeString()} - compiled #{source}"
   path.exists dir, (exists) ->
     if exists then compile() else exec "mkdir -p #{dir}", compile
@@ -198,7 +198,8 @@ parseOptions = ->
   o = opts      = optionParser.parse process.argv.slice 2
   if o.join and o.watch
     printLine '--join with --watch is not supported'; return false
-  o.run         = not (o.compile or o.output or o.print or o.lint)
+  o.recompile   = o.compile or o.output
+  o.run         = not (o.recompile or o.print or o.lint)
   o.print       = !!  (o.print or (o.eval or o.stdio and o.compile))
   sources       = o.arguments
   true


### PR DESCRIPTION
This patch resolves #1312 by allowing you to use the command

```
coffee -wo lib src
```

to mean "watch the files in `src` and recompile them only when changed" (the behavior of `-cwo` remains the same).

Also, this patch makes `coffee` quit with an error message when `-w` and `-j` are used together (#1075) rather than just ignoring `-w`.
