### PR TITLE
add Jison line numbers to nodes

### DIFF
--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -36,7 +36,7 @@ o = (patternString, action, options) ->
   action = if match = unwrap.exec action then match[1] else "(#{action}())"
   action = action.replace /\bnew /g, '$&yy.'
   action = action.replace /\b(?:Block\.wrap|extend)\b/g, 'yy.$&'
-  [patternString, "$$ = #{action};", options]
+  [patternString, "$$ = (function(){ var _ = #{action}; _.lineno = yylineno; return _; })()", options]
 
 # Grammatical Rules
 # -----------------


### PR DESCRIPTION
This is a patch that adds JISON line numbers to the node objects.  They can be exported with third party utilities that reference CoffeeScript.nodes.  Example use cases:
1. Linters
2. Code analyzers/visualizers.
3. Editor plugins.
4. Compiler troubleshooting.
