### PR TITLE
Add a [Link] button to the "Try CoffeeScript" interface

### DIFF
--- a/documentation/css/docs.css
+++ b/documentation/css/docs.css
@@ -264,6 +264,10 @@ div.code {
           width: 40px;
           text-transform: none;
         }
+          .navigation .code a.minibutton.permalink {
+            top: 38px;
+            display: block;
+          }
 
 .bookmark {
   display: block;

--- a/documentation/index.html.erb
+++ b/documentation/index.html.erb
@@ -84,7 +84,7 @@
           </div>
           <div id="repl_results_wrap"><pre id="repl_results"></pre></div>
           <div class="minibutton dark run" title="Ctrl-Enter">Run</div>
-          <a class="minibutton permalink" id="repl_permalink" style="display: block; top: 38px;">Link</a>
+          <a class="minibutton permalink" id="repl_permalink">Link</a>
           <br class="clear" />
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
           </div>
           <div id="repl_results_wrap"><pre id="repl_results"></pre></div>
           <div class="minibutton dark run" title="Ctrl-Enter">Run</div>
-          <a class="minibutton permalink" id="repl_permalink" style="display: block; top: 38px;">Link</a>
+          <a class="minibutton permalink" id="repl_permalink">Link</a>
           <br class="clear" />
         </div>
       </div>


### PR DESCRIPTION
(Replacing #1628.) This adds a button to the "Try CoffeeScript" interface which is a permalink to the current source code. [Here's an example on my fork](http://jeremybanks.github.com/coffee-script/#try_src:frame%20%3D%20%24%28%22%3Cdiv%20%2F%3E%22%29%0A%0Aframe.text%20%22Making%20API%20request...%22%0Aframe.animate%20%28opacity%3A%200.8%2C%20bottom%3A%200%29%2C%20300%0A%0AapiUrl%20%3D%20%22https%3A%2F%2Fapi.github.com%2Frepos%2Fjashkenas%2Fcoffee-script%2Fpulls%2F1711%3Fcallback%3D%3F%22%0A%0AjQuery.ajax%0A%20%20%20%20url%3A%20apiUrl%0A%20%20%20%20dataType%3A%20%22jsonp%22%0A%20%20%20%20async%3A%20%22async%22%0A%20%20%20%20success%3A%20%28response%29%20-%3E%0A%20%20%20%20%20%20%20%20comments%20%3D%20response.data.comments%0A%20%20%20%20%20%20%20%20frame.animate%20%28opacity%3A%200.0%2C%20right%3A%20%22%2B%3D4em%22%2C%20left%3A%20%22-%3D4em%22%29%2C%20200%0A%20%20%20%20%20%20%20%20frame.queue%20-%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20frame.text%20%22This%20pull%20requests%20has%20%23%7Bcomments%7D%20comments.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20frame.dequeue%28%29%0A%20%20%20%20%20%20%20%20frame.animate%20%28opacity%3A%200.96%2C%20bottom%3A%20%22100px%22%29%2C%20300%0A%20%20%20%20%20%20%20%20frame.animate%20%28left%3A%20%22%2B%3D8em%22%2C%20right%3A%20%22-%3D8em%22%29%2C%205000%0A%20%20%20%20%20%20%20%20frame.animate%20%28opacity%3A%200%2C%20bottom%3A%20%22-1em%22%29%2C%20300%0A%20%20%20%20%20%20%20%20frame.animate%20%28left%3A%20%225em%22%2C%20right%3A%20%225em%22%29%2C%200%0A%20%20%20%20error%3A%20-%3E%0A%20%20%20%20%20%20%20%20frame.text%20%22API%20requst%20failed.%22%0A%20%20%20%20%20%20%20%20frame.animate%20%28opacity%3A%200%29%2C%205000%0A%0Aframe.css%0A%20%20%20%20position%3A%20%22fixed%22%0A%20%20%20%20bottom%3A%20%22-1em%22%0A%20%20%20%20right%3A%20%225em%22%0A%20%20%20%20left%3A%20%225em%22%0A%20%20%20%20textAlign%3A%20%22center%22%0A%20%20%20%20cursor%3A%20%22pointer%22%0A%20%20%20%20opacity%3A%200%0A%20%20%20%20padding%3A%20%22.5em%20.3em%22%0A%20%20%20%20background%3A%20%22%23F8F8F8%22%0A%20%20%20%20zIndex%3A%201000%0A%20%20%20%20border%3A%20%221px%20solid%20%23000%22%0A%20%20%20%20boxShadow%3A%20%220.5px%200.5px%203px%20%23444%22%0A%20%20%20%20fontSize%3A%20%221.7em%22%0A%0Aframe.appendTo%28%22body%22%29).
