### PR TITLE
Using console.log and console.error in command.coffee (#1798)

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -1,5 +1,5 @@
 (function() {
-  var BANNER, CoffeeScript, EventEmitter, SWITCHES, compileJoin, compileOptions, compileScript, compileScripts, compileStdio, contents, exec, forkNode, fs, helpers, lint, loadRequires, optionParser, optparse, opts, parseOptions, path, printLine, printTokens, printWarn, sources, spawn, usage, version, watch, writeJs, _ref;
+  var BANNER, CoffeeScript, EventEmitter, SWITCHES, compileJoin, compileOptions, compileScript, compileScripts, compileStdio, contents, exec, forkNode, fs, helpers, lint, loadRequires, optionParser, optparse, opts, parseOptions, path, printTokens, sources, spawn, usage, version, watch, writeJs, _ref;
 
   fs = require('fs');
 
@@ -16,14 +16,6 @@
   EventEmitter = require('events').EventEmitter;
 
   helpers.extend(CoffeeScript, new EventEmitter);
-
-  printLine = function(line) {
-    return process.stdout.write(line + '\n');
-  };
-
-  printWarn = function(line) {
-    return process.binding('stdio').writeError(line + '\n');
-  };
 
   BANNER = 'Usage: coffee [options] path/to/script.coffee\n\nIf called without options, `coffee` will run your script.';
 
@@ -142,14 +134,14 @@
       if (o.tokens) {
         return printTokens(CoffeeScript.tokens(t.input));
       } else if (o.nodes) {
-        return printLine(CoffeeScript.nodes(t.input).toString().trim());
+        return console.log(CoffeeScript.nodes(t.input).toString().trim());
       } else if (o.run) {
         return CoffeeScript.run(t.input, t.options);
       } else {
         t.output = CoffeeScript.compile(t.input, t.options);
         CoffeeScript.emit('success', task);
         if (o.print) {
-          return printLine(t.output.trim());
+          return console.log(t.output.trim());
         } else if (o.compile) {
           return writeJs(t.file, t.output, base);
         } else if (o.lint) {
@@ -159,8 +151,8 @@
     } catch (err) {
       CoffeeScript.emit('failure', err, task);
       if (CoffeeScript.listeners('failure').length) return;
-      if (o.watch) return printLine(err.message);
-      printWarn(err instanceof Error && err.stack || ("ERROR: " + err));
+      if (o.watch) return console.log(err.message);
+      console.error(err instanceof Error && err.stack || ("ERROR: " + err));
       return process.exit(1);
     }
   };
@@ -221,7 +213,7 @@
       if (js.length <= 0) js = ' ';
       return fs.writeFile(jsPath, js, function(err) {
         if (err) {
-          return printLine(err.message);
+          return console.log(err.message);
         } else if (opts.compile && opts.watch) {
           return console.log("" + ((new Date).toLocaleTimeString()) + " - compiled " + source);
         }
@@ -239,7 +231,7 @@
   lint = function(file, js) {
     var conf, jsl, printIt;
     printIt = function(buffer) {
-      return printLine(file + ':\t' + buffer.toString().trim());
+      return console.log(file + ':\t' + buffer.toString().trim());
     };
     conf = __dirname + '/../extras/jsl.conf';
     jsl = spawn('jsl', ['-nologo', '-stdin', '-conf', conf]);
@@ -261,7 +253,7 @@
       }
       return _results;
     })();
-    return printLine(strings.join(' '));
+    return console.log(strings.join(' '));
   };
 
   parseOptions = function() {
@@ -294,11 +286,11 @@
   };
 
   usage = function() {
-    return printLine((new optparse.OptionParser(SWITCHES, BANNER)).help());
+    return console.log((new optparse.OptionParser(SWITCHES, BANNER)).help());
   };
 
   version = function() {
-    return printLine("CoffeeScript version " + CoffeeScript.VERSION);
+    return console.log("CoffeeScript version " + CoffeeScript.VERSION);
   };
 
 }).call(this);

--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -107,14 +107,15 @@
     };
 
     Lexer.prototype.numberToken = function() {
-      var is_binary, match, number, numlen;
+      var binaryLiteral, lexedLength, match, number;
       if (!(match = NUMBER.exec(this.chunk))) return 0;
       number = match[0];
-      numlen = number.length;
-      is_binary = /0b([01]+)/.exec(number);
-      if (is_binary) number = (parseInt(is_binary[1], 2)).toString();
+      lexedLength = number.length;
+      if (binaryLiteral = /0b([01]+)/.exec(number)) {
+        number = (parseInt(binaryLiteral[1], 2)).toString();
+      }
       this.token('NUMBER', number);
-      return numlen;
+      return lexedLength;
     };
 
     Lexer.prototype.stringToken = function() {


### PR DESCRIPTION
See discussion at #1798. This may break compatibility with pre-0.4 versions of Node, but our package.json already states that 0.4+ is required.
