### PR TITLE
compileJoin should happen once after all files are read

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -66,8 +66,8 @@
       source = sources[_j];
       base = path.join(source);
       compile = function(source, sourceIndex, topLevel) {
-        var remaining;
-        remaining = function() {
+        var remaining_files;
+        remaining_files = function() {
           var total, x, _k, _len3;
           total = 0;
           for (_k = 0, _len3 = unprocessed.length; _k < _len3; _k++) {
@@ -99,10 +99,8 @@
                 unprocessed[sourceIndex] -= 1;
                 if (opts.join) {
                   contents[sourceIndex] = helpers.compact([contents[sourceIndex], code.toString()]).join('\n');
-                  if (remaining() === 0) {
-                    if (helpers.compact(contents).length > 0) {
-                      return compileJoin();
-                    }
+                  if (helpers.compact(contents).length > 0 && remaining_files() === 0) {
+                    return compileJoin();
                   }
                 } else {
                   return compileScript(source, code.toString(), base);

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -99,8 +99,8 @@ compileScripts = ->
               unprocessed[sourceIndex] -= 1
               if opts.join
                 contents[sourceIndex] = helpers.compact([contents[sourceIndex], code.toString()]).join('\n')
-                if remaining_files() == 0
-                  compileJoin() if helpers.compact(contents).length > 0
+                if helpers.compact(contents).length > 0 and remaining_files() == 0
+                  compileJoin()
               else
                 compileScript(source, code.toString(), base)
             watch source, base if opts.watch and not opts.join


### PR DESCRIPTION
This fixes --print in combination with --join... I realize join takes a filename... currently --print takes precedence (not saving a file)... but this patch corrects the behavior of print in combination with join.  Previously each iteration thru the loop printed output:

[file1 compiled]
[file1+file2 compiled]
[file1+file2+file3 compiled]

This patch fixes that behavior.
