### PR TITLE
reverting to 26a28ab behaviour

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -303,13 +303,18 @@
     };
 
     Block.prototype.compileRoot = function(o) {
-      var code, e, exp, i, prelude, preludeExps, rest;
-      o.indent = o.bare ? '' : TAB;
+      var code, e, exp, hasReturn, i, prelude, preludeExps, rest;
+      o.indent = "";
       o.scope = new Scope(null, this, null);
       o.level = LEVEL_TOP;
       this.spaced = true;
       prelude = "";
-      if (!o.bare) {
+      hasReturn = false;
+      this.traverseChildren(false, function(e) {
+        if (e instanceof Return) hasReturn = true;
+        return !hasReturn;
+      });
+      if (hasReturn || !o.bare) {
         preludeExps = (function() {
           var _len, _ref2, _results;
           _ref2 = this.expressions;
@@ -326,10 +331,13 @@
         this.expressions = preludeExps;
         if (preludeExps.length) prelude = "" + (this.compileNode(o)) + "\n";
         this.expressions = rest;
+        o.indent = TAB;
       }
       code = this.compileWithDeclarations(o);
-      if (o.bare) return prelude + code;
-      return "" + prelude + "(function() {\n" + code + "\n}).call(this);\n";
+      if (hasReturn || (!o.bare && o.scope.variables.length > 1)) {
+        return "" + prelude + "(function() {\n" + code + "\n}).call(this);\n";
+      }
+      return prelude + code;
     };
 
     Block.prototype.compileWithDeclarations = function(o) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -243,12 +243,16 @@ exports.Block = class Block extends Base
   # It would be better not to generate them in the first place, but for now,
   # clean up obvious double-parentheses.
   compileRoot: (o) ->
-    o.indent  = if o.bare then '' else TAB
+    o.indent  = ""
     o.scope   = new Scope null, this, null
     o.level   = LEVEL_TOP
     @spaced   = yes
     prelude   = ""
-    unless o.bare
+    hasReturn = no
+    @traverseChildren no, (e) ->
+      hasReturn = yes if e instanceof Return
+      !hasReturn
+    if hasReturn or not o.bare
       preludeExps = for exp, i in @expressions
         e = exp.unwrap()
         break unless e instanceof Comment or e instanceof Literal
@@ -257,9 +261,13 @@ exports.Block = class Block extends Base
       @expressions = preludeExps
       prelude = "#{@compileNode o}\n" if preludeExps.length
       @expressions = rest
+      # We assume that we will need the safety wrapper.
+      # This is the best we can do without compiling twice.
+      o.indent = TAB
     code = @compileWithDeclarations o
-    return prelude + code if o.bare
-    "#{prelude}(function() {\n#{code}\n}).call(this);\n"
+    if hasReturn or (not o.bare and o.scope.variables.length > 1)
+      return "#{prelude}(function() {\n#{code}\n}).call(this);\n"
+    prelude + code
 
   # Compile the expressions body for the contents of a function, with
   # declarations of all inner variables pushed up to the top.


### PR DESCRIPTION
This is only slightly problematic for the most pathological of cases where a prelude is followed by a set of statements, none of which generate top-level variables or attempt to return. In these cases, the non-prelude statements will be indented. See related discussion at e4b3e838e2f308d5d39eb54361374fb171ef58c9.
