### PR TITLE
'coffee' silently fails with no output when the --join option is specified and the source files specified include directories

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -60,7 +60,7 @@
     for (_i = 0, _len = sources.length; _i < _len; _i++) {
       source = sources[_i];
       base = path.join(source);
-      compile = function(source, topLevel) {
+      compile = function(source, sourceIndex, topLevel) {
         return path.exists(source, function(exists) {
           if (topLevel && !exists) {
             throw new Error("File not found: " + source);
@@ -75,14 +75,14 @@
                 _results2 = [];
                 for (_j = 0, _len2 = files.length; _j < _len2; _j++) {
                   file = files[_j];
-                  _results2.push(compile(path.join(source, file)));
+                  _results2.push(compile(path.join(source, file), sourceIndex));
                 }
                 return _results2;
               });
             } else if (topLevel || path.extname(source) === '.coffee') {
               fs.readFile(source, function(err, code) {
                 if (opts.join) {
-                  contents[sources.indexOf(source)] = code.toString();
+                  contents[sourceIndex] = helpers.compact([contents[sourceIndex], code.toString()]).join('\n');
                   if (helpers.compact(contents).length > 0) {
                     return compileJoin();
                   }
@@ -97,7 +97,7 @@
           });
         });
       };
-      _results.push(compile(source, true));
+      _results.push(compile(source, sources.indexOf(source), true));
     }
     return _results;
   };

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -76,7 +76,7 @@ exports.run = ->
 compileScripts = ->
   for source in sources
     base = path.join(source)
-    compile = (source, topLevel) ->
+    compile = (source, sourceIndex, topLevel) ->
       path.exists source, (exists) ->
         throw new Error "File not found: #{source}" if topLevel and not exists
         fs.stat source, (err, stats) ->
@@ -84,16 +84,16 @@ compileScripts = ->
           if stats.isDirectory()
             fs.readdir source, (err, files) ->
               for file in files
-                compile path.join(source, file)
+                compile path.join(source, file), sourceIndex
           else if topLevel or path.extname(source) is '.coffee'
             fs.readFile source, (err, code) ->
               if opts.join
-                contents[sources.indexOf source] = code.toString()
+                contents[sourceIndex] = helpers.compact([contents[sourceIndex], code.toString()]).join('\n')
                 compileJoin() if helpers.compact(contents).length > 0
               else
                 compileScript(source, code.toString(), base)
             watch source, base if opts.watch and not opts.join
-    compile source, true
+    compile source, sources.indexOf(source), true
 
 # Compile a single source script, containing the given code, according to the
 # requested options. If evaluating the script directly sets `__filename`,


### PR DESCRIPTION
The command-line compiler fails silently with no output when the --join option is specified and the source files specified include directories.

The current --join handling logic in compile() assumes that the source being compiled is among the explicit list of source files specified for compilation.  When one of those source files is a directory, compile() is called recursively with files that were not among the original explicitly specified list of source files, invalidating that assumption.

This patch tweaks the compileScript logic to ensure that the recursively read directory content is aggregated and joined, while still preserving the content order of the original source files specified at the command line.

For instance:

```
coffee --join output.js --compile src/Main.coffee src/model/ src/service/
```

would join Main.coffee + all .coffee files (recursively) in src/model + all .coffee files (recursively) in src/service/
