### PR TITLE
--jsonast option (expose AST to third party devs in more useful form)

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -15,7 +15,7 @@
     return process.binding('stdio').writeError(line + '\n');
   };
   BANNER = 'Usage: coffee [options] path/to/script.coffee';
-  SWITCHES = [['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-o', '--output [DIR]', 'set the directory for compiled JavaScript'], ['-j', '--join [FILE]', 'concatenate the scripts before compiling'], ['-w', '--watch', 'watch scripts for changes, and recompile'], ['-p', '--print', 'print the compiled JavaScript to stdout'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-e', '--eval', 'compile a string from the command line'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-b', '--bare', 'compile without the top-level function wrapper'], ['-t', '--tokens', 'print the tokens that the lexer produces'], ['-n', '--nodes', 'print the parse tree that Jison produces'], ['--nodejs [ARGS]', 'pass options through to the "node" binary'], ['-v', '--version', 'display CoffeeScript version'], ['-h', '--help', 'display this help message']];
+  SWITCHES = [['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-o', '--output [DIR]', 'set the directory for compiled JavaScript'], ['-j', '--join [FILE]', 'concatenate the scripts before compiling'], ['-w', '--watch', 'watch scripts for changes, and recompile'], ['-p', '--print', 'print the compiled JavaScript to stdout'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-e', '--eval', 'compile a string from the command line'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-b', '--bare', 'compile without the top-level function wrapper'], ['-t', '--tokens', 'print the tokens that the lexer produces'], ['-n', '--nodes', 'print the parse tree that Jison produces'], ['--jsonast', 'print the parse tree that Jison produces as JSON'], ['--nodejs [ARGS]', 'pass options through to the "node" binary'], ['-v', '--version', 'display CoffeeScript version'], ['-h', '--help', 'display this help message']];
   opts = {};
   sources = [];
   contents = [];
@@ -124,6 +124,8 @@
         return printTokens(CoffeeScript.tokens(t.input));
       } else if (o.nodes) {
         return printLine(CoffeeScript.nodes(t.input).toString().trim());
+      } else if (o.jsonast) {
+        return printLine(CoffeeScript.nodes(t.input).toJson().trim());
       } else if (o.run) {
         return CoffeeScript.run(t.input, t.options);
       } else {

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -112,6 +112,14 @@
       });
       return tree;
     };
+    Base.prototype.toJson = function() {
+      var nodes;
+      nodes = [];
+      this.eachChild(function(node) {
+        return nodes.push(node);
+      });
+      return JSON.stringify(nodes, null, TAB);
+    };
     Base.prototype.eachChild = function(func) {
       var attr, child, _i, _j, _len, _len2, _ref2, _ref3;
       if (!this.children) return this;

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -39,6 +39,7 @@ SWITCHES = [
   ['-b', '--bare',            'compile without the top-level function wrapper']
   ['-t', '--tokens',          'print the tokens that the lexer produces']
   ['-n', '--nodes',           'print the parse tree that Jison produces']
+  [      '--jsonast',         'print the parse tree that Jison produces as JSON']
   [      '--nodejs [ARGS]',   'pass options through to the "node" binary']
   ['-v', '--version',         'display CoffeeScript version']
   ['-h', '--help',            'display this help message']
@@ -129,6 +130,7 @@ compileScript = (file, input, base) ->
     CoffeeScript.emit 'compile', task
     if      o.tokens      then printTokens CoffeeScript.tokens t.input
     else if o.nodes       then printLine CoffeeScript.nodes(t.input).toString().trim()
+    else if o.jsonast     then printLine CoffeeScript.nodes(t.input).toJson().trim()
     else if o.run         then CoffeeScript.run t.input, t.options
     else
       t.output = CoffeeScript.compile t.input, t.options

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -109,6 +109,13 @@ exports.Base = class Base
     @eachChild (node) -> tree += node.toString idt + TAB
     tree
 
+  # `toJson` representation of the node, for inspecting the parse tree.
+  # This is what `coffee --jsonast` prints out.
+  toJson: () ->
+    nodes = []
+    @eachChild (node) -> nodes.push(node)
+    return JSON.stringify(nodes, null, TAB)
+
   # Passes each child to a function, breaking when the function returns `false`.
   eachChild: (func) ->
     return this unless @children


### PR DESCRIPTION
I was hoping to have a --jsonast option added to the command line syntax.  The current output from --nodes is a bit difficult to manipulate for walking the AST in utilities like code visualizers, linters, translators, etc.

The current patch has the benefit of writing to JSON, but there might be a slightly better canonical form for the AST (i.e. still in JSON, but perhaps with the data structure flattened in some way).
