### PR TITLE
Issue #1768 - allow spacing for [ when following '::' operator.

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -344,14 +344,15 @@ exports.Lexer = class Lexer
     else if value in UNARY           then tag = 'UNARY'
     else if value in SHIFT           then tag = 'SHIFT'
     else if value in LOGIC or value is '?' and prev?.spaced then tag = 'LOGIC'
-    else if prev and not prev.spaced
-      if value is '(' and prev[0] in CALLABLE
+    else if prev
+      if value is '(' and prev[0] in CALLABLE and not prev.spaced
         prev[0] = 'FUNC_EXIST' if prev[0] is '?'
         tag = 'CALL_START'
       else if value is '[' and prev[0] in INDEXABLE
-        tag = 'INDEX_START'
-        switch prev[0]
-          when '?'  then prev[0] = 'INDEX_SOAK'
+        if prev[0] is '::' or not prev.spaced
+          tag = 'INDEX_START'
+          switch prev[0]
+            when '?'  then prev[0] = 'INDEX_SOAK'
     switch value
       when '(', '{', '[' then @ends.push INVERSES[value]
       when ')', '}', ']' then @pair value


### PR DESCRIPTION
This allows '[' to be preceded by whitespace and still get recognized when following the '::' operator.

In other words, 

```
Array:: ['isArray']
```

will now compile as expected (though I'm not sure I would have expected this!)

I didn't write a test, as I don't know how to do tests for coffeescript.  If you want me to write a test, I can try but I may need some help getting started.
