### PR TITLE
always treat blocks as statements

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -198,17 +198,7 @@
     Block.prototype.isEmpty = function() {
       return !this.expressions.length;
     };
-    Block.prototype.isStatement = function(o) {
-      var exp, _i, _len, _ref2;
-      _ref2 = this.expressions;
-      for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-        exp = _ref2[_i];
-        if (exp.isStatement(o)) {
-          return true;
-        }
-      }
-      return false;
-    };
+    Block.prototype.isStatement = YES;
     Block.prototype.jumps = function(o) {
       var exp, _i, _len, _ref2;
       _ref2 = this.expressions;
@@ -798,7 +788,7 @@
       }
     };
     Range.prototype.compileNode = function(o) {
-      var cond, condPart, from, gt, idx, known, lt, stepPart, to, varPart, _ref2, _ref3;
+      var cond, condPart, from, gt, idx, known, lt, stepPart, to, varPart, _ref2;
       if (!this.fromVar) {
         this.compileVariables(o);
       }
@@ -815,7 +805,18 @@
         varPart += ", " + this.step;
       }
       _ref2 = ["" + idx + " <" + this.equals, "" + idx + " >" + this.equals], lt = _ref2[0], gt = _ref2[1];
-      condPart = this.stepNum ? condPart = +this.stepNum > 0 ? "" + lt + " " + this.toVar : "" + gt + " " + this.toVar : known ? ((_ref3 = [+this.fromNum, +this.toNum], from = _ref3[0], to = _ref3[1], _ref3), condPart = from <= to ? "" + lt + " " + to : "" + gt + " " + to) : (cond = "" + this.fromVar + " <= " + this.toVar, condPart = "" + cond + " ? " + lt + " " + this.toVar + " : " + gt + " " + this.toVar);
+      condPart = (function() {
+        var _ref3;
+        if (this.stepNum) {
+          return condPart = +this.stepNum > 0 ? "" + lt + " " + this.toVar : "" + gt + " " + this.toVar;
+        } else if (known) {
+          _ref3 = [+this.fromNum, +this.toNum], from = _ref3[0], to = _ref3[1];
+          return condPart = from <= to ? "" + lt + " " + to : "" + gt + " " + to;
+        } else {
+          cond = "" + this.fromVar + " <= " + this.toVar;
+          return condPart = "" + cond + " ? " + lt + " " + this.toVar + " : " + gt + " " + this.toVar;
+        }
+      }).call(this);
       stepPart = this.stepVar ? "" + idx + " += " + this.stepVar : known ? from <= to ? "" + idx + "++" : "" + idx + "--" : "" + cond + " ? " + idx + "++ : " + idx + "--";
       return "" + varPart + "; " + condPart + "; " + stepPart;
     };
@@ -1849,9 +1850,17 @@
     Existence.prototype.children = ['expression'];
     Existence.prototype.invert = NEGATE;
     Existence.prototype.compileNode = function(o) {
-      var cmp, cnj, code, _ref2;
+      var cmp, cnj, code;
       code = this.expression.compile(o, LEVEL_OP);
-      code = IDENTIFIER.test(code) && !o.scope.check(code) ? ((_ref2 = this.negated ? ['===', '||'] : ['!==', '&&'], cmp = _ref2[0], cnj = _ref2[1], _ref2), "typeof " + code + " " + cmp + " \"undefined\" " + cnj + " " + code + " " + cmp + " null") : "" + code + " " + (this.negated ? '==' : '!=') + " null";
+      code = (function() {
+        var _ref2;
+        if (IDENTIFIER.test(code) && !o.scope.check(code)) {
+          _ref2 = this.negated ? ['===', '||'] : ['!==', '&&'], cmp = _ref2[0], cnj = _ref2[1];
+          return "typeof " + code + " " + cmp + " \"undefined\" " + cnj + " " + code + " " + cmp + " null";
+        } else {
+          return "" + code + " " + (this.negated ? '==' : '!=') + " null";
+        }
+      }).call(this);
       if (o.level <= LEVEL_COND) {
         return code;
       } else {
@@ -2187,7 +2196,15 @@
       if (!this.elseBody) {
         return ifPart;
       }
-      return ifPart + ' else ' + (this.isChain ? (o.indent = this.tab, o.chainChild = true, this.elseBody.unwrap().compile(o, LEVEL_TOP)) : "{\n" + (this.elseBody.compile(o, LEVEL_TOP)) + "\n" + this.tab + "}");
+      return ifPart + ' else ' + (function() {
+        if (this.isChain) {
+          o.indent = this.tab;
+          o.chainChild = true;
+          return this.elseBody.unwrap().compile(o, LEVEL_TOP);
+        } else {
+          return "{\n" + (this.elseBody.compile(o, LEVEL_TOP)) + "\n" + this.tab + "}";
+        }
+      }).call(this);
     };
     If.prototype.compileExpression = function(o) {
       var alt, body, code, cond;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -179,10 +179,7 @@ exports.Block = class Block extends Base
   isEmpty: ->
     not @expressions.length
 
-  isStatement: (o) ->
-    for exp in @expressions when exp.isStatement o
-      return yes
-    no
+  isStatement: YES
 
   jumps: (o) ->
     for exp in @expressions

--- a/test/compilation.coffee
+++ b/test/compilation.coffee
@@ -62,3 +62,6 @@ test "#1106: __proto__ compilation", ->
 
 test "eval returns result when bare is false and filename is not set", ->
   ok 'passed' is CoffeeScript.eval '"passed"'
+
+test "don't generate consecutive semicolons", ->
+  ok CoffeeScript.compile("(0;0)").indexOf(';;') < 0


### PR DESCRIPTION
It makes sense for the body of `Block`s to be compiled as comma-separated expressions because it generates more compressed output than the alternative compilation of an immediately-invoked function expression. But the output is much less readable that way. So I changed the behaviour so that now `Block`s are always treated as statements, resulting in the IIFE compilation every time. This change also resolves a minor side issue where a block within parentheses (such as `(0;0)`) generates consecutive semicolons.

See the diff, it will explain everything better than I can.

Anyway, I'm not sure if this is an improvement or not yet, so I'd like to hear some opinions. And if the patch is voted down, we should look into some alternative solutions for the minor consecutive semicolon issue.
