### PR TITLE
Fix for issue #1446: Compiler fails with unrelated exception on file permissions problems

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -90,6 +90,9 @@
             if (stats.isDirectory()) {
               return fs.readdir(source, function(err, files) {
                 var file, _k, _len3;
+                if (err) {
+                  throw err;
+                }
                 unprocessed[sourceIndex] += files.length;
                 for (_k = 0, _len3 = files.length; _k < _len3; _k++) {
                   file = files[_k];
@@ -99,6 +102,9 @@
               });
             } else if (topLevel || path.extname(source) === '.coffee') {
               fs.readFile(source, function(err, code) {
+                if (err) {
+                  throw err;
+                }
                 unprocessed[sourceIndex] -= 1;
                 if (opts.join) {
                   contents[sourceIndex] = helpers.compact([contents[sourceIndex], code.toString()]).join('\n');

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -93,12 +93,14 @@ compileScripts = ->
           throw err if err
           if stats.isDirectory()
             fs.readdir source, (err, files) ->
+              throw err if err
               unprocessed[sourceIndex] += files.length
               for file in files
                 compile path.join(source, file), sourceIndex
               unprocessed[sourceIndex] -= 1
           else if topLevel or path.extname(source) is '.coffee'
             fs.readFile source, (err, code) ->
+              throw err if err
               unprocessed[sourceIndex] -= 1
               if opts.join
                 contents[sourceIndex] = helpers.compact([contents[sourceIndex], code.toString()]).join('\n')


### PR DESCRIPTION
The fix for this was easy enough:  just add `throw err if err` to `fs.readdir` and `fs.readFile` callbacks.

To test:

```
touch testing.coffee
chown 000 testing.coffee
coffee testing.coffee            # Verify this throws unrelated exception
bin/coffee testing.coffee       # Verify this throws permission denied exception
```
