### PR TITLE
Add uglify-js and jison as development dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/fixtures/underscore
 test/*.js
 examples/beautiful_code/parse.coffee
 *.gem
+/node_modules

--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
   "repository":   {
     "type": "git",
     "url": "git://github.com/jashkenas/coffee-script.git"
+  },
+  "devDependencies": {
+    "uglify-js":  "1.0.6",
+    "jison":      "0.2.9"
   }
 }


### PR DESCRIPTION
`npm install` in a coffee-script checkout will install uglify-js and jison to the `node_modules` directory to ensure everyone has the same version.
