### PR TITLE
Corrected example to correctly refer to grade, instead of eldest.

### DIFF
--- a/documentation/coffee/expressions.coffee
+++ b/documentation/coffee/expressions.coffee
@@ -6,4 +6,9 @@ grade = (student) ->
   else
     "C"
 
-eldest = if 24 > 21 then "Liz" else "Ike"
+students =
+  "salvador":
+    okayStuff: true
+    triedHard: true
+
+alert grade(students["salvador"])


### PR DESCRIPTION
Amazing work so far! I was noticing that this example seems to be incorrect, hopefully my proposed change better matches your intentions.
