### PR TITLE
Mark implicit parens generated

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -203,7 +203,7 @@
         return this.tokens.splice((this.tag(i - 1) === ',' ? i - 1 : i), 0, outdent);
       };
       return this.scanTokens(function(token, i, tokens) {
-        var implicit, tag, _ref, _ref2;
+        var tag, _ref, _ref2;
         tag = token[0];
         if (tag === 'TERMINATOR' && this.tag(i + 1) === 'THEN') {
           tokens.splice(i, 1);
@@ -219,7 +219,7 @@
         }
         if (__indexOf.call(SINGLE_LINERS, tag) >= 0 && this.tag(i + 1) !== 'INDENT' && !(tag === 'ELSE' && this.tag(i + 1) === 'IF')) {
           starter = tag;
-          _ref2 = this.indentation(token, implicit = true), indent = _ref2[0], outdent = _ref2[1];
+          _ref2 = this.indentation(token, true), indent = _ref2[0], outdent = _ref2[1];
           if (starter === 'THEN') indent.fromThen = true;
           tokens.splice(i + 1, 0, indent);
           this.detectEnd(i + 2, condition, action);

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -213,7 +213,7 @@ class exports.Rewriter
       if tag in SINGLE_LINERS and @tag(i + 1) isnt 'INDENT' and
          not (tag is 'ELSE' and @tag(i + 1) is 'IF')
         starter = tag
-        [indent, outdent] = @indentation token, implicit=true
+        [indent, outdent] = @indentation token, yes
         indent.fromThen   = true if starter is 'THEN'
         tokens.splice i + 1, 0, indent
         @detectEnd i + 2, condition, action
@@ -240,7 +240,7 @@ class exports.Rewriter
       1
 
   # Generate the indentation tokens, based on another token on the same line.
-  indentation: (token, implicit=false) ->
+  indentation: (token, implicit = false) ->
     tokens = [['INDENT', 2, token[2]], ['OUTDENT', 2, token[2]]]
     if implicit then (@generated(t) for t in tokens) else tokens
 


### PR DESCRIPTION
Hello all,

This  patch marks implicit parentheses generated and adds a helper function for marking tokens generated. It's a fall-out from the discussion in issue #1921.

Thanks a lot,
Matt
