### PR TITLE
--join fails silently with no resulting output file

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -37,27 +37,39 @@
     return compileScripts();
   };
   compileScripts = function() {
-    var base, compile, source, unprocessed, _i, _j, _len, _len2, _results;
+    var base, compile, remaining_files, source, trackCompleteFiles, trackUnprocessedFiles, unprocessed, _i, _j, _len, _len2, _results;
     unprocessed = [];
+    remaining_files = function() {
+      var total, x, _i, _len;
+      total = 0;
+      for (_i = 0, _len = unprocessed.length; _i < _len; _i++) {
+        x = unprocessed[_i];
+        total += x;
+      }
+      return total;
+    };
+    trackUnprocessedFiles = function(sourceIndex, fileCount) {
+      var _ref2;
+      if ((_ref2 = unprocessed[sourceIndex]) == null) unprocessed[sourceIndex] = 0;
+      return unprocessed[sourceIndex] += fileCount;
+    };
+    trackCompleteFiles = function(sourceIndex, fileCount) {
+      unprocessed[sourceIndex] -= fileCount;
+      if (opts.join) {
+        if (helpers.compact(contents).length > 0 && remaining_files() === 0) {
+          return compileJoin();
+        }
+      }
+    };
     for (_i = 0, _len = sources.length; _i < _len; _i++) {
       source = sources[_i];
-      unprocessed[sources.indexOf(source)] = 1;
+      trackUnprocessedFiles(sources.indexOf(source), 1);
     }
     _results = [];
     for (_j = 0, _len2 = sources.length; _j < _len2; _j++) {
       source = sources[_j];
       base = path.join(source);
       compile = function(source, sourceIndex, topLevel) {
-        var remaining_files;
-        remaining_files = function() {
-          var total, x, _k, _len3;
-          total = 0;
-          for (_k = 0, _len3 = unprocessed.length; _k < _len3; _k++) {
-            x = unprocessed[_k];
-            total += x;
-          }
-          return total;
-        };
         return path.exists(source, function(exists) {
           if (topLevel && !exists && source.slice(-7) !== '.coffee') {
             return compile("" + source + ".coffee", sourceIndex, topLevel);
@@ -69,29 +81,26 @@
               return fs.readdir(source, function(err, files) {
                 var file, _k, _len3;
                 if (err) throw err;
-                unprocessed[sourceIndex] += files.length;
+                trackUnprocessedFiles(sourceIndex, files.length);
                 for (_k = 0, _len3 = files.length; _k < _len3; _k++) {
                   file = files[_k];
                   compile(path.join(source, file), sourceIndex);
                 }
-                return unprocessed[sourceIndex] -= 1;
+                return trackCompleteFiles(sourceIndex, 1);
               });
             } else if (topLevel || path.extname(source) === '.coffee') {
               fs.readFile(source, function(err, code) {
                 if (err) throw err;
-                unprocessed[sourceIndex] -= 1;
                 if (opts.join) {
                   contents[sourceIndex] = helpers.compact([contents[sourceIndex], code.toString()]).join('\n');
-                  if (helpers.compact(contents).length > 0 && remaining_files() === 0) {
-                    return compileJoin();
-                  }
                 } else {
-                  return compileScript(source, code.toString(), base);
+                  compileScript(source, code.toString(), base);
                 }
+                return trackCompleteFiles(sourceIndex, 1);
               });
               if (opts.watch && !opts.join) return watch(source, base);
             } else {
-              return unprocessed[sourceIndex] -= 1;
+              return trackCompleteFiles(sourceIndex, 1);
             }
           });
         });


### PR DESCRIPTION
Resolved an issue that could occur while compiling with the --join option which would cause the compiler to silently fail with no resulting output file.

While recursively traversing a source directory, if a directory was encountered containing either no .coffee files (ex. an .svn metadata directory) or where the last file processed in that directory was not a .coffee file, compileJoin() might never be called.

This issue was originally introduced by a (well-needed) optimization in commit dc272a680bdca83948c5.

In join mode, anytime the 'unprocessed' count is decremented, the remaining file count should be evaluated to determine if it is time to run compileJoin().  Previously, compileJoin() would only ever be called in one of the four possible terminating branches of this recursive asynchronous operation.
