### PR TITLE
Rewatch files on change event (redo)

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -195,17 +195,31 @@
   };
 
   watch = function(source, base) {
-    var callback, compile, compileTimeout, prevStats, watchErr, watcher;
+    var compile, compileTimeout, prevStats, rewatch, rewatchTimeout, watchErr, watcher;
     prevStats = null;
     compileTimeout = null;
+    rewatchTimeout = null;
     watchErr = function(e) {
       if (e.code === 'ENOENT') {
         if (sources.indexOf(source) === -1) return;
-        removeSource(source, base, true);
-        return compileJoin();
+        clearTimeout(rewatchTimeout);
+        return rewatchTimeout = wait(25, function() {
+          try {
+            rewatch();
+            return compile();
+          } catch (e) {
+            removeSource(source, base, true);
+            return compileJoin();
+          }
+        });
       } else {
         throw e;
       }
+    };
+    rewatch = function() {
+      var watcher;
+      if (typeof watcher !== "undefined" && watcher !== null) watcher.close();
+      return watcher = fs.watch(source, compile);
     };
     compile = function() {
       clearTimeout(compileTimeout);
@@ -213,28 +227,19 @@
         return fs.stat(source, function(err, stats) {
           if (err) return watchErr(err);
           if (prevStats && (stats.size === prevStats.size && stats.mtime.getTime() === prevStats.mtime.getTime())) {
-            return;
+            return rewatch();
           }
           prevStats = stats;
           return fs.readFile(source, function(err, code) {
             if (err) return watchErr(err);
-            return compileScript(source, code.toString(), base);
+            compileScript(source, code.toString(), base);
+            return rewatch();
           });
         });
       });
     };
     try {
-      return watcher = fs.watch(source, callback = function(event) {
-        compile();
-        return wait(250, function() {
-          try {
-            watcher.close();
-            return watcher = fs.watch(source, callback);
-          } catch (e) {
-            return watchErr(e);
-          }
-        });
-      });
+      return watcher = fs.watch(source, compile);
     } catch (e) {
       return watchErr(e);
     }

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -174,35 +174,40 @@ watch = (source, base) ->
 
   prevStats = null
   compileTimeout = null
+  rewatchTimeout = null
 
   watchErr = (e) ->
     if e.code is 'ENOENT'
       return if sources.indexOf(source) is -1
-      removeSource source, base, yes
-      compileJoin()
+      clearTimeout rewatchTimeout
+      rewatchTimeout = wait 25, ->
+        try
+          rewatch()
+          compile()
+        catch e
+          removeSource source, base, yes
+          compileJoin()
     else throw e
+
+  rewatch = ->
+    watcher?.close()
+    watcher = fs.watch source, compile
 
   compile = ->
     clearTimeout compileTimeout
     compileTimeout = wait 25, ->
       fs.stat source, (err, stats) ->
         return watchErr err if err
-        return if prevStats and (stats.size is prevStats.size and
+        return rewatch() if prevStats and (stats.size is prevStats.size and
           stats.mtime.getTime() is prevStats.mtime.getTime())
         prevStats = stats
         fs.readFile source, (err, code) ->
           return watchErr err if err
           compileScript(source, code.toString(), base)
+          rewatch()
 
   try
-    watcher = fs.watch source, callback = (event) ->
-      compile()
-      wait 250, ->
-        try
-          watcher.close()
-          watcher = fs.watch source, callback
-        catch e
-          watchErr e
+    watcher = fs.watch source, compile
   catch e
     watchErr e
 


### PR DESCRIPTION
Replaces botched pull request #1963.

This patch may feel a bit excessive, but it seems to produce consistent behavior under Coda, TextMate 2, git, and all the other edge cases we've encountered with `fs.watch`. Further testing is very welcome.
