### PR TITLE
Issue #1470: Command line compiler now assumes ".coffee" extension if left off of file names

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -63,7 +63,7 @@
       compile = function(source, sourceIndex, topLevel) {
         return path.exists(source, function(exists) {
           if (topLevel && !exists && source.slice(-7) !== '.coffee') {
-            return compile(source + ".coffee", sourceIndex, topLevel);
+            return compile("" + source + ".coffee", sourceIndex, topLevel);
           }
           if (topLevel && !exists) {
             throw new Error("File not found: " + source);

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -79,7 +79,7 @@ compileScripts = ->
     compile = (source, sourceIndex, topLevel) ->
       path.exists source, (exists) ->
         if topLevel and not exists and source[-7..] isnt '.coffee'
-            return compile source + ".coffee", sourceIndex, topLevel
+            return compile "#{source}.coffee", sourceIndex, topLevel
                 
         throw new Error "File not found: #{source}" if topLevel and not exists
         fs.stat source, (err, stats) ->


### PR DESCRIPTION
Does a simple check to see if, when the file doesn't exist, it also doesn't have a ".coffee" extension.  If it doesn't, we recursively call compile with the filename + ".coffee" and see if that file exists.
