### PR TITLE
Extended --watch support

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -1,5 +1,6 @@
 (function() {
-  var BANNER, CoffeeScript, EventEmitter, SWITCHES, compileJoin, compileOptions, compileScript, compileScripts, compileStdio, contents, exec, forkNode, fs, helpers, lint, loadRequires, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, sources, spawn, usage, version, watch, writeJs, _ref;
+  var BANNER, CoffeeScript, EventEmitter, SWITCHES, compileJoin, compileOptions, compileScript, compileScripts, compileStdio, contents, exec, forkNode, fs, helpers, lint, loadRequires, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, rmOutput, sources, spawn, usage, version, watch, watching, writeJs, _ref;
+  var __hasProp = Object.prototype.hasOwnProperty;
   fs = require('fs');
   path = require('path');
   helpers = require('./helpers');
@@ -18,7 +19,8 @@
   SWITCHES = [['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-o', '--output [DIR]', 'set the directory for compiled JavaScript'], ['-j', '--join [FILE]', 'concatenate the scripts before compiling'], ['-w', '--watch', 'watch scripts for changes, and recompile'], ['-p', '--print', 'print the compiled JavaScript to stdout'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-e', '--eval', 'compile a string from the command line'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-b', '--bare', 'compile without the top-level function wrapper'], ['-t', '--tokens', 'print the tokens that the lexer produces'], ['-n', '--nodes', 'print the parse tree that Jison produces'], ['--nodejs [ARGS]', 'pass options through to the "node" binary'], ['-v', '--version', 'display CoffeeScript version'], ['-h', '--help', 'display this help message']];
   opts = {};
   sources = [];
-  contents = [];
+  watching = {};
+  contents = {};
   optionParser = null;
   exports.run = function() {
     parseOptions();
@@ -34,78 +36,37 @@
     process.ARGV = process.argv = process.argv.slice(0, 2).concat(opts.literals);
     process.argv[0] = 'coffee';
     process.execPath = require.main.filename;
-    return compileScripts();
+    compileScripts(sources, null, true);
+    if (opts.join) return compileJoin();
   };
-  compileScripts = function() {
-    var base, compile, remaining_files, source, trackCompleteFiles, trackUnprocessedFiles, unprocessed, _i, _j, _len, _len2, _results;
-    unprocessed = [];
-    remaining_files = function() {
-      var total, x, _i, _len;
-      total = 0;
-      for (_i = 0, _len = unprocessed.length; _i < _len; _i++) {
-        x = unprocessed[_i];
-        total += x;
-      }
-      return total;
-    };
-    trackUnprocessedFiles = function(sourceIndex, fileCount) {
-      var _ref2;
-      if ((_ref2 = unprocessed[sourceIndex]) == null) unprocessed[sourceIndex] = 0;
-      return unprocessed[sourceIndex] += fileCount;
-    };
-    trackCompleteFiles = function(sourceIndex, fileCount) {
-      unprocessed[sourceIndex] -= fileCount;
-      if (opts.join) {
-        if (helpers.compact(contents).length > 0 && remaining_files() === 0) {
-          return compileJoin();
-        }
-      }
-    };
+  compileScripts = function(sources, base, topLevel) {
+    var code, file, files, source, stats, _i, _j, _len, _len2, _results;
+    _results = [];
     for (_i = 0, _len = sources.length; _i < _len; _i++) {
       source = sources[_i];
-      trackUnprocessedFiles(sources.indexOf(source), 1);
-    }
-    _results = [];
-    for (_j = 0, _len2 = sources.length; _j < _len2; _j++) {
-      source = sources[_j];
-      base = path.join(source);
-      compile = function(source, sourceIndex, topLevel) {
-        return path.exists(source, function(exists) {
-          if (topLevel && !exists && source.slice(-7) !== '.coffee') {
-            return compile("" + source + ".coffee", sourceIndex, topLevel);
-          }
-          if (topLevel && !exists) throw new Error("File not found: " + source);
-          return fs.stat(source, function(err, stats) {
-            if (err) throw err;
-            if (stats.isDirectory()) {
-              return fs.readdir(source, function(err, files) {
-                var file, _k, _len3;
-                if (err) throw err;
-                trackUnprocessedFiles(sourceIndex, files.length);
-                for (_k = 0, _len3 = files.length; _k < _len3; _k++) {
-                  file = files[_k];
-                  compile(path.join(source, file), sourceIndex);
-                }
-                return trackCompleteFiles(sourceIndex, 1);
-              });
-            } else if (topLevel || path.extname(source) === '.coffee') {
-              fs.readFile(source, function(err, code) {
-                if (err) throw err;
-                if (opts.join) {
-                  contents[sourceIndex] = helpers.compact([contents[sourceIndex], code.toString()]).join('\n');
-                } else {
-                  compileScript(source, code.toString(), base);
-                }
-                return trackCompleteFiles(sourceIndex, 1);
-              });
-              if (opts.watch && !opts.join) return watch(source, base);
-            } else {
-              return trackCompleteFiles(sourceIndex, 1);
-            }
-          });
-        });
-      };
-      _results.push(compile(source, sources.indexOf(source), true));
+      if (base == null) base = path.join(source);
+      if (!(path.existsSync(source))) {
+        if (topLevel && path.extname(source) !== '.coffee') {
+          return compileScripts(["" + source + ".coffee"], base);
+        }
+        if (topLevel) throw new Error("File not found: " + source);
+      }
+      stats = fs.statSync(source);
+      if (stats.isDirectory()) {
+        files = fs.readdirSync(source);
+        for (_j = 0, _len2 = files.length; _j < _len2; _j++) {
+          file = files[_j];
+          compileScripts([path.join(source, file)], base);
+        }
+      } else if (topLevel || path.extname(source) === '.coffee') {
+        code = fs.readFileSync(source);
+        if (opts.join) {
+          contents[source] = code.toString();
+        } else {
+          compileScript(source, code.toString(), base);
+        }
+      }
+      _results.push(opts.watch ? watch(source, base) : void 0);
     }
     return _results;
   };
@@ -157,9 +118,18 @@
     });
   };
   compileJoin = function() {
-    var code;
-    code = contents.join('\n');
-    return compileScript(opts.join, code, opts.join);
+    var code, content, source;
+    code = ((function() {
+      var _results;
+      _results = [];
+      for (source in contents) {
+        if (!__hasProp.call(contents, source)) continue;
+        content = contents[source];
+        _results.push(content);
+      }
+      return _results;
+    })()).join('\n');
+    if (code.length) return compileScript(opts.join, code, opts.join);
   };
   loadRequires = function() {
     var realFilename, req, _i, _len, _ref2;
@@ -173,18 +143,86 @@
     return module.filename = realFilename;
   };
   watch = function(source, base) {
-    return fs.watchFile(source, {
+    if (watching[source] != null) return;
+    fs.watchFile(source, {
       persistent: true,
       interval: 500
     }, function(curr, prev) {
+      var file, files, isWatched, lWatching, newSources, pathed, recompile, _i, _len;
       if (curr.size === prev.size && curr.mtime.getTime() === prev.mtime.getTime()) {
+        return;
+      }
+      if (curr.isDirectory()) {
+        recompile = false;
+        files = fs.readdirSync(source);
+        lWatching = {};
+        for (file in watching) {
+          isWatched = watching[file];
+          if (path.dirname(file) === source) lWatching[file] = true;
+        }
+        newSources = [];
+        for (_i = 0, _len = files.length; _i < _len; _i++) {
+          file = files[_i];
+          pathed = path.join(source, file);
+          if (!lWatching[pathed]) {
+            newSources.push(pathed);
+          } else {
+            delete lWatching[pathed];
+          }
+        }
+        if (newSources.length) recompile = true;
+        for (file in lWatching) {
+          if (!__hasProp.call(lWatching, file)) continue;
+          isWatched = lWatching[file];
+          recompile = true;
+          rmOutput(file, base);
+        }
+        if (recompile) {
+          compileScripts(newSources, base);
+          if (opts.join) compileJoin();
+        }
         return;
       }
       return fs.readFile(source, function(err, code) {
         if (err) throw err;
-        return compileScript(source, code.toString(), base);
+        if (opts.join) {
+          contents[source] = code.toString();
+          return compileJoin();
+        } else {
+          return compileScript(source, code.toString(), base);
+        }
       });
     });
+    return watching[source] = true;
+  };
+  rmOutput = function(source, base) {
+    var baseDir, dir, file, filename, fullPath, isWatched, srcDir;
+    delete contents[source];
+    delete watching[source];
+    fs.unwatchFile(source);
+    for (file in watching) {
+      if (!__hasProp.call(watching, file)) continue;
+      isWatched = watching[file];
+      if (path.dirname(file) === source) rmOutput(file, base);
+    }
+    if (opts.join) return;
+    filename = path.basename(source, path.extname(source));
+    srcDir = path.dirname(source);
+    baseDir = base === '.' ? srcDir : srcDir.substring(base.length);
+    dir = opts.output ? path.join(opts.output, baseDir) : srcDir;
+    fullPath = path.join(dir, filename);
+    if (path.existsSync(fullPath)) {
+      try {
+        fs.rmdirSync(fullPath);
+        return printLine("" + ((new Date).toLocaleTimeString()) + " - removed " + fullPath);
+      } catch (x) {
+        return printWarn("" + ((new Date).toLocaleTimeString()) + " - could not remove " + fullPath + "        " + x);
+      }
+    } else {
+      fullPath += '.js';
+      fs.unlinkSync(fullPath);
+      return printLine("" + ((new Date).toLocaleTimeString()) + " - removed " + fullPath);
+    }
   };
   writeJs = function(source, js, base) {
     var baseDir, compile, dir, filename, jsPath, srcDir;
@@ -199,7 +237,7 @@
         if (err) {
           return printLine(err.message);
         } else if (opts.compile && opts.watch) {
-          return console.log("" + ((new Date).toLocaleTimeString()) + " - compiled " + source);
+          return printLine("" + ((new Date).toLocaleTimeString()) + " - compiled " + source);
         }
       });
     };


### PR DESCRIPTION
The following capabilities were added to the --watch option:
- new coffee scripts are discovered and compiled
- removed coffee scripts have their corresponding javascript files removed
- new directories are watched 
- removed directories are removed from the output directory 
- the --join option now works with --watch

Note:  The compileScripts function now uses synchronous file operations. This reduces and simplifies the code. And makes the function usable for --watch updates.

I have only sent a few pull requests so apologies if this isn't done correctly :)
