### PR TITLE
add other javascript keywords

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -512,6 +512,7 @@ JS_KEYWORDS = [
   'new', 'delete', 'typeof', 'in', 'instanceof'
   'return', 'throw', 'break', 'continue', 'debugger'
   'if', 'else', 'switch', 'for', 'while', 'do', 'try', 'catch', 'finally'
+  'final', 'case', 'function', 'var', 'void'
   'class', 'extends', 'super'
 ]
 


### PR DESCRIPTION
because these are also keywords in js, 
we should make sure they get quoted when 
used as object keys.  There are technically others 
that arn't actually used but are still reserved,
but I am assuming there was a reason for not including
everything.  If not, then I think _all_ reserved words
should be quoted.

see: http://javascript.crockford.com/survey.html
