### PR TITLE
Support CRLF output for codegen of nodes.

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -30,6 +30,7 @@ BANNER = '''
 SWITCHES = [
   ['-b', '--bare',            'compile without a top-level function wrapper']
   ['-c', '--compile',         'compile to JavaScript and save as .js files']
+  [      '--crlf',            'use crlf as line endings']
   ['-e', '--eval',            'pass a string from the command line as input']
   ['-h', '--help',            'display this help message']
   ['-i', '--interactive',     'run an interactive CoffeeScript REPL']
@@ -67,6 +68,7 @@ exports.run = ->
   return require './repl'                unless sources.length
   if opts.run
     opts.literals = sources.splice(1).concat opts.literals
+  opts.lineEnd = '\r\n'                  if opts.crlf
   process.ARGV = process.argv = process.argv.slice(0, 2).concat opts.literals
   process.argv[0] = 'coffee'
   process.execPath = require.main.filename
@@ -226,7 +228,7 @@ parseOptions = ->
   sources       = o.arguments
 
 # The compile-time options to pass to the CoffeeScript compiler.
-compileOptions = (filename) -> {filename, bare: opts.bare}
+compileOptions = (filename) -> {filename, bare: opts.bare, lineEnd: opts.lineEnd}
 
 # Start up a new Node.js instance with the arguments in `--nodejs` passed to
 # the `node` binary, preserving the other options.


### PR DESCRIPTION
This commit allows the user to specify an option on the command line (--crlf) that will turn on CRLF line endings for the output of the compile step.  I had a lot of trouble getting things going on windows, so I wasn't really able to run tests to cover this change.  If you want it as is, I'm offering it, as I'm pretty sure you could modify the tests pretty easily (if even needed) to test this feature.  If you'd rather tell me a bit more about how you'd like this commit to look, I'll be happy to go back and get my linux VM set up to compile coffeescript and make the appropriate changes to the tests.

We needed this change for our usage of coffeescript since we use CRLF throughout our project's JS files and it was giving us fits in git using the CS compiler to compile files that we checkin (stupid core.autocrlf crap in git that I'm pretty sure everyone hates).

Anyway, you're welcome to take this as is, or recommend how I can improve it and I'll try to do so.
