### PR TITLE
Documentation fix: s/traverse/traverseChildren/

### DIFF
--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -45,7 +45,7 @@ exports.tokens = (code, options) ->
 
 # Parse a string of CoffeeScript code or an array of lexed tokens, and
 # return the AST. You can then compile it by calling `.compile()` on the root,
-# or traverse it by using `.traverse()` with a callback.
+# or traverse it by using `.traverseChildren()` with a callback.
 exports.nodes = (source, options) ->
   if typeof source is 'string'
     parser.parse lexer.tokenize source, options


### PR DESCRIPTION
Hey all,

A small fix for the docs.

```
> var nodes = CoffeeScript.nodes('1234');
undefined
> nodes.traverse
undefined
> nodes.traverseChildren
function (a,b){ ...}
```

Matt
