### PR TITLE
Debug mode for running .coffee scripts #558, #987

### DIFF
--- a/lib/coffee-script.js
+++ b/lib/coffee-script.js
@@ -1,10 +1,11 @@
 (function() {
-  var Lexer, RESERVED, compile, fs, lexer, parser, path, vm, _ref;
+  var DebugCSFile, DebugCSLine, Lexer, RESERVED, compile, debug, fs, lexer, parser, path, printLinenos, vm, _ref;
   fs = require('fs');
   path = require('path');
   vm = require('vm');
   _ref = require('./lexer'), Lexer = _ref.Lexer, RESERVED = _ref.RESERVED;
   parser = require('./parser').parser;
+  printLinenos = require('./nodes').printLinenos;
   if (require.extensions) {
     require.extensions['.coffee'] = function(module, filename) {
       var content;
@@ -45,7 +46,7 @@
     }
   };
   exports.run = function(code, options) {
-    var Module, mainModule;
+    var Module, js, mainModule;
     mainModule = require.main;
     mainModule.filename = process.argv[1] = options.filename ? fs.realpathSync(options.filename) : '.';
     mainModule.moduleCache && (mainModule.moduleCache = {});
@@ -54,11 +55,112 @@
       mainModule.paths = Module._nodeModulePaths(path.dirname(options.filename));
     }
     if (path.extname(mainModule.filename) !== '.coffee' || require.extensions) {
-      return mainModule._compile(compile(code, options), mainModule.filename);
+      js = compile(code, options);
     } else {
-      return mainModule._compile(code, mainModule.filename);
+      js = code;
     }
+    try {
+      mainModule._compile(js, mainModule.filename);
+    } catch (err) {
+      if (options.debug) {
+        err.debug = debug(code, err.stack.split('\n'), options, js);
+      }
+      err.stack = err.stack.replace(/\.coffee\:/g, '.js:');
+      throw err;
+    }
+    return true;
   };
+  debug = function(code, stack, options, ojs) {
+    var all, comment, csfile, cslineno, csmsg, errline, errlinenos, file, inEval, js, jsline, jslines, jsmsg, lineno, match, msg, ojsline, stackline, _i, _j, _len, _len2, _ref2, _ref3;
+    msg = "\n  " + stack[0] + "\n\n";
+    printLinenos();
+    js = compile(code, options);
+    jslines = js.split('\n');
+    csfile = new DebugCSFile(code);
+    for (_i = 0, _len = stack.length; _i < _len; _i++) {
+      stackline = stack[_i];
+      if (stackline.indexOf('.coffee') > -1) {
+        break;
+      }
+    }
+    inEval = stack[1].match(/\(\.\:(\d*)\:\d*\)/);
+    if (inEval) {
+      stackline = "/__commandline__.coffee:" + inEval[1] + ":1";
+    }
+    _ref2 = stackline.match(/\/([A-Za-z0-9_\ \$\-\_\.]*\.(?:coffee|js))\:(\d*)\:\d/), match = _ref2[0], file = _ref2[1], lineno = _ref2[2];
+    lineno = parseInt(lineno);
+    ojsline = ojs.split('\n')[lineno - 1];
+    jsmsg = "in " + (file.replace(/.coffee/, '.js')) + " on line " + lineno + "\n";
+    msg += "  " + jsmsg + "  " + (new Array(jsmsg.length).join('-')) + "\n";
+    msg += "  > " + lineno + " | " + ojsline + "\n\n";
+    jsline = jslines[options.bare ? lineno - 2 : lineno - 3];
+    errlinenos = jsline.match(/.*?\/\*\@line\:\ \d*\*\//g);
+    for (_j = 0, _len2 = errlinenos.length; _j < _len2; _j++) {
+      errline = errlinenos[_j];
+      _ref3 = errline.match(/(.*?)(\/\*\@line\:\ (\d*)\*\/)/), all = _ref3[0], code = _ref3[1], comment = _ref3[2], cslineno = _ref3[3];
+      csfile.error(cslineno);
+    }
+    csmsg = "in " + file + " on line " + cslineno + "\n";
+    msg += "  " + csmsg + "  " + (new Array(csmsg.length).join('-')) + "\n";
+    return msg += csfile.print() + '\n';
+  };
+  DebugCSFile = (function() {
+    function DebugCSFile(code) {
+      this.cslines = code.split('\n');
+      this.lines = {};
+    }
+    DebugCSFile.prototype.error = function(lineno) {
+      lineno = parseInt(lineno);
+      this.lines[lineno] = new DebugCSLine(lineno, this.cslines[lineno - 1], true);
+      return this.contextualize(lineno);
+    };
+    DebugCSFile.prototype.contextualize = function(errlineno) {
+      var lineno, _ref2, _ref3, _results;
+      _results = [];
+      for (lineno = _ref2 = errlineno - 3, _ref3 = errlineno + 3; _ref2 <= _ref3 ? lineno < _ref3 : lineno > _ref3; _ref2 <= _ref3 ? lineno++ : lineno--) {
+        if ((0 < lineno && lineno < this.cslines.length - 1)) {
+          _results.push(!this.lines[lineno] ? this.lines[lineno] = new DebugCSLine(lineno, this.cslines[lineno - 1], false) : void 0);
+        }
+      }
+      return _results;
+    };
+    DebugCSFile.prototype.numlines = function() {
+      var lineno, max;
+      max = 0;
+      for (lineno in this.lines) {
+        max = Math.max(parseInt(lineno), max);
+      }
+      return max;
+    };
+    DebugCSFile.prototype.print = function() {
+      var length, line, lineno, out, _ref2;
+      out = [];
+      length = String(this.numlines()).length;
+      _ref2 = this.lines;
+      for (lineno in _ref2) {
+        line = _ref2[lineno];
+        out.push(line.print(length));
+      }
+      return out.join('\n');
+    };
+    return DebugCSFile;
+  })();
+  DebugCSLine = (function() {
+    function DebugCSLine(lineno, line, isError) {
+      this.line = line;
+      this.isError = isError;
+      this.lineno = String(lineno);
+    }
+    DebugCSLine.prototype.print = function(length) {
+      var spaces;
+      spaces = new Array(Math.max(length + 2, 4)).join(' ').slice(this.lineno.length);
+      if (this.isError) {
+        spaces = spaces.slice(1);
+      }
+      return "" + spaces + (this.isError ? '>' : '') + " " + this.lineno + " | " + this.line;
+    };
+    return DebugCSLine;
+  })();
   exports.eval = function(code, options) {
     var g, js, k, o, sandbox, v, _i, _len, _ref2;
     if (options == null) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -15,7 +15,7 @@
     return process.binding('stdio').writeError(line + '\n');
   };
   BANNER = 'Usage: coffee [options] path/to/script.coffee';
-  SWITCHES = [['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-o', '--output [DIR]', 'set the directory for compiled JavaScript'], ['-j', '--join [FILE]', 'concatenate the scripts before compiling'], ['-w', '--watch', 'watch scripts for changes, and recompile'], ['-p', '--print', 'print the compiled JavaScript to stdout'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-e', '--eval', 'compile a string from the command line'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-b', '--bare', 'compile without the top-level function wrapper'], ['-t', '--tokens', 'print the tokens that the lexer produces'], ['-n', '--nodes', 'print the parse tree that Jison produces'], ['--nodejs [ARGS]', 'pass options through to the "node" binary'], ['-v', '--version', 'display CoffeeScript version'], ['-h', '--help', 'display this help message']];
+  SWITCHES = [['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-d', '--debug', 'print debug info when a running .coffee file encounters an error'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-o', '--output [DIR]', 'set the directory for compiled JavaScript'], ['-j', '--join [FILE]', 'concatenate the scripts before compiling'], ['-w', '--watch', 'watch scripts for changes, and recompile'], ['-p', '--print', 'print the compiled JavaScript to stdout'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-e', '--eval', 'compile a string from the command line'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-b', '--bare', 'compile without the top-level function wrapper'], ['-t', '--tokens', 'print the tokens that the lexer produces'], ['-n', '--nodes', 'print the parse tree that Jison produces'], ['--nodejs [ARGS]', 'pass options through to the "node" binary'], ['-v', '--version', 'display CoffeeScript version'], ['-h', '--help', 'display this help message']];
   opts = {};
   sources = [];
   contents = [];
@@ -137,7 +137,15 @@
       if (o.watch) {
         return printLine(err.message);
       }
-      printWarn(err.stack);
+      if (o.debug) {
+        if (err.debug) {
+          printWarn(err.debug);
+        } else {
+          printWarn(err.stack);
+        }
+      } else {
+        printWarn(err.stack);
+      }
       return process.exit(1);
     }
   };
@@ -251,7 +259,8 @@
   compileOptions = function(filename) {
     return {
       filename: filename,
-      bare: opts.bare
+      bare: opts.bare,
+      debug: opts.debug
     };
   };
   forkNode = function() {

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -11,7 +11,7 @@
     action = (match = unwrap.exec(action)) ? match[1] : "(" + action + "())";
     action = action.replace(/\bnew /g, '$&yy.');
     action = action.replace(/\b(?:Block\.wrap|extend)\b/g, 'yy.$&');
-    return [patternString, "$$ = " + action + ";", options];
+    return [patternString, "$$ = (function(){ var _ = " + action + "; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()", options];
   };
   grammar = {
     Root: [

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -160,6 +160,9 @@
       }
       return node;
     };
+    Base.prototype.printLineno = function() {
+      return "/*@line: " + (this.lineno + 1) + "*/";
+    };
     Base.prototype.children = [];
     Base.prototype.isStatement = NO;
     Base.prototype.jumps = NO;
@@ -169,6 +172,7 @@
     Base.prototype.unwrap = THIS;
     Base.prototype.unfoldSoak = NO;
     Base.prototype.assigns = NO;
+    Base.prototype.lineno = -1;
     return Base;
   })();
   exports.Block = Block = (function() {
@@ -2273,5 +2277,37 @@
   };
   multident = function(code, tab) {
     return code.replace(/\n/g, '$&' + tab);
+  };
+  exports.printLinenos = function() {
+    var name, node, nodes, _i, _len, _results;
+    nodes = (function() {
+      var _results;
+      _results = [];
+      for (name in exports) {
+        node = exports[name];
+        if (name[0].toUpperCase() === name[0]) {
+          _results.push(node);
+        }
+      }
+      return _results;
+    })();
+    _results = [];
+    for (_i = 0, _len = nodes.length; _i < _len; _i++) {
+      node = nodes[_i];
+      _results.push((function(node) {
+        var $compile;
+        $compile = node.prototype.compile;
+        return node.prototype.compile = function() {
+          var compiled, haslineno;
+          compiled = $compile.apply(this, Array.prototype.slice.call(arguments));
+          haslineno = compiled.match(/(.*?)(\/\*\@line\:\ (\d*)\*\/)/gm);
+          if (!haslineno && this.lineno > -1) {
+            compiled += this.printLineno();
+          }
+          return compiled;
+        };
+      })(node));
+    }
+    return _results;
   };
 }).call(this);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -9,15 +9,15 @@ performAction: function anonymous(yytext,yyleng,yylineno,yy,yystate,$$,_$) {
 
 var $0 = $$.length - 1;
 switch (yystate) {
-case 1:return this.$ = new yy.Block;
+case 1:return this.$ = (function(){ var _ = new yy.Block; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 2:return this.$ = $$[$0];
 break;
 case 3:return this.$ = $$[$0-1];
 break;
-case 4:this.$ = yy.Block.wrap([$$[$0]]);
+case 4:this.$ = (function(){ var _ = yy.Block.wrap([$$[$0]]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 5:this.$ = $$[$0-2].push($$[$0]);
+case 5:this.$ = (function(){ var _ = $$[$0-2].push($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 6:this.$ = $$[$0-1];
 break;
@@ -31,7 +31,7 @@ case 10:this.$ = $$[$0];
 break;
 case 11:this.$ = $$[$0];
 break;
-case 12:this.$ = new yy.Literal($$[$0]);
+case 12:this.$ = (function(){ var _ = new yy.Literal($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 13:this.$ = $$[$0];
 break;
@@ -55,40 +55,40 @@ case 22:this.$ = $$[$0];
 break;
 case 23:this.$ = $$[$0];
 break;
-case 24:this.$ = new yy.Block;
+case 24:this.$ = (function(){ var _ = new yy.Block; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 25:this.$ = $$[$0-1];
+case 25:this.$ = (function(){ var _ = $$[$0-1]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 26:this.$ = new yy.Literal($$[$0]);
+case 26:this.$ = (function(){ var _ = new yy.Literal($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 27:this.$ = new yy.Literal($$[$0]);
+case 27:this.$ = (function(){ var _ = new yy.Literal($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 28:this.$ = new yy.Literal($$[$0]);
+case 28:this.$ = (function(){ var _ = new yy.Literal($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 29:this.$ = $$[$0];
 break;
-case 30:this.$ = new yy.Literal($$[$0]);
+case 30:this.$ = (function(){ var _ = new yy.Literal($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 31:this.$ = new yy.Literal($$[$0]);
+case 31:this.$ = (function(){ var _ = new yy.Literal($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 32:this.$ = (function () {
+case 32:this.$ = (function(){ var _ = (function () {
         var val;
         val = new yy.Literal($$[$0]);
         if ($$[$0] === 'undefined') {
           val.isUndefined = true;
         }
         return val;
-      }());
+      }()); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 33:this.$ = new yy.Assign($$[$0-2], $$[$0]);
+case 33:this.$ = (function(){ var _ = new yy.Assign($$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 34:this.$ = new yy.Assign($$[$0-4], $$[$0-1]);
+case 34:this.$ = (function(){ var _ = new yy.Assign($$[$0-4], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 35:this.$ = new yy.Value($$[$0]);
+case 35:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 36:this.$ = new yy.Assign(new yy.Value($$[$0-2]), $$[$0], 'object');
+case 36:this.$ = (function(){ var _ = new yy.Assign(new yy.Value($$[$0-2]), $$[$0], 'object'); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 37:this.$ = new yy.Assign(new yy.Value($$[$0-4]), $$[$0-1], 'object');
+case 37:this.$ = (function(){ var _ = new yy.Assign(new yy.Value($$[$0-4]), $$[$0-1], 'object'); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 38:this.$ = $$[$0];
 break;
@@ -98,35 +98,35 @@ case 40:this.$ = $$[$0];
 break;
 case 41:this.$ = $$[$0];
 break;
-case 42:this.$ = new yy.Return($$[$0]);
+case 42:this.$ = (function(){ var _ = new yy.Return($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 43:this.$ = new yy.Return;
+case 43:this.$ = (function(){ var _ = new yy.Return; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 44:this.$ = new yy.Comment($$[$0]);
+case 44:this.$ = (function(){ var _ = new yy.Comment($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 45:this.$ = new yy.Code($$[$0-3], $$[$0], $$[$0-1]);
+case 45:this.$ = (function(){ var _ = new yy.Code($$[$0-3], $$[$0], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 46:this.$ = new yy.Code([], $$[$0], $$[$0-1]);
+case 46:this.$ = (function(){ var _ = new yy.Code([], $$[$0], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 47:this.$ = 'func';
+case 47:this.$ = (function(){ var _ = 'func'; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 48:this.$ = 'boundfunc';
+case 48:this.$ = (function(){ var _ = 'boundfunc'; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 49:this.$ = $$[$0];
 break;
 case 50:this.$ = $$[$0];
 break;
-case 51:this.$ = [];
+case 51:this.$ = (function(){ var _ = []; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 52:this.$ = [$$[$0]];
+case 52:this.$ = (function(){ var _ = [$$[$0]]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 53:this.$ = $$[$0-2].concat($$[$0]);
+case 53:this.$ = (function(){ var _ = $$[$0-2].concat($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 54:this.$ = new yy.Param($$[$0]);
+case 54:this.$ = (function(){ var _ = new yy.Param($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 55:this.$ = new yy.Param($$[$0-1], null, true);
+case 55:this.$ = (function(){ var _ = new yy.Param($$[$0-1], null, true); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 56:this.$ = new yy.Param($$[$0-2], $$[$0]);
+case 56:this.$ = (function(){ var _ = new yy.Param($$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 57:this.$ = $$[$0];
 break;
@@ -136,131 +136,131 @@ case 59:this.$ = $$[$0];
 break;
 case 60:this.$ = $$[$0];
 break;
-case 61:this.$ = new yy.Splat($$[$0-1]);
+case 61:this.$ = (function(){ var _ = new yy.Splat($$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 62:this.$ = new yy.Value($$[$0]);
+case 62:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 63:this.$ = $$[$0-1].push($$[$0]);
+case 63:this.$ = (function(){ var _ = $$[$0-1].push($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 64:this.$ = new yy.Value($$[$0-1], [$$[$0]]);
+case 64:this.$ = (function(){ var _ = new yy.Value($$[$0-1], [$$[$0]]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 65:this.$ = $$[$0];
 break;
 case 66:this.$ = $$[$0];
 break;
-case 67:this.$ = new yy.Value($$[$0]);
+case 67:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 68:this.$ = new yy.Value($$[$0]);
+case 68:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 69:this.$ = $$[$0];
 break;
-case 70:this.$ = new yy.Value($$[$0]);
+case 70:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 71:this.$ = new yy.Value($$[$0]);
+case 71:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 72:this.$ = new yy.Value($$[$0]);
+case 72:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 73:this.$ = $$[$0];
 break;
-case 74:this.$ = new yy.Access($$[$0]);
+case 74:this.$ = (function(){ var _ = new yy.Access($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 75:this.$ = new yy.Access($$[$0], 'soak');
+case 75:this.$ = (function(){ var _ = new yy.Access($$[$0], 'soak'); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 76:this.$ = new yy.Access($$[$0], 'proto');
+case 76:this.$ = (function(){ var _ = new yy.Access($$[$0], 'proto'); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 77:this.$ = new yy.Access(new yy.Literal('prototype'));
+case 77:this.$ = (function(){ var _ = new yy.Access(new yy.Literal('prototype')); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 78:this.$ = $$[$0];
 break;
-case 79:this.$ = $$[$0-1];
+case 79:this.$ = (function(){ var _ = $$[$0-1]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 80:this.$ = yy.extend($$[$0], {
+case 80:this.$ = (function(){ var _ = yy.extend($$[$0], {
           soak: true
-        });
+        }); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 81:this.$ = yy.extend($$[$0], {
+case 81:this.$ = (function(){ var _ = yy.extend($$[$0], {
           proto: true
-        });
+        }); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 82:this.$ = new yy.Index($$[$0]);
+case 82:this.$ = (function(){ var _ = new yy.Index($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 83:this.$ = new yy.Slice($$[$0]);
+case 83:this.$ = (function(){ var _ = new yy.Slice($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 84:this.$ = new yy.Obj($$[$0-2], $$[$0-3].generated);
+case 84:this.$ = (function(){ var _ = new yy.Obj($$[$0-2], $$[$0-3].generated); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 85:this.$ = [];
+case 85:this.$ = (function(){ var _ = []; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 86:this.$ = [$$[$0]];
+case 86:this.$ = (function(){ var _ = [$$[$0]]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 87:this.$ = $$[$0-2].concat($$[$0]);
+case 87:this.$ = (function(){ var _ = $$[$0-2].concat($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 88:this.$ = $$[$0-3].concat($$[$0]);
+case 88:this.$ = (function(){ var _ = $$[$0-3].concat($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 89:this.$ = $$[$0-5].concat($$[$0-2]);
+case 89:this.$ = (function(){ var _ = $$[$0-5].concat($$[$0-2]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 90:this.$ = new yy.Class;
+case 90:this.$ = (function(){ var _ = new yy.Class; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 91:this.$ = new yy.Class(null, null, $$[$0]);
+case 91:this.$ = (function(){ var _ = new yy.Class(null, null, $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 92:this.$ = new yy.Class(null, $$[$0]);
+case 92:this.$ = (function(){ var _ = new yy.Class(null, $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 93:this.$ = new yy.Class(null, $$[$0-1], $$[$0]);
+case 93:this.$ = (function(){ var _ = new yy.Class(null, $$[$0-1], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 94:this.$ = new yy.Class($$[$0]);
+case 94:this.$ = (function(){ var _ = new yy.Class($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 95:this.$ = new yy.Class($$[$0-1], null, $$[$0]);
+case 95:this.$ = (function(){ var _ = new yy.Class($$[$0-1], null, $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 96:this.$ = new yy.Class($$[$0-2], $$[$0]);
+case 96:this.$ = (function(){ var _ = new yy.Class($$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 97:this.$ = new yy.Class($$[$0-3], $$[$0-1], $$[$0]);
+case 97:this.$ = (function(){ var _ = new yy.Class($$[$0-3], $$[$0-1], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 98:this.$ = new yy.Call($$[$0-2], $$[$0], $$[$0-1]);
+case 98:this.$ = (function(){ var _ = new yy.Call($$[$0-2], $$[$0], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 99:this.$ = new yy.Call($$[$0-2], $$[$0], $$[$0-1]);
+case 99:this.$ = (function(){ var _ = new yy.Call($$[$0-2], $$[$0], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 100:this.$ = new yy.Call('super', [new yy.Splat(new yy.Literal('arguments'))]);
+case 100:this.$ = (function(){ var _ = new yy.Call('super', [new yy.Splat(new yy.Literal('arguments'))]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 101:this.$ = new yy.Call('super', $$[$0]);
+case 101:this.$ = (function(){ var _ = new yy.Call('super', $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 102:this.$ = false;
+case 102:this.$ = (function(){ var _ = false; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 103:this.$ = true;
+case 103:this.$ = (function(){ var _ = true; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 104:this.$ = [];
+case 104:this.$ = (function(){ var _ = []; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 105:this.$ = $$[$0-2];
+case 105:this.$ = (function(){ var _ = $$[$0-2]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 106:this.$ = new yy.Value(new yy.Literal('this'));
+case 106:this.$ = (function(){ var _ = new yy.Value(new yy.Literal('this')); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 107:this.$ = new yy.Value(new yy.Literal('this'));
+case 107:this.$ = (function(){ var _ = new yy.Value(new yy.Literal('this')); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 108:this.$ = new yy.Value(new yy.Literal('this'), [new yy.Access($$[$0])], 'this');
+case 108:this.$ = (function(){ var _ = new yy.Value(new yy.Literal('this'), [new yy.Access($$[$0])], 'this'); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 109:this.$ = new yy.Arr([]);
+case 109:this.$ = (function(){ var _ = new yy.Arr([]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 110:this.$ = new yy.Arr($$[$0-2]);
+case 110:this.$ = (function(){ var _ = new yy.Arr($$[$0-2]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 111:this.$ = 'inclusive';
+case 111:this.$ = (function(){ var _ = 'inclusive'; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 112:this.$ = 'exclusive';
+case 112:this.$ = (function(){ var _ = 'exclusive'; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 113:this.$ = new yy.Range($$[$0-3], $$[$0-1], $$[$0-2]);
+case 113:this.$ = (function(){ var _ = new yy.Range($$[$0-3], $$[$0-1], $$[$0-2]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 114:this.$ = new yy.Range($$[$0-2], $$[$0], $$[$0-1]);
+case 114:this.$ = (function(){ var _ = new yy.Range($$[$0-2], $$[$0], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 115:this.$ = new yy.Range($$[$0-1], null, $$[$0]);
+case 115:this.$ = (function(){ var _ = new yy.Range($$[$0-1], null, $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 116:this.$ = new yy.Range(null, $$[$0], $$[$0-1]);
+case 116:this.$ = (function(){ var _ = new yy.Range(null, $$[$0], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 117:this.$ = [$$[$0]];
+case 117:this.$ = (function(){ var _ = [$$[$0]]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 118:this.$ = $$[$0-2].concat($$[$0]);
+case 118:this.$ = (function(){ var _ = $$[$0-2].concat($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 119:this.$ = $$[$0-3].concat($$[$0]);
+case 119:this.$ = (function(){ var _ = $$[$0-3].concat($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 120:this.$ = $$[$0-2];
+case 120:this.$ = (function(){ var _ = $$[$0-2]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 121:this.$ = $$[$0-5].concat($$[$0-2]);
+case 121:this.$ = (function(){ var _ = $$[$0-5].concat($$[$0-2]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 122:this.$ = $$[$0];
 break;
@@ -268,201 +268,201 @@ case 123:this.$ = $$[$0];
 break;
 case 124:this.$ = $$[$0];
 break;
-case 125:this.$ = [].concat($$[$0-2], $$[$0]);
+case 125:this.$ = (function(){ var _ = [].concat($$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 126:this.$ = new yy.Try($$[$0]);
+case 126:this.$ = (function(){ var _ = new yy.Try($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 127:this.$ = new yy.Try($$[$0-1], $$[$0][0], $$[$0][1]);
+case 127:this.$ = (function(){ var _ = new yy.Try($$[$0-1], $$[$0][0], $$[$0][1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 128:this.$ = new yy.Try($$[$0-2], null, null, $$[$0]);
+case 128:this.$ = (function(){ var _ = new yy.Try($$[$0-2], null, null, $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 129:this.$ = new yy.Try($$[$0-3], $$[$0-2][0], $$[$0-2][1], $$[$0]);
+case 129:this.$ = (function(){ var _ = new yy.Try($$[$0-3], $$[$0-2][0], $$[$0-2][1], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 130:this.$ = [$$[$0-1], $$[$0]];
+case 130:this.$ = (function(){ var _ = [$$[$0-1], $$[$0]]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 131:this.$ = new yy.Throw($$[$0]);
+case 131:this.$ = (function(){ var _ = new yy.Throw($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 132:this.$ = new yy.Parens($$[$0-1]);
+case 132:this.$ = (function(){ var _ = new yy.Parens($$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 133:this.$ = new yy.Parens($$[$0-2]);
+case 133:this.$ = (function(){ var _ = new yy.Parens($$[$0-2]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 134:this.$ = new yy.While($$[$0]);
+case 134:this.$ = (function(){ var _ = new yy.While($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 135:this.$ = new yy.While($$[$0-2], {
+case 135:this.$ = (function(){ var _ = new yy.While($$[$0-2], {
           guard: $$[$0]
-        });
+        }); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 136:this.$ = new yy.While($$[$0], {
+case 136:this.$ = (function(){ var _ = new yy.While($$[$0], {
           invert: true
-        });
+        }); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 137:this.$ = new yy.While($$[$0-2], {
+case 137:this.$ = (function(){ var _ = new yy.While($$[$0-2], {
           invert: true,
           guard: $$[$0]
-        });
+        }); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 138:this.$ = $$[$0-1].addBody($$[$0]);
+case 138:this.$ = (function(){ var _ = $$[$0-1].addBody($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 139:this.$ = $$[$0].addBody(yy.Block.wrap([$$[$0-1]]));
+case 139:this.$ = (function(){ var _ = $$[$0].addBody(yy.Block.wrap([$$[$0-1]])); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 140:this.$ = $$[$0].addBody(yy.Block.wrap([$$[$0-1]]));
+case 140:this.$ = (function(){ var _ = $$[$0].addBody(yy.Block.wrap([$$[$0-1]])); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 141:this.$ = $$[$0];
+case 141:this.$ = (function(){ var _ = $$[$0]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 142:this.$ = new yy.While(new yy.Literal('true')).addBody($$[$0]);
+case 142:this.$ = (function(){ var _ = new yy.While(new yy.Literal('true')).addBody($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 143:this.$ = new yy.While(new yy.Literal('true')).addBody(yy.Block.wrap([$$[$0]]));
+case 143:this.$ = (function(){ var _ = new yy.While(new yy.Literal('true')).addBody(yy.Block.wrap([$$[$0]])); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 144:this.$ = new yy.For($$[$0-1], $$[$0]);
+case 144:this.$ = (function(){ var _ = new yy.For($$[$0-1], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 145:this.$ = new yy.For($$[$0-1], $$[$0]);
+case 145:this.$ = (function(){ var _ = new yy.For($$[$0-1], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 146:this.$ = new yy.For($$[$0], $$[$0-1]);
+case 146:this.$ = (function(){ var _ = new yy.For($$[$0], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 147:this.$ = {
+case 147:this.$ = (function(){ var _ = {
           source: new yy.Value($$[$0])
-        };
+        }; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 148:this.$ = (function () {
+case 148:this.$ = (function(){ var _ = (function () {
         $$[$0].own = $$[$0-1].own;
         $$[$0].name = $$[$0-1][0];
         $$[$0].index = $$[$0-1][1];
         return $$[$0];
-      }());
+      }()); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 149:this.$ = $$[$0];
+case 149:this.$ = (function(){ var _ = $$[$0]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 150:this.$ = (function () {
+case 150:this.$ = (function(){ var _ = (function () {
         $$[$0].own = true;
         return $$[$0];
-      }());
+      }()); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 151:this.$ = $$[$0];
 break;
-case 152:this.$ = new yy.Value($$[$0]);
+case 152:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 153:this.$ = new yy.Value($$[$0]);
+case 153:this.$ = (function(){ var _ = new yy.Value($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 154:this.$ = [$$[$0]];
+case 154:this.$ = (function(){ var _ = [$$[$0]]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 155:this.$ = [$$[$0-2], $$[$0]];
+case 155:this.$ = (function(){ var _ = [$$[$0-2], $$[$0]]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 156:this.$ = {
+case 156:this.$ = (function(){ var _ = {
           source: $$[$0]
-        };
+        }; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 157:this.$ = {
+case 157:this.$ = (function(){ var _ = {
           source: $$[$0],
           object: true
-        };
+        }; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 158:this.$ = {
+case 158:this.$ = (function(){ var _ = {
           source: $$[$0-2],
           guard: $$[$0]
-        };
+        }; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 159:this.$ = {
+case 159:this.$ = (function(){ var _ = {
           source: $$[$0-2],
           guard: $$[$0],
           object: true
-        };
+        }; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 160:this.$ = {
+case 160:this.$ = (function(){ var _ = {
           source: $$[$0-2],
           step: $$[$0]
-        };
+        }; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 161:this.$ = {
+case 161:this.$ = (function(){ var _ = {
           source: $$[$0-4],
           guard: $$[$0-2],
           step: $$[$0]
-        };
+        }; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 162:this.$ = {
+case 162:this.$ = (function(){ var _ = {
           source: $$[$0-4],
           step: $$[$0-2],
           guard: $$[$0]
-        };
+        }; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 163:this.$ = new yy.Switch($$[$0-3], $$[$0-1]);
+case 163:this.$ = (function(){ var _ = new yy.Switch($$[$0-3], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 164:this.$ = new yy.Switch($$[$0-5], $$[$0-3], $$[$0-1]);
+case 164:this.$ = (function(){ var _ = new yy.Switch($$[$0-5], $$[$0-3], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 165:this.$ = new yy.Switch(null, $$[$0-1]);
+case 165:this.$ = (function(){ var _ = new yy.Switch(null, $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 166:this.$ = new yy.Switch(null, $$[$0-3], $$[$0-1]);
+case 166:this.$ = (function(){ var _ = new yy.Switch(null, $$[$0-3], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 167:this.$ = $$[$0];
 break;
-case 168:this.$ = $$[$0-1].concat($$[$0]);
+case 168:this.$ = (function(){ var _ = $$[$0-1].concat($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 169:this.$ = [[$$[$0-1], $$[$0]]];
+case 169:this.$ = (function(){ var _ = [[$$[$0-1], $$[$0]]]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 170:this.$ = [[$$[$0-2], $$[$0-1]]];
+case 170:this.$ = (function(){ var _ = [[$$[$0-2], $$[$0-1]]]; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 171:this.$ = new yy.If($$[$0-1], $$[$0], {
+case 171:this.$ = (function(){ var _ = new yy.If($$[$0-1], $$[$0], {
           type: $$[$0-2]
-        });
+        }); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 172:this.$ = $$[$0-4].addElse(new yy.If($$[$0-1], $$[$0], {
+case 172:this.$ = (function(){ var _ = $$[$0-4].addElse(new yy.If($$[$0-1], $$[$0], {
           type: $$[$0-2]
-        }));
+        })); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 case 173:this.$ = $$[$0];
 break;
-case 174:this.$ = $$[$0-2].addElse($$[$0]);
+case 174:this.$ = (function(){ var _ = $$[$0-2].addElse($$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 175:this.$ = new yy.If($$[$0], yy.Block.wrap([$$[$0-2]]), {
+case 175:this.$ = (function(){ var _ = new yy.If($$[$0], yy.Block.wrap([$$[$0-2]]), {
           type: $$[$0-1],
           statement: true
-        });
+        }); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 176:this.$ = new yy.If($$[$0], yy.Block.wrap([$$[$0-2]]), {
+case 176:this.$ = (function(){ var _ = new yy.If($$[$0], yy.Block.wrap([$$[$0-2]]), {
           type: $$[$0-1],
           statement: true
-        });
+        }); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 177:this.$ = new yy.Op($$[$0-1], $$[$0]);
+case 177:this.$ = (function(){ var _ = new yy.Op($$[$0-1], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 178:this.$ = new yy.Op('-', $$[$0]);
+case 178:this.$ = (function(){ var _ = new yy.Op('-', $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 179:this.$ = new yy.Op('+', $$[$0]);
+case 179:this.$ = (function(){ var _ = new yy.Op('+', $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 180:this.$ = new yy.Op('--', $$[$0]);
+case 180:this.$ = (function(){ var _ = new yy.Op('--', $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 181:this.$ = new yy.Op('++', $$[$0]);
+case 181:this.$ = (function(){ var _ = new yy.Op('++', $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 182:this.$ = new yy.Op('--', $$[$0-1], null, true);
+case 182:this.$ = (function(){ var _ = new yy.Op('--', $$[$0-1], null, true); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 183:this.$ = new yy.Op('++', $$[$0-1], null, true);
+case 183:this.$ = (function(){ var _ = new yy.Op('++', $$[$0-1], null, true); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 184:this.$ = new yy.Existence($$[$0-1]);
+case 184:this.$ = (function(){ var _ = new yy.Existence($$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 185:this.$ = new yy.Op('+', $$[$0-2], $$[$0]);
+case 185:this.$ = (function(){ var _ = new yy.Op('+', $$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 186:this.$ = new yy.Op('-', $$[$0-2], $$[$0]);
+case 186:this.$ = (function(){ var _ = new yy.Op('-', $$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 187:this.$ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+case 187:this.$ = (function(){ var _ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 188:this.$ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+case 188:this.$ = (function(){ var _ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 189:this.$ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+case 189:this.$ = (function(){ var _ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 190:this.$ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+case 190:this.$ = (function(){ var _ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 191:this.$ = (function () {
+case 191:this.$ = (function(){ var _ = (function () {
         if ($$[$0-1].charAt(0) === '!') {
           return new yy.Op($$[$0-1].slice(1), $$[$0-2], $$[$0]).invert();
         } else {
           return new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
         }
-      }());
+      }()); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 192:this.$ = new yy.Assign($$[$0-2], $$[$0], $$[$0-1]);
+case 192:this.$ = (function(){ var _ = new yy.Assign($$[$0-2], $$[$0], $$[$0-1]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 193:this.$ = new yy.Assign($$[$0-4], $$[$0-1], $$[$0-3]);
+case 193:this.$ = (function(){ var _ = new yy.Assign($$[$0-4], $$[$0-1], $$[$0-3]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
-case 194:this.$ = new yy.Extends($$[$0-2], $$[$0]);
+case 194:this.$ = (function(){ var _ = new yy.Extends($$[$0-2], $$[$0]); if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()
 break;
 }
 },

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -11,6 +11,7 @@ path             = require 'path'
 vm               = require 'vm'
 {Lexer,RESERVED} = require './lexer'
 {parser}         = require './parser'
+{printLinenos}   = require './nodes'
 
 # TODO: Remove registerExtension when fully deprecated.
 if require.extensions
@@ -70,9 +71,138 @@ exports.run = (code, options) ->
 
   # Compile.
   if path.extname(mainModule.filename) isnt '.coffee' or require.extensions
-    mainModule._compile compile(code, options), mainModule.filename
+    js = compile(code, options)
   else
-    mainModule._compile code, mainModule.filename
+    js = code
+  
+  # Debug.
+  try
+    mainModule._compile js, mainModule.filename
+  catch err
+    err.debug = debug code, err.stack.split('\n'), options, js if options.debug
+    # Node.js reports the error is from the .coffee file, when it's actually occuring in the
+    # compiled .js file
+    # [fixes issue #987] (https://github.com/jashkenas/coffee-script/issues/987)
+    err.stack = err.stack.replace /\.coffee\:/g, '.js:'
+    # forward on the runtime's error (handled by `command.coffee`)
+    throw err
+  true
+
+# Debugging
+# ---------
+# If a .coffee script successfully compiles into JavaScript, but the runtime throws an error,
+# the --debug option will map the error in the output JavaScript with the associated
+# CoffeeScript line
+debug = (code,stack,options,ojs) ->
+    # print the error message as reported by the runtime
+    msg = "\n  #{stack[0]}\n\n"
+
+    # The script is re-compiled, this time with printed line numbers placed next to
+    # each element of js code (as inlined block comments)
+    #
+    #   f = (i) -> log i
+    #
+    # after `compile`, becomes:
+    #
+    #   f = function(i) {
+    #     return log(i);
+    #   };
+    #
+    # after `printLinenos()` becomes:
+    #
+    #   f/*@line: 3*/ = function(i/*@line: 3*/) {
+    #     return log/*@line: 3*/(i/*@line: 3*/);
+    #   };
+
+    # ojs is the original js output, so we can reference the line without line numbers
+    #    f = function(i) { ...
+
+    # `printLinenos` from Nodes.coffee monkeypatches each node's `compile` method
+    # to append the node's .coffee line number as a block comment
+    #   f/*@line: 3*/ = function(i/*@line: 3*/) { ...
+    printLinenos()
+
+    # recompile
+    js       = compile(code, options)
+    jslines  = js.split '\n'
+
+    # a DebugCSFile object is used to store references to error line numbers
+    # and to print the lines with errors
+    csfile   = new DebugCSFile code
+
+    # grab the stackline where the error actually occured
+    for stackline in stack
+      if stackline.indexOf('.coffee') > -1 then break
+
+    #at Object.<anonymous> (.:3:1)
+    inEval = stack[1].match /\(\.\:(\d*)\:\d*\)/
+    if inEval then stackline = "/__commandline__.coffee:#{inEval[1]}:1"
+
+    [match, file, lineno] = stackline.match /\/([A-Za-z0-9_\ \$\-\_\.]*\.(?:coffee|js))\:(\d*)\:\d/
+    lineno = parseInt lineno
+
+    ojsline = ojs.split('\n')[lineno - 1]
+
+    # print the .js file's error information
+    jsmsg = "in #{file.replace(/.coffee/, '.js')} on line #{lineno}\n"
+    msg +=  "  #{jsmsg}  #{new Array(jsmsg.length).join('-')}\n"
+    msg +=  "  > #{lineno} | #{ojsline}\n\n"
+
+    # issue: for some reason, when recompiling, the jslines don't match...
+    # I think the line where all the vars are declared doesn't get output again
+    # (maybe something with scope.coffee?)
+    jsline = jslines[ if options.bare then lineno - 2 else lineno - 3 ]
+
+    # grab the CoffeeScript line numbers from the block comments in the .js file
+    errlinenos = jsline.match /.*?\/\*\@line\:\ \d*\*\//g
+    for errline in errlinenos
+      [all,code,comment,cslineno] = errline.match /(.*?)(\/\*\@line\:\ (\d*)\*\/)/
+      # add the error to the DebugCSFile
+      csfile.error cslineno
+
+    # print the .cs file's error information
+    csmsg = "in #{file} on line #{cslineno}\n"
+    msg +=  "  #{csmsg}  #{new Array(csmsg.length).join('-')}\n"
+
+    # print all lines from the .cs file that contain an error, and
+    # a few of the surrounding lines to give context
+    # (error lines are indicated with a ">")
+    msg += csfile.print() + '\n'
+
+class DebugCSFile
+  constructor: (code) ->
+    @cslines = code.split '\n'
+    @lines = {}
+
+  error: (lineno) ->
+    lineno = parseInt lineno
+    @lines[lineno] = new DebugCSLine lineno, @cslines[lineno - 1], yes
+    @contextualize lineno
+
+  contextualize: (errlineno) ->
+    for lineno in [errlineno-3...errlineno+3] when 0 < lineno < @cslines.length-1
+      @lines[lineno] = new DebugCSLine lineno, @cslines[lineno - 1], no unless @lines[lineno]
+
+  numlines: () ->
+    max = 0
+    for lineno of @lines
+      max = Math.max parseInt(lineno),max
+    max
+
+  print: ->
+    out = []
+    length = String( @numlines() ).length
+    out.push( line.print( length ) ) for lineno,line of @lines
+    out.join('\n')
+
+class DebugCSLine
+  constructor: (lineno,@line,@isError) ->
+    @lineno = String lineno
+
+  print: (length) ->
+    spaces = new Array( Math.max length + 2, 4 ).join(' ')[@lineno.length..]
+    if @isError then spaces = spaces[1..]
+    "#{spaces}#{if @isError then '>' else '' } #{@lineno} | #{@line}"
 
 # Compile and evaluate a string of CoffeeScript (in a Node.js-like environment).
 # The CoffeeScript REPL uses this to run the input.

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -27,6 +27,7 @@ BANNER = '''
 # The list of all the valid option flags that `coffee` knows how to handle.
 SWITCHES = [
   ['-c', '--compile',         'compile to JavaScript and save as .js files']
+  ['-d', '--debug',           'print debug info when a running .coffee file encounters an error']
   ['-i', '--interactive',     'run an interactive CoffeeScript REPL']
   ['-o', '--output [DIR]',    'set the directory for compiled JavaScript']
   ['-j', '--join [FILE]',     'concatenate the scripts before compiling']
@@ -117,7 +118,12 @@ compileScript = (file, input, base) ->
     CoffeeScript.emit 'failure', err, task
     return if CoffeeScript.listeners('failure').length
     return printLine err.message if o.watch
-    printWarn err.stack
+    if o.debug
+      # while this feature is being developed, sometimes a bug prevents .debug
+      # from having a value, so we must check that here
+      if err.debug then printWarn err.debug else printWarn err.stack
+    else
+      printWarn err.stack
     process.exit 1
 
 # Attach the appropriate listeners to compile scripts incoming over **stdin**,
@@ -201,7 +207,7 @@ parseOptions = ->
   sources       = o.arguments
 
 # The compile-time options to pass to the CoffeeScript compiler.
-compileOptions = (filename) -> {filename, bare: opts.bare}
+compileOptions = (filename) -> {filename, bare: opts.bare, debug: opts.debug}
 
 # Start up a new Node.js instance with the arguments in `--nodejs` passed to
 # the `node` binary, preserving the other options.

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -36,7 +36,8 @@ o = (patternString, action, options) ->
   action = if match = unwrap.exec action then match[1] else "(#{action}())"
   action = action.replace /\bnew /g, '$&yy.'
   action = action.replace /\b(?:Block\.wrap|extend)\b/g, 'yy.$&'
-  [patternString, "$$ = #{action};", options]
+  [patternString, "$$ = (function(){ var _ = #{action}; if(typeof _.lineno !== 'undefined'){_.lineno = yylineno; }; return _; })()", options]
+  #[patternString, "$$ = (function(){ var _ = #{action}; _.lineno && _.lineno = yylineno; }; return _; })()", options]
 
 # Grammatical Rules
 # -----------------

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -129,6 +129,8 @@ exports.Base = class Base
     continue until node is node = node.unwrap()
     node
 
+  printLineno: -> "/*@line: #{@lineno + 1}*/"
+
   # Default implementations of the common node properties and methods. Nodes
   # will override these with custom logic, if needed.
   children: []
@@ -144,6 +146,8 @@ exports.Base = class Base
 
   # Is this node used to assign a certain variable?
   assigns: NO
+
+  lineno: -1
 
 #### Block
 
@@ -1831,3 +1835,18 @@ utility = (name) ->
 
 multident = (code, tab) ->
   code.replace /\n/g, '$&' + tab
+
+exports.printLinenos = () ->
+  # grab all the nodes, but not `extends` and other lowercase, non-classes (like this method)
+  nodes = ( node for name,node of exports when name[0].toUpperCase() is name[0] )
+
+  # monkey patch their compileNode methods so that lineno is appended to their compiled form
+  for node in nodes
+    do ( node ) ->
+      $compile = node::compile
+      node::compile = () ->
+        compiled = $compile.apply( this, Array::slice.call arguments )
+        haslineno = compiled.match(/(.*?)(\/\*\@line\:\ (\d*)\*\/)/gm)
+        # lineno > -1 : filters out node.js code (such as `console.log`)
+        if not haslineno and @lineno > -1 then compiled += @printLineno()
+        compiled


### PR DESCRIPTION
## Debug mode for running .coffee scripts #558, #987

Adds a --debug option for .coffee scripts that outputs more helpful error messages (mapping compiled .js lines of code to the input .coffee file's lines).

**This branch should be considered experimental at the moment -- it serves as a proof-of-concept and to expose additional issues with adding debugging support to CoffeeScript. I.e., don't merge it into master :)**

Current output:  

```
TypeError: string is not a function
    at String.CALL_NON_FUNCTION (native)
    at Object.<anonymous> (/Users/geraldlewis/Work/Interactive/projects/coffee-script/errs/err.coffee:10:3)
    at Module._compile (module.js:420:26)
    at Object.run (/Users/geraldlewis/Work/Interactive/projects/coffee-script/coffee-script/lib/coffee-script.js:68:12)
    at /Users/geraldlewis/Work/Interactive/projects/coffee-script/coffee-script/lib/command.js:120:29
    at /Users/geraldlewis/Work/Interactive/projects/coffee-script/coffee-script/lib/command.js:90:26
    at [object Object].<anonymous> (fs.js:107:5)
    at [object Object].emit (events.js:61:17)
    at afterRead (fs.js:970:12)
    at wrapper (fs.js:245:17)
```

--debug Output:  

```
  TypeError: string is not a function

  in err.js on line 10
  --------------------
  > 10 |   s();

  in err.coffee on line 10
  ------------------------
   7 | 
   8 | 
   9 | for k,v in [1,2,3]
> 10 |   s()
  11 |   try
  12 |     #log undef
```
- Uses a few strategies outlined in #558, namely @atrefz 's `--debug` compiler option with line number comments, @andrewschaaf 's "FUGLY" option (though modified so that the end user never sees the ugly JS line number comments)
- Speaking of, @andrewschaaf has done some great work on this same issue, which I'm having trouble locating at the moment 
- Uses @aseemk 's suggestion for Stylus style error messages (#1351)
- Also fixes #987 (stack trace refers to [filename].js instead of [filename].coffee)

**Caveats**  
- only works with node.js at the moment
- only works for `run`ning and `eval`-ed .coffee scripts (see below)
- needs **a lot** of testing; I've not tested it with a lot of sample bugs

Here's the branch:
    https://github.com/geraldalewis/coffee-script/tree/debug

Here's the commit:
  https://github.com/geraldalewis/coffee-script/commit/9d0fa7cc4d4b73e8de1a0a8179753ba3fa0df1b8

=What works=
### Running .coffee files

```
bin/coffee -d ../errs/err.coffee 

  TypeError: string is not a function

  in err.js on line 11
  --------------------
  > 11 |     s();

  in err.coffee on line 10
  ------------------------
   7 | 
   8 | 
   9 | for k,v in [1,2,3]
> 10 |   s()
  11 |   try
  12 |     #log undef
```
### Eval

...**Sort of** -- this works:

```
bin/coffee -bed 'i = 0; undef()'
```

but this fails for some reason (some bug in the `DebugCSFile.error`, I think -- seems to happen if < 2 lines of .js)

```
bin/coffee -bed 'undef()'
```
## What doesn't work

There are a few classes of errors I'm struggling to get debug info from. I have no solutions at the moment, but some ideas below.
### Errors in CoffeeScript

@jashkenas 's first question to me was what kind of output he'd see if there was an error in `src/scope.coffee`. I inserted a bug into `Scope`'s constructor (a call to `undef()`), recompiled CoffeeScript, and ran coffee -bed 'i = 1'  

```
dev:coffee-script(debugging)$ coffee -bed 'i = 1'
ReferenceError: undef is not defined
    at new Scope (/Users/geraldlewis/Work/interactive/projects/coffee-script/coffee-script/lib/scope.js:10:7)
    ...
```

Clearly, `debug` didn't work -- we have the same `node.js` error message output, instead of the expected:

```
ReferenceError: undef is not defined

in scope.coffee on line 21
--------------------------
  19 |constructor: (@parent, @expressions, @method) ->
> 21 |  undef()
  22 |  @variables = [{name: 'arguments', type: 'arguments'}]
```

My mistake was forgetting that `coffee` uses pre-compiled .js files to run CoffeeScript. `debug` relies on CoffeeScript compiling a .coffee file -- the .coffee file needs to be present so that the executing .js file's line numbers can be mapped to their CoffeeScript source. Since we no longer have a reference to the original `scope.coffee` file, we don't have any way of associating the lines of code where an error occured in `scope.js`.

Compounding the issue: because `debug` needs to re-compile the source .coffee file(s) (to insert the line-number comments mapping the line of .js to its respective line of .coffee) **a bug in the `compile` pipeline is a bug in `debug`**... 
### Possible Solutions

 1) `cake build` ensures a clean, working copy of CoffeeScript is available even if a bug is introduced into its source
 2) introduce a bug into the source of CoffeeScript

```
    # in source.coffee
    constructor: ()->
      undef()
```

 3) compile the buggy CoffeeScript via `cake build`
 4) run a bug-free script to see if an error occurs

```
    bin/coffee -be 'i = 1'
```

 5) on error, grab the buggy .js file from the error stack

```
    at new Scope (coffee-script/lib/scope.js:10:7)
```

 6) _somehow_ get the .js file's associated .coffee file

```
    # in scope.js
    //@source_file:coffee-script/src/scope.coffee
```

 7) and send it to the _clean working copy of CoffeeScript_
 7) output that debug message...
## Docco

Debugging Docco represents a subtly different class of issues than debugging CoffeeScript. Like CoffeeScript, `docco.coffee` has already been compiled to `docco.js` when `bin/docco` `require`s it:  

```
#!/usr/bin/env node

var path = require('path');
var fs = require('fs');
var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');

process.ARGV = process.argv = process.argv.slice(2, process.argv.length);
require(lib + '/docco.js'); #completely bypasses the .coffee compilation stage
```

We have the same issue -- since we no longer have a reference to the original `.coffee` script, we don't have any way of associating the line of JavaScript code with its originating CoffeeScript line.
### Possible solutions:

1) `run` `docco` via bin/coffee  
- modify `command.coffee` `run` to allow args to be sent via "<" to the running script if the `-d` option is set:  
  
  ```
  coffee -d src/docco.coffee < src/some_project.coffee
  # for the `run`ning src/docco.coffee script, process.ARGV would = process.ARGV[2..]
  ```

2) a `--debugsource` flag (oof?)  
- not sure how this would work exactly, but some loose ideas:
- `debugsource` points to the .coffee source file or src/ folder for the running script
- if an error is encountered in the `node.js` runtime
- use `process.on 'uncaughtException'` to catch it and save details as "`stack`"
- run `coffee-script.debug ( debugsource, stack ... )` 
- (this recompiles the debugsource so that the CoffeeScript lines can be associated with their JS counterparts )
  
    docco --debugsource=src/docco.coffee src/some_project.coffee
