### PR TITLE
Add Regexp operator =~

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -1,5 +1,5 @@
 (function() {
-  var ASSIGNED, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARE, COMPOUND_ASSIGN, HEREDOC, HEREDOC_ILLEGAL, HEREDOC_INDENT, HEREGEX, HEREGEX_OMIT, IDENTIFIER, INDEXABLE, JSTOKEN, JS_FORBIDDEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, LOGIC, Lexer, MATH, MULTILINER, MULTI_DENT, NOT_REGEX, NOT_SPACED_REGEX, NO_NEWLINE, NUMBER, OPERATOR, REGEX, RELATION, RESERVED, Rewriter, SHIFT, SIMPLESTR, TRAILING_SPACES, UNARY, WHITESPACE, compact, count, key, last, starts, _ref;
+  var ASSIGNED, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARE, COMPOUND_ASSIGN, HEREDOC, HEREDOC_ILLEGAL, HEREDOC_INDENT, HEREGEX, HEREGEX_OMIT, IDENTIFIER, INDEXABLE, JSTOKEN, JS_FORBIDDEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, LOGIC, Lexer, MATH, MULTILINER, MULTI_DENT, NOT_REGEX, NOT_SPACED_REGEX, NO_NEWLINE, NUMBER, OPERATOR, REGEX, REGEX_MATCH, RELATION, RESERVED, Rewriter, SHIFT, SIMPLESTR, TRAILING_SPACES, UNARY, WHITESPACE, compact, count, key, last, starts, _ref;
   var __hasProp = Object.prototype.hasOwnProperty, __indexOf = Array.prototype.indexOf || function(item) {
     for (var i = 0, l = this.length; i < l; i++) {
       if (__hasProp.call(this, i) && this[i] === item) return i;
@@ -31,7 +31,7 @@
       return (new Rewriter).rewrite(this.tokens);
     };
     Lexer.prototype.identifierToken = function() {
-      var colon, forcedIdentifier, id, input, match, prev, tag, _ref2, _ref3;
+      var colon, forcedIdentifier, id, index, input, match, matches, prev, submatch, tag, _ref2, _ref3;
       if (!(match = IDENTIFIER.exec(this.chunk))) return 0;
       input = match[0], id = match[1], colon = match[2];
       if (id === 'own' && this.tag() === 'FOR') {
@@ -80,6 +80,7 @@
               return 'UNARY';
             case '==':
             case '!=':
+            case '=~':
               return 'COMPARE';
             case '&&':
             case '||':
@@ -98,7 +99,17 @@
           }
         })();
       }
-      this.token(tag, id);
+      if (matches = id.match(REGEX_MATCH)) {
+        this.token('IDENTIFIER', '__matches');
+        if (matches[1] === '&' || (submatch = matches[1].match(/([1-9])/))) {
+          index = matches[1] === '&' ? 0 : submatch[1];
+          this.token('INDEX_START', '[');
+          this.token('NUMBER', index);
+          this.token(']', ']');
+        }
+      } else {
+        this.token(tag, id);
+      }
       if (colon) this.token(':', ':');
       return input.length;
     };
@@ -540,13 +551,14 @@
     return _results;
   })();
   COFFEE_KEYWORDS = COFFEE_KEYWORDS.concat(COFFEE_ALIASES);
-  RESERVED = ['case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum', 'export', 'import', 'native', '__hasProp', '__extends', '__slice', '__bind', '__indexOf'];
+  RESERVED = ['case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum', 'export', 'import', 'native', '__hasProp', '__extends', '__slice', '__bind', '__indexOf', '__matches'];
   JS_FORBIDDEN = JS_KEYWORDS.concat(RESERVED);
   exports.RESERVED = RESERVED.concat(JS_KEYWORDS).concat(COFFEE_KEYWORDS);
-  IDENTIFIER = /^([$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*)([^\n\S]*:(?!:))?/;
+  IDENTIFIER = /^([$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*|\\[&~1-9])([^\n\S]*:(?!:))?/;
+  REGEX_MATCH = /^\\(&|~|[1-9])$/;
   NUMBER = /^0x[\da-f]+|^\d*\.?\d+(?:e[+-]?\d+)?/i;
   HEREDOC = /^("""|''')([\s\S]*?)(?:\n[^\n\S]*)?\1/;
-  OPERATOR = /^(?:[-=]>|[-+*\/%<>&|^!?=]=|>>>=?|([-+:])\1|([&|<>])\2=?|\?\.|\.{2,3})/;
+  OPERATOR = /^(?:[-=]>|[-+*\/%<>&|^!?=]=|>>>=?|([-+:])\1|([&|<>])\2=?|=~|\?\.|\.{2,3})/;
   WHITESPACE = /^[^\n\S]+/;
   COMMENT = /^###([^#][\s\S]*?)(?:###[^\n\S]*|(?:###)?$)|^(?:\s*#(?!##[^#]).*)+/;
   CODE = /^[-=]>/;
@@ -567,7 +579,7 @@
   UNARY = ['!', '~', 'NEW', 'TYPEOF', 'DELETE', 'DO'];
   LOGIC = ['&&', '||', '&', '|', '^'];
   SHIFT = ['<<', '>>', '>>>'];
-  COMPARE = ['==', '!=', '<', '>', '<=', '>='];
+  COMPARE = ['==', '!=', '<', '>', '<=', '>=', '=~'];
   MATH = ['*', '/', '%'];
   RELATION = ['IN', 'OF', 'INSTANCEOF'];
   BOOL = ['TRUE', 'FALSE', 'NULL', 'UNDEFINED'];

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1,5 +1,5 @@
 (function() {
-  var Access, Arr, Assign, Base, Block, Call, Class, Closure, Code, Comment, Existence, Extends, For, IDENTIFIER, IDENTIFIER_STR, IS_STRING, If, In, Index, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, Literal, METHOD_DEF, NEGATE, NO, Obj, Op, Param, Parens, Push, RESERVED, Range, Return, SIMPLENUM, Scope, Slice, Splat, Switch, TAB, THIS, Throw, Try, UTILITIES, Value, While, YES, compact, del, ends, extend, flatten, last, merge, multident, starts, unfoldSoak, utility, _ref;
+  var Access, Arr, Assign, Base, Block, Call, Class, Closure, Code, Comment, Existence, Extends, For, IDENTIFIER, IDENTIFIER_STR, IS_STRING, If, In, Index, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, Literal, METHOD_DEF, NEGATE, NO, Obj, Op, Param, Parens, Push, RESERVED, Range, RegexMatch, Return, SIMPLENUM, Scope, Slice, Splat, Switch, TAB, THIS, Throw, Try, UTILITIES, Value, While, YES, compact, del, ends, extend, flatten, last, merge, multident, starts, unfoldSoak, utility, _ref;
   var __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
     for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }
     function ctor() { this.constructor = child; }
@@ -1469,6 +1469,7 @@
     function Op(op, first, second, flip) {
       var call;
       if (op === 'in') return new In(first, second);
+      if (op === '=~') return new RegexMatch(first, second);
       if (op === 'do') {
         call = new Call(first, first.params || []);
         call["do"] = true;
@@ -1594,6 +1595,20 @@
       return Op.__super__.toString.call(this, idt, this.constructor.name + ' ' + this.operator);
     };
     return Op;
+  })();
+  exports.RegexMatch = RegexMatch = (function() {
+    __extends(RegexMatch, Base);
+    function RegexMatch(data, pattern) {
+      this.data = data;
+      this.pattern = pattern;
+    }
+    RegexMatch.prototype.compileNode = function(o) {
+      var data, pattern;
+      data = this.data.compile(o, LEVEL_ACCESS);
+      pattern = this.pattern.compile(o, LEVEL_PAREN);
+      return "" + (utility('matches')) + " = " + data + ".match(" + pattern + ")";
+    };
+    return RegexMatch;
   })();
   exports.In = In = (function() {
     __extends(In, Base);
@@ -2099,6 +2114,9 @@
     },
     slice: function() {
       return 'Array.prototype.slice';
+    },
+    matches: function() {
+      return 'null';
     }
   };
   LEVEL_TOP = 1;

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -116,13 +116,21 @@ exports.Lexer = class Lexer
       id  = COFFEE_ALIAS_MAP[id] if id in COFFEE_ALIASES
       tag = switch id
         when '!'                                  then 'UNARY'
-        when '==', '!='                           then 'COMPARE'
+        when '==', '!=', '=~'                     then 'COMPARE'
         when '&&', '||'                           then 'LOGIC'
         when 'true', 'false', 'null', 'undefined' then 'BOOL'
         when 'break', 'continue', 'debugger'      then 'STATEMENT'
         else  tag
 
-    @token tag, id
+    if matches = id.match REGEX_MATCH
+      @token 'IDENTIFIER', '__matches'
+      if matches[1] == '&' || submatch = matches[1].match /([1-9])/
+        index = if matches[1] == '&' then 0 else submatch[1]
+        @token 'INDEX_START', '['
+        @token 'NUMBER', index
+        @token ']', ']'
+    else
+      @token tag, id
     @token ':', ':' if colon
     input.length
 
@@ -538,7 +546,7 @@ COFFEE_KEYWORDS = COFFEE_KEYWORDS.concat COFFEE_ALIASES
 RESERVED = [
   'case', 'default', 'function', 'var', 'void', 'with'
   'const', 'let', 'enum', 'export', 'import', 'native'
-  '__hasProp', '__extends', '__slice', '__bind', '__indexOf'
+  '__hasProp', '__extends', '__slice', '__bind', '__indexOf', '__matches'
 ]
 
 # The superset of both JavaScript keywords and reserved words, none of which may
@@ -549,9 +557,11 @@ exports.RESERVED = RESERVED.concat(JS_KEYWORDS).concat(COFFEE_KEYWORDS)
 
 # Token matching regexes.
 IDENTIFIER = /// ^
-  ( [$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]* )
+  ( [$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]* | \\[&~1-9] )
   ( [^\n\S]* : (?!:) )?  # Is this a property name?
 ///
+
+REGEX_MATCH = ///^ \\(&|~|[1-9]) $///
 
 NUMBER     = ///
   ^ 0x[\da-f]+ |                              # hex
@@ -566,6 +576,7 @@ OPERATOR   = /// ^ (
    | >>>=?             # zero-fill right shift
    | ([-+:])\1         # doubles
    | ([&|<>])\2=?      # logic / shift
+   | =~                # regexp
    | \?\.              # soak access
    | \.{2,3}           # range or splat
 ) ///
@@ -635,7 +646,7 @@ LOGIC   = ['&&', '||', '&', '|', '^']
 SHIFT   = ['<<', '>>', '>>>']
 
 # Comparison tokens.
-COMPARE = ['==', '!=', '<', '>', '<=', '>=']
+COMPARE = ['==', '!=', '<', '>', '<=', '>=', '=~']
 
 # Mathematical tokens.
 MATH    = ['*', '/', '%']

--- a/test/regexps.coffee
+++ b/test/regexps.coffee
@@ -49,3 +49,12 @@ test "a heregex will ignore whitespace and comments", ->
 
 test "an empty heregex will compile to an empty, non-capturing group", ->
   eq /(?:)/ + '', ///  /// + ''
+
+test "=~ operator", ->
+  m = '3-4' =~ /^\d+-(\d+)$/
+  ok \& is '3-4'
+  ok \1 is '4'
+  ok m is \~
+  ok m[0] is \~[0]
+  ok m[1] is \1
+


### PR DESCRIPTION
Add regexp operator =~
For $1 use in grammar.coffee and is valid variable so I decide use \1 instead.
Then the varibables are
__matches(reserved): __matches has the same scope as __bind, it initialize with null and will store the return of method .match
~ = __matches
& = __matches[0]
\1..9 = __matches[1..9]

Test passed

<pre>
  m = '3-4' =~ /^\d+-(\d+)$/
  ok \& is '3-4'
  ok \1 is '4'
  ok m is \~
  ok m[0] is \~[0]
  ok m[1] is \1
</pre>
