### PR TITLE
Command: Support for non-standard file extensions

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -188,7 +188,7 @@
   };
   writeJs = function(source, js, base) {
     var baseDir, compile, dir, filename, jsPath, srcDir;
-		filename = path.basename(source).replace(/(\.coffee\b|\.[^.]$|$)/, '.js');
+		filename = path.basename(source).replace(/(\.coffee\b|\.[^.]*$|$)/, '.js');
     srcDir = path.dirname(source);
     baseDir = base === '.' ? srcDir : srcDir.substring(base.length);
     dir = opts.output ? path.join(opts.output, baseDir) : srcDir;


### PR DESCRIPTION
I would expect

```
coffee -c myfile.coffee.template
```

to compile `myfile.coffee.template` into a file named `myfile.js.template`. Currently, it yields `myfile.coffee.js` which is rather pointless. As an alternative, I suppose, one could also let the user specify the output filename.
