### PR TITLE
Using fs.watchFile if supported, fs.watch otherwise (fixes #1803)

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -197,22 +197,42 @@
 
   watch = function(source, base) {
     return fs.stat(source, function(err, prevStats) {
+      var onChange, watchFileUnsupported;
       if (err) throw err;
-      return fs.watch(source, function(event) {
-        if (event === 'change') {
-          return fs.stat(source, function(err, stats) {
-            if (err) throw err;
-            if (stats.size === prevStats.size && stats.mtime.getTime() === prevStats.mtime.getTime()) {
-              return;
+      onChange = function() {
+        return fs.readFile(source, function(err, code) {
+          if (err) throw err;
+          return compileScript(source, code.toString(), base);
+        });
+      };
+      if (fs.watchFile) {
+        try {
+          fs.watchFile(source, {
+            persistent: true,
+            interval: 500
+          }, function(curr, prev) {
+            if (!(curr.size === prev.size && curr.mtime.getTime() === prev.mtime.getTime())) {
+              return onChange();
             }
-            prevStats = stats;
-            return fs.readFile(source, function(err, code) {
-              if (err) throw err;
-              return compileScript(source, code.toString(), base);
-            });
           });
+        } catch (e) {
+          watchFileUnsupported = true;
         }
-      });
+      }
+      if (watchFileUnsupported || !fs.watchFile) {
+        return fs.watch(source, function(event) {
+          if (event === 'change') {
+            return fs.stat(source, function(err, stats) {
+              if (err) throw err;
+              if (stats.size === prevStats.size && stats.mtime.getTime() === prevStats.mtime.getTime()) {
+                return;
+              }
+              prevStats = stats;
+              return onChange();
+            });
+          }
+        });
+      }
     });
   };
 


### PR DESCRIPTION
This isn't elegant, but at least it doesn't do platform-sniffing. Instead, it:
- Improves backward compatibility (since it uses `fs.watchFile` under Node 0.4.x),
- Future-proofs us (in case `fs.watchFile` is removed in a future release), and
- Allows us to use the less-buggy `fs.watchFile` on non-Windows systems (see [discussion at #1803](https://github.com/jashkenas/coffee-script/issues/1803#issuecomment-2683842))

I've tested that it works on the Mac (detecting saves from Coda and everything); someone else will have to give it a whirl under Windows.
