### PR TITLE
Making underscore.coffee export CommonJS as the orig underscore lib does

### DIFF
--- a/examples/underscore.coffee
+++ b/examples/underscore.coffee
@@ -461,8 +461,6 @@ _.isEqual = (a, b) ->
   # Different types?
   atype = typeof(a); btype = typeof(b)
   return false if atype isnt btype
-  # Basic equality test (watch out for coercions).
-  return true if `a == b`
   # One is falsy and the other truthy.
   return false if (!a and b) or (a and !b)
   # One of them implements an `isEqual()`?


### PR DESCRIPTION
Hey, 

It was always adding to the root object whereas underscore only does it if modules does not exist.
I matched what underscore does in coffeescript.

Tom 
