### PR TITLE
jison 0.2.11 requires node v0.4 - v0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "devDependencies": {
     "uglify-js":  "1.0.6",
-    "jison":      "0.2.11"
+    "jison":      "0.2.x"
   }
 }


### PR DESCRIPTION
which in turns makes coffee-script incompatible with node v0.6.
this patch makes it so it should at minimum use any of the latest minor releases of Jison, which _is_ compatible with node v0.6.*
