### PR TITLE
Re-fs.watching files on rename event

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -202,7 +202,9 @@
       return watcher = fs.watch(source, callback = function(event) {
         if (event === 'rename') {
           watcher.close();
-          return watcher = fs.watch(source, callback);
+          try {
+            return watcher = fs.watch(source, callback);
+          } catch (_error) {}
         } else if (event === 'change') {
           return fs.stat(source, function(err, stats) {
             if (err) throw err;

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -177,7 +177,8 @@ watch = (source, base) ->
     watcher = fs.watch source, callback = (event) ->
       if event is 'rename'
         watcher.close()
-        watcher = fs.watch source, callback
+        try  # if source no longer exists, never mind
+          watcher = fs.watch source, callback
       else if event is 'change'
         fs.stat source, (err, stats) ->
           throw err if err


### PR DESCRIPTION
Some editors (e.g. Coda) rename temp files rather than directly overwriting files on save; `fs.watch` loses track of the file at that point. This patch makes `fs.watch` re-bind itself on `"rename"` events. See discussion at #1803, #1846, and at https://github.com/joyent/node/issues/2062.
