### PR TITLE
#1840 Invocation Prototype Prop Access

### DIFF
--- a/lib/coffee-script/grammar.js
+++ b/lib/coffee-script/grammar.js
@@ -141,7 +141,7 @@
       }), o('Value Accessor', function() {
         return $1.add($2);
       }), o('Invocation Accessor', function() {
-        return new Value($1, [$2]);
+        return new Value($1, [].concat($2));
       }), o('ThisProperty')
     ],
     Assignable: [

--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -140,7 +140,7 @@ case 62:this.$ = new yy.Value($$[$0]);
 break;
 case 63:this.$ = $$[$0-1].add($$[$0]);
 break;
-case 64:this.$ = new yy.Value($$[$0-1], [$$[$0]]);
+case 64:this.$ = new yy.Value($$[$0-1], [].concat($$[$0]));
 break;
 case 65:this.$ = $$[$0];
 break;

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -218,7 +218,7 @@ grammar =
   SimpleAssignable: [
     o 'Identifier',                             -> new Value $1
     o 'Value Accessor',                         -> $1.add $2
-    o 'Invocation Accessor',                    -> new Value $1, [$2]
+    o 'Invocation Accessor',                    -> new Value $1, [].concat $2
     o 'ThisProperty'
   ]
 

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -506,3 +506,15 @@ test "#1416: don't omit one 'new' when compiling 'new new fn()()'", ->
   eq obj.prop, nonce
   eq obj.a, argNonceA
   eq obj.b, argNonceB
+
+test "#1840: accessing the `prototype` after function invocation should compile", ->
+  doesNotThrow -> CoffeeScript.compile 'fn()::prop'
+  
+  nonce = {}
+  class Test then id: nonce
+
+  dotAccess = -> Test::
+  protoAccess = -> Test
+  
+  eq dotAccess().id, nonce
+  eq protoAccess()::id, nonce


### PR DESCRIPTION
**Issue**: #1840 Referencing the prototype of a function call results in a TypeError (1.1.3)
**By**: @hornairs
**Opened**: November 9, 2011
**Milestone**: none

**Issue** 
`fn()::prop` would fail to compile. Pull #1590 introduced a regression where the array of `Accessor`s created by `prototype` property access was being inserted into a new array instead of being used as is.

**Solution**
`Accessors` following invocation are now concat'd to an empty array so that a solitary `Accessor` object or an array of `Accessors` can be acceptable values.

Thanks to @TrevorBurnham for bisecting and bringing this to my attention.
