### PR TITLE
regex =~ and magic identifiers in 2 commits

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -1,5 +1,5 @@
 (function() {
-  var ASSIGNED, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARE, COMPOUND_ASSIGN, HEREDOC, HEREDOC_ILLEGAL, HEREDOC_INDENT, HEREGEX, HEREGEX_OMIT, IDENTIFIER, INDEXABLE, JSTOKEN, JS_FORBIDDEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, LOGIC, Lexer, MATH, MULTILINER, MULTI_DENT, NOT_REGEX, NOT_SPACED_REGEX, NO_NEWLINE, NUMBER, OPERATOR, REGEX, RELATION, RESERVED, Rewriter, SHIFT, SIMPLESTR, TRAILING_SPACES, UNARY, WHITESPACE, compact, count, key, last, starts, _ref;
+  var ASSIGNED, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARE, COMPOUND_ASSIGN, HEREDOC, HEREDOC_ILLEGAL, HEREDOC_INDENT, HEREGEX, HEREGEX_OMIT, IDENTIFIER, INDEXABLE, JSTOKEN, JS_FORBIDDEN, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, LOGIC, Lexer, MATH, MULTILINER, MULTI_DENT, NOT_REGEX, NOT_SPACED_REGEX, NO_NEWLINE, NUMBER, OPERATOR, REGEX, REGEX_MATCH, RELATION, RESERVED, Rewriter, SHIFT, SIMPLESTR, TRAILING_SPACES, UNARY, WHITESPACE, compact, count, key, last, starts, _ref;
   var __hasProp = Object.prototype.hasOwnProperty, __indexOf = Array.prototype.indexOf || function(item) {
     for (var i = 0, l = this.length; i < l; i++) {
       if (__hasProp.call(this, i) && this[i] === item) return i;
@@ -31,7 +31,7 @@
       return (new Rewriter).rewrite(this.tokens);
     };
     Lexer.prototype.identifierToken = function() {
-      var colon, forcedIdentifier, id, input, match, prev, tag, _ref2, _ref3;
+      var colon, forcedIdentifier, id, index, input, match, matches, prev, submatch, tag, _ref2, _ref3;
       if (!(match = IDENTIFIER.exec(this.chunk))) return 0;
       input = match[0], id = match[1], colon = match[2];
       if (id === 'own' && this.tag() === 'FOR') {
@@ -99,7 +99,17 @@
           }
         })();
       }
-      this.token(tag, id);
+      if (matches = id.match(REGEX_MATCH)) {
+        this.token('IDENTIFIER', '__matches');
+        if (matches[1] === '&' || (submatch = matches[1].match(/([1-9])/))) {
+          index = matches[1] === '&' ? 0 : submatch[1];
+          this.token('INDEX_START', '[');
+          this.token('NUMBER', index);
+          this.token(']', ']');
+        }
+      } else {
+        this.token(tag, id);
+      }
       if (colon) this.token(':', ':');
       return input.length;
     };
@@ -541,10 +551,11 @@
     return _results;
   })();
   COFFEE_KEYWORDS = COFFEE_KEYWORDS.concat(COFFEE_ALIASES);
-  RESERVED = ['case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum', 'export', 'import', 'native', '__hasProp', '__extends', '__slice', '__bind', '__indexOf'];
+  RESERVED = ['case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum', 'export', 'import', 'native', '__hasProp', '__extends', '__slice', '__bind', '__indexOf', '__matches'];
   JS_FORBIDDEN = JS_KEYWORDS.concat(RESERVED);
   exports.RESERVED = RESERVED.concat(JS_KEYWORDS).concat(COFFEE_KEYWORDS);
-  IDENTIFIER = /^([$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*)([^\n\S]*:(?!:))?/;
+  IDENTIFIER = /^([$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*|\\[&~1-9])([^\n\S]*:(?!:))?/;
+  REGEX_MATCH = /^\\(&|~|[1-9])$/;
   NUMBER = /^0x[\da-f]+|^\d*\.?\d+(?:e[+-]?\d+)?/i;
   HEREDOC = /^("""|''')([\s\S]*?)(?:\n[^\n\S]*)?\1/;
   OPERATOR = /^(?:[-=]>|[-+*\/%<>&|^!?=]=|>>>=?|([-+:])\1|([&|<>])\2=?|=~|\?\.|\.{2,3})/;

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1606,7 +1606,7 @@
       var data, pattern;
       data = this.data.compile(o, LEVEL_ACCESS);
       pattern = this.pattern.compile(o, LEVEL_PAREN);
-      return "" + data + ".match(" + pattern + ")";
+      return "(" + (utility('matches')) + " = " + data + ".match(" + pattern + "))";
     };
     return RegexMatch;
   })();
@@ -2114,6 +2114,9 @@
     },
     slice: function() {
       return 'Array.prototype.slice';
+    },
+    matches: function() {
+      return 'null';
     }
   };
   LEVEL_TOP = 1;

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -122,7 +122,15 @@ exports.Lexer = class Lexer
         when 'break', 'continue', 'debugger'      then 'STATEMENT'
         else  tag
 
-    @token tag, id
+    if matches = id.match REGEX_MATCH
+      @token 'IDENTIFIER', '__matches'
+      if matches[1] == '&' || submatch = matches[1].match /([1-9])/
+        index = if matches[1] == '&' then 0 else submatch[1]
+        @token 'INDEX_START', '['
+        @token 'NUMBER', index
+        @token ']', ']'
+    else
+      @token tag, id
     @token ':', ':' if colon
     input.length
 
@@ -538,7 +546,7 @@ COFFEE_KEYWORDS = COFFEE_KEYWORDS.concat COFFEE_ALIASES
 RESERVED = [
   'case', 'default', 'function', 'var', 'void', 'with'
   'const', 'let', 'enum', 'export', 'import', 'native'
-  '__hasProp', '__extends', '__slice', '__bind', '__indexOf'
+  '__hasProp', '__extends', '__slice', '__bind', '__indexOf', '__matches'
 ]
 
 # The superset of both JavaScript keywords and reserved words, none of which may
@@ -549,9 +557,11 @@ exports.RESERVED = RESERVED.concat(JS_KEYWORDS).concat(COFFEE_KEYWORDS)
 
 # Token matching regexes.
 IDENTIFIER = /// ^
-  ( [$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]* )
+  ( [$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]* | \\[&~1-9] )
   ( [^\n\S]* : (?!:) )?  # Is this a property name?
 ///
+
+REGEX_MATCH = ///^ \\(&|~|[1-9]) $///
 
 NUMBER     = ///
   ^ 0x[\da-f]+ |                              # hex

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1378,7 +1378,9 @@ exports.RegexMatch = class RegexMatch extends Base
     data    = @data.compile o, LEVEL_ACCESS
     pattern = @pattern.compile o, LEVEL_PAREN
 
-    "#{data}.match(#{pattern})"
+    # use (...) wrap the code to ensure the match is a whole part
+    # without (...) the 'unless' will broke the code
+    "(#{utility('matches')} = #{data}.match(#{pattern}))"
 
 #### In
 exports.In = class In extends Base
@@ -1757,6 +1759,7 @@ exports.If = class If extends Base
   unfoldSoak: ->
     @soak and this
 
+
 # Faux-Nodes
 # ----------
 # Faux-nodes are never created by the grammar, but are used during code
@@ -1841,6 +1844,8 @@ UTILITIES =
   # Shortcuts to speed up the lookup time for native functions.
   hasProp: -> 'Object.prototype.hasOwnProperty'
   slice  : -> 'Array.prototype.slice'
+
+  matches: -> 'null'
 
 # Levels indicate a node's position in the AST. Useful for knowing if
 # parens are necessary or superfluous.

--- a/test/regexps.coffee
+++ b/test/regexps.coffee
@@ -56,3 +56,11 @@ test "=~ operator", ->
   ok m[1] is '4'
   unless 'abc' =~ /\d+/
     ok true
+
+test "=~ with magic variables", ->
+  m = '3-4' =~ /^\d+-(\d+)$/
+  ok \& is '3-4'
+  ok \1 is '4'
+  ok m is \~
+  ok m[0] is \~[0]
+  ok m[1] is \1


### PR DESCRIPTION
I've splitted the patch in two commits.
The magic identifiers base on operator =~, so cannot split them in two pull requests

Add regexp operator =~
For $1 use in grammar.coffee and is valid variable so I decide use \1 instead.
Then the varibables are
__matches(reserved): __matches has the same scope as __bind, it initialize with null and will store the return of method .match
~ = __matches
\& = __matches[0]
\1..9 = __matches[1..9]

Test passed

<pre>
  m = '3-4' =~ /^\d+-(\d+)$/
  ok \& is '3-4'
  ok \1 is '4'
  ok m is \~
  ok m[0] is \~[0]
  ok m[1] is \1
</pre>


<pre>
do ->
  if '3-4' =~ /^\d+-(\d+)$/
    console.info \~, \&, \1

  unless 'abc' =~ /\d+/
    console.info true
</pre>

will translate to

<pre>
var __matches = null;
(function() {
  if ((__matches = '3-4'.match(/^\d+-(\d+)$/))) {
    console.info(__matches, __matches[0], __matches[1]);
  }
  if (!(__matches = 'abc'.match(/\d+/))) return console.info(true);
})();
</pre>
