### PR TITLE
Misc fixes for --watch

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -188,20 +188,24 @@
   };
 
   watch = function(source, base) {
-    var callback, compile, prevStats, watchErr, watcher;
+    var callback, compile, compileTimeout, prevStats, watchErr, watcher;
     prevStats = null;
+    compileTimeout = null;
     compile = function() {
-      return fs.stat(source, function(err, stats) {
-        if (err) throw err;
-        if (prevStats && (stats.size === prevStats.size && stats.mtime.getTime() === prevStats.mtime.getTime())) {
-          return;
-        }
-        prevStats = stats;
-        return fs.readFile(source, function(err, code) {
+      clearTimeout(compileTimeout);
+      return compileTimeout = setTimeout(function() {
+        return fs.stat(source, function(err, stats) {
           if (err) throw err;
-          return compileScript(source, code.toString(), base);
+          if (prevStats && (stats.size === prevStats.size && stats.mtime.getTime() === prevStats.mtime.getTime())) {
+            return;
+          }
+          prevStats = stats;
+          return fs.readFile(source, function(err, code) {
+            if (err) throw err;
+            return compileScript(source, code.toString(), base);
+          });
         });
-      });
+      }, 25);
     };
     watchErr = function(e) {
       if (e.code === 'ENOENT') {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -168,16 +168,20 @@ loadRequires = ->
 watch = (source, base) ->
 
   prevStats = null
+  compileTimeout = null
 
   compile = ->
-    fs.stat source, (err, stats) ->
-      throw err if err
-      return if prevStats and (stats.size is prevStats.size and
-        stats.mtime.getTime() is prevStats.mtime.getTime())
-      prevStats = stats
-      fs.readFile source, (err, code) ->
+    clearTimeout compileTimeout
+    compileTimeout = setTimeout ->
+      fs.stat source, (err, stats) ->
         throw err if err
-        compileScript(source, code.toString(), base)
+        return if prevStats and (stats.size is prevStats.size and
+          stats.mtime.getTime() is prevStats.mtime.getTime())
+        prevStats = stats
+        fs.readFile source, (err, code) ->
+          throw err if err
+          compileScript(source, code.toString(), base)
+    , 25
 
   watchErr = (e) ->
     if e.code is 'ENOENT'


### PR DESCRIPTION
So, the `fs.watch` API has a problem that forces us to get a little messy: If you try to `fs.watch` a nonexistent file, an error will be thrown. There's no "async" version of `fs.watch`. Since there's always a chance that a file will be deleted between a `path.exists` or `fs.stats` call and an `fs.watch` inside of it (in fact, in tests I found that this happened frequently when using tools like git), the only safe fix is to catch those `ENOENT` errors and handle them properly. That's the main thing this patch does.

The other thing is that it wraps watched file compilation in a timeout that gets reset if the file is modified again within 25ms. That's small enough that the delay shouldn't be noticeable, but large enough to get rid of those annoying duplicate

```
 compiled foo.coffee
 compiled foo.coffee
```

messages that happen when a tool blanks the file to 0 length before overwriting it.
