### PR TITLE
Bump node dependency from 0.2.5 to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url":        "http://github.com/jashkenas/coffee-script/raw/master/LICENSE"
   }],
   "engines":      {
-    "node":       ">=0.2.5"
+    "node":       ">=0.4.0"
   },
   "directories" : {
     "lib" : "./lib/coffee-script"


### PR DESCRIPTION
package.json has long said

```
"engines":      {
  "node":       ">=0.2.5"
},
```

but `repl.coffee` has a `require 'vm'` in it; the vm module didn't exist in 0.2.x, so CoffeeScript has actually required a more recent version for a while (for the REPL, anyway). At any rate, at this point I don't think there's any reason to accomodate versions prior to 0.4.0. Agreed?
