### PR TITLE
Add documentation on executing .coffee scripts

### DIFF
--- a/README
+++ b/README
@@ -29,8 +29,11 @@
   npm install -g coffee-script
   (Leave off the -g if you don't wish to install globally.)
 
-  Compile a script:
+  Run a script:
   coffee /path/to/script.coffee
+
+  Compile to JavaScript:
+  coffee -c /path/to/script.coffee
 
   For documentation, usage, and examples, see:
   http://coffeescript.org/

--- a/documentation/coffee/hello_world.coffee
+++ b/documentation/coffee/hello_world.coffee
@@ -1,0 +1,4 @@
+#!/usr/bin/env coffee
+
+console.log "Hello, world"
+

--- a/documentation/index.html.erb
+++ b/documentation/index.html.erb
@@ -197,11 +197,21 @@ sudo bin/cake install</pre>
     <p>
       Once installed, you should have access to the <tt>coffee</tt> command,
       which can execute scripts, compile <tt>.coffee</tt> files into <tt>.js</tt>,
-      and provide an interactive REPL. The <tt>coffee</tt> command takes the
-      following options:
+      and provide an interactive REPL. The command <tt>coffee [options] [file]</tt>
+      takes the following arguments:
     </p>
-
     <table>
+      <tr>
+        <td><code>file</code></td>
+        <td>
+          The <tt>.coffee</tt> script file to execute or compile. Running 
+          <tt>coffee file.coffee</tt> will compile and execute the
+          <tt>.coffee</tt> script and print its output to <b>stdout</b>.
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">Options:</td>
+      </tr>
       <tr>
         <td><code>-c, --compile</code></td>
         <td>
@@ -322,6 +332,10 @@ Expressions
     </p>
 
     <ul>
+      <li>
+        Run a <tt>.coffee</tt> script and echo its output to the console:<br />
+        <tt>coffee helloworld.coffee</tt>
+      </li>
       <li>
         Compile a directory tree of <tt>.coffee</tt> files into a parallel
         tree of <tt>.js</tt>, in <tt>lib</tt>:<br />
@@ -923,6 +937,26 @@ Expressions
       run within a closure wrapper, so if you want to expose global variables or
       functions, attach them to the <tt>window</tt> object.
     </p>
+
+
+    <h2>
+      <span id="shell_scripts" class="bookmark"></span>
+      Shell Scripting
+    </h2>
+
+    <p>
+      You can write command line executables in CoffeeScript by invoking the
+      <tt>coffee</tt> interpreter on the first line of the script. The
+      <tt>.coffee</tt> script will be compiled to JavaScript and executed using
+      <a href="http://nodejs.org/docs/latest/api/">Node.js</a>.
+    </p>
+    <%= code_for('hello_world') %>
+    <p>
+      If this was saved to a file called <tt>helloworld.coffee</tt> and marked
+      as executable, you could run it directly from the command line with
+      <tt>$ ./helloworld.coffee</tt>.
+    </p>
+
 
     <h2>
       <span id="resources" class="bookmark"></span>

--- a/documentation/js/hello_world.js
+++ b/documentation/js/hello_world.js
@@ -1,0 +1,1 @@
+console.log("Hello, world");


### PR DESCRIPTION
Currently there is no documentation on http://jashkenas.github.com/coffee-script/ that indicates that you can execute a .coffee file using `coffee file.coffee`. I've been playing with coffeescript for months, and I just discovered it yesterday! There is line that says the `coffee` command can execute scripts, but no examples or any other indication of the most basic form of the coffee command.

This pull request updates the documentation on the `coffee` command, adds an example of calling `coffee file.coffee`, and adds a section on writing shell scripts in CoffeeScript. Also, a misleading example of using `coffee` is fixed in README.

I'm not including the processed index.html because some syntax highlighting was messed up when I ran ran `rake doc` on my machine. `rake doc` will need to run once this branch is merged.

Another place that needs to be changed is the help docs when you run `coffee --help`. There is currently no indication there that you can run `coffee file.coffee` to execute a .coffee script. Also, it is not clear there that running `coffee` with no args will launch the REPL.

It'd be great if someone could update command.coffee to clarify those two cases, but I didn't know the best way to do so myself.

These changes are based off the master branch since gh-pages seemed to be far behind. If this should be based of another branch, please let me know.

Thanks! I appreciate any feedback, clarifications, or questions.
