### PR TITLE
split out Usage section

### DIFF
--- a/documentation/index.html.erb
+++ b/documentation/index.html.erb
@@ -44,7 +44,8 @@
       </div>
       <div class="contents menu">
         <a href="#overview">Overview</a>
-        <a href="#installation">Installation and Usage</a>
+        <a href="#installation">Installation</a>
+        <a href="#usage">Usage</a>
         <a href="#language">Language Reference</a>
         <a href="#literals">Literals: Functions, Objects and Arrays</a>
         <a href="#lexical_scope">Lexical Scoping and Variable Safety</a>
@@ -145,7 +146,7 @@
 
     <h2>
       <span id="installation" class="bookmark"></span>
-      Installation and Usage
+      Installation
     </h2>
 
     <p>
@@ -193,6 +194,12 @@ sudo bin/cake install</pre>
       just like to experiment, you can try the 
       <a href="https://github.com/alisey/CoffeeScript-Compiler-for-Windows">CoffeeScript Compiler For Windows</a>.
     </p>
+
+
+    <h2>
+      <span id="usage" class="bookmark"></span>
+      Usage
+    </h2>
 
     <p>
       Once installed, you should have access to the <tt>coffee</tt> command,


### PR DESCRIPTION
Please see 97de3a59, which splits out a Usage section in the docs.  Right now the "Installation and Usage" section is a bit long, especially considering most folks only need to read about Installation once, but they'll often come back for Usage.

I was not able to run "rake doc" to verify the fix, as my Ruby install is kind of broken.

The first two commits in the pull request should be ignored.  I don't know how to remove these via Github.
