### PR TITLE
Using fs.watch instead of fs.watchFile under Windows (fixes #1803)

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -196,18 +196,27 @@
   };
 
   watch = function(source, base) {
-    return fs.watchFile(source, {
-      persistent: true,
-      interval: 500
-    }, function(curr, prev) {
-      if (curr.size === prev.size && curr.mtime.getTime() === prev.mtime.getTime()) {
-        return;
-      }
+    var onChange;
+    onChange = function() {
       return fs.readFile(source, function(err, code) {
         if (err) throw err;
         return compileScript(source, code.toString(), base);
       });
-    });
+    };
+    if (process.platform === 'win32') {
+      return fs.watch(source, function(event) {
+        if (event === 'change') return onChange();
+      });
+    } else {
+      return fs.watchFile(source, {
+        persistent: true,
+        interval: 500
+      }, function(curr, prev) {
+        if (!(curr.size === prev.size && curr.mtime.getTime() === prev.mtime.getTime())) {
+          return onChange();
+        }
+      });
+    }
   };
 
   writeJs = function(source, js, base) {


### PR DESCRIPTION
See discussion at #1803. Someone else needs to test that this actually works under Windows.
