### PR TITLE
Catch creates its own shared scope.

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1822,10 +1822,10 @@
       return this;
     };
     Try.prototype.compileNode = function(o) {
-      var catchPart, errorPart;
+      var catchPart, errorPart, subO;
       o.indent += TAB;
       errorPart = this.error ? " (" + (this.error.compile(o)) + ") " : ' ';
-      catchPart = this.recovery ? (o.scope.add(this.error.value, 'param'), " catch" + errorPart + "{\n" + (this.recovery.compile(o, LEVEL_TOP)) + "\n" + this.tab + "}") : !(this.ensure || this.recovery) ? ' catch (_e) {}' : void 0;
+      catchPart = this.recovery ? (subO = extend({}, o), subO.scope = new Scope(o.scope, this, o.scope.method), subO.scope.shared = true, subO.scope.add(this.error.value, 'param', true), " catch" + errorPart + "{\n" + (this.recovery.compile(subO, LEVEL_TOP)) + "\n" + this.tab + "}") : !(this.ensure || this.recovery) ? ' catch (_e) {}' : void 0;
       return ("" + this.tab + "try {\n" + (this.attempt.compile(o, LEVEL_TOP)) + "\n" + this.tab + "}" + (catchPart || '')) + (this.ensure ? " finally {\n" + (this.ensure.compile(o, LEVEL_TOP)) + "\n" + this.tab + "}" : '');
     };
     return Try;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1405,8 +1405,11 @@ exports.Try = class Try extends Base
     o.indent  += TAB
     errorPart = if @error then " (#{ @error.compile o }) " else ' '
     catchPart = if @recovery
-      o.scope.add @error.value, 'param'
-      " catch#{errorPart}{\n#{ @recovery.compile o, LEVEL_TOP }\n#{@tab}}"
+      subO = extend {}, o
+      subO.scope = new Scope o.scope, this, o.scope.method
+      subO.scope.shared = true
+      subO.scope.add @error.value, 'param', true
+      " catch#{errorPart}{\n#{ @recovery.compile subO, LEVEL_TOP }\n#{@tab}}"
     else unless @ensure or @recovery
       ' catch (_e) {}'
     """

--- a/test/scope.coffee
+++ b/test/scope.coffee
@@ -32,3 +32,21 @@ test "catch statements should introduce their argument to scope", ->
   catch e
     do -> e = 5
     eq 5, e
+
+test "catch statements should create shared scope with their argument", ->
+  g = ->
+    try
+    catch e
+    e = 2 # e should local to g
+    try
+      throw "error"
+    catch e
+      e = 3 # e should local to catch clause
+      x = 1 # x should local to g, not catch clause
+
+    ok e is 2
+    ok x is 1
+
+  e = 1 # this e should be different to e in g
+  g()
+  ok e is 1


### PR DESCRIPTION
"catch e" should create its own shared scope with e in it.
Current implementation simply add e to current scope.
However, in compiled JavaScript, e is local to catch clause.
This mismatch breaks lexical scope of CoffeeScript.

Neither simply adding e to current scope, nor creating non-shared scope passes the following test:

```
test "catch statements should create shared scope with their argument", ->
  g = ->
    try
    catch e
    e = 2 # e should local to g
    try
      throw "error"
    catch e
      e = 3 # e should local to catch clause
      x = 1 # x should local to g, not catch clause

    ok e is 2
    ok x is 1

  e = 1 # this e should be different to e in g
  g()
  ok e is 1
```
