### PR TITLE
Interface enhancements for cake (#1862)

### DIFF
--- a/lib/coffee-script/cake.js
+++ b/lib/coffee-script/cake.js
@@ -1,5 +1,5 @@
 (function() {
-  var CoffeeScript, badArgument, cakefileDirectory, fs, helpers, missingTask, oparse, options, optparse, path, printTasks, switches, tasks;
+  var CoffeeScript, cakefileDirectory, fatalError, fs, helpers, missingTask, oparse, options, optparse, path, printTasks, switches, tasks;
 
   fs = require('fs');
 
@@ -53,7 +53,7 @@
     try {
       options = oparse.parse(args);
     } catch (e) {
-      return badArgument(("" + e).match(/option: (.+)/)[1], "option");
+      return fatalError("" + e);
     }
     _ref = options.arguments;
     _results = [];
@@ -78,14 +78,14 @@
     if (switches.length) return console.log(oparse.help());
   };
 
-  badArgument = function(arg, type) {
-    console.error("No such " + type + ": \"" + arg + "\"\n");
+  fatalError = function(message) {
+    console.error(message + '\n');
     console.log('To see a list of all tasks/options, run "cake"');
     return process.exit(1);
   };
 
   missingTask = function(task) {
-    return badArgument(task, "task");
+    return fatalError("No such task: " + task);
   };
 
   cakefileDirectory = function(dir) {

--- a/src/cake.coffee
+++ b/src/cake.coffee
@@ -53,7 +53,7 @@ exports.run = ->
   try
     options = oparse.parse(args)
   catch e
-    return badArgument "#{e}".match(/option: (.+)/)[1], "option"
+    return fatalError "#{e}"
   invoke arg for arg in options.arguments
 
 # Display the list of Cake tasks in a format similar to `rake -T`
@@ -68,12 +68,12 @@ printTasks = ->
   console.log oparse.help() if switches.length
 
 # Print an error and exit when attempting to use an invalid task/option.
-badArgument = (arg, type) ->
-  console.error """No such #{type}: "#{arg}"\n"""
+fatalError = (message) ->
+  console.error message + '\n'
   console.log 'To see a list of all tasks/options, run "cake"'
   process.exit 1
 
-missingTask = (task) -> badArgument task, "task"
+missingTask = (task) -> fatalError "No such task: #{task}"
 
 # When `cake` is invoked, search in the current and all parent directories
 # to find the relevant Cakefile.


### PR DESCRIPTION
On the current master, while using an invalid task name produces a simple message, an invalid option (flag) produces a stack trace, because the exception thrown by `OptionParser` isn't caught (#1862). This pull request corrects that, instead producing, for example:

```
> cake --help
No such option: "--help"

To see a list of all tasks/options, run "cake"
```

The other thing this patch does is preface the task list with a message like this:

```
Cakefile defines the following tasks:
```

This becomes useful when the relevant `Cakefile` is in a parent directory (feature introduced by #1687), as it will then say

```
../Cakefile defines the following tasks:
```

making things much easier for folks with a hierarchy of `Cakefile`s.
