### PR TITLE
Patch for issue #1492 (consecutive semicolons in compiled output)

### DIFF
--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -254,7 +254,9 @@
         node = _ref2[_i];
         node = node.unwrapAll();
         node = node.unfoldSoak(o) || node;
-        if (top) {
+        if (node instanceof Block) {
+          codes.push(node.compileNode(o));
+        } else if (top) {
           node.front = true;
           code = node.compile(o);
           codes.push(node.isStatement(o) ? code : this.tab + code + ';');

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -214,7 +214,12 @@ exports.Block = class Block extends Base
     for node in @expressions
       node = node.unwrapAll()
       node = (node.unfoldSoak(o) or node)
-      if top
+      if node instanceof Block
+        # This is a nested block.  We don't do anything special here like enclose
+        # it in a new scope; we just compile the statements in this block along with
+        # our own
+        codes.push node.compileNode o
+      else if top
         node.front = true
         code = node.compile o
         codes.push if node.isStatement o then code else @tab + code + ';'

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -116,3 +116,10 @@ test "indented heredoc", ->
                 abc
                 """)
   eq "abc", result
+
+# Nested blocks caused by paren unwrapping
+test "#1492: Nested blocks don't cause double semicolons", ->
+  js = CoffeeScript.compile """
+    (0;0)
+    """
+  eq -1, js.indexOf ';;'


### PR DESCRIPTION
In situations like 

```
(0;0)
```

The compiled output can have multiple semicolons at the end.  This is because the `Block` node didn't handle the case where it had another `Block` as a child.  Fixed by adding a check for this in `compileNode()` so that we just had the sub-block's compiled code directly to our block instead of treating the block itself as a child.
