### PR TITLE
fixes #1966: external constructors should produce their return value

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1255,6 +1255,7 @@
         if (this.externalCtor) {
           this.ctor.body.push(new Literal("" + this.externalCtor + ".apply(this, arguments)"));
         }
+        this.ctor.body.makeReturn();
         this.body.expressions.unshift(this.ctor);
       }
       this.ctor.ctor = this.ctor.name = name;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -923,6 +923,7 @@ exports.Class = class Class extends Base
       @ctor = new Code
       @ctor.body.push new Literal "#{name}.__super__.constructor.apply(this, arguments)" if @parent
       @ctor.body.push new Literal "#{@externalCtor}.apply(this, arguments)" if @externalCtor
+      @ctor.body.makeReturn()
       @body.expressions.unshift @ctor
     @ctor.ctor     = @ctor.name = name
     @ctor.klass    = null

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -490,6 +490,7 @@ test "#1182: execution order needs to be considered as well", ->
 test "#1182: external constructors with bound functions", ->
   fn = ->
     {one: 1}
+    this
   class B
   class A
     constructor: fn
@@ -604,3 +605,8 @@ test "#494: Named classes", ->
     
   class A.B["C"]        
   ok A.B.C.name isnt 'C'
+
+test "#1966: external constructors should produce their return value", ->
+  ctor = -> {}
+  class A then constructor: ctor
+  ok (new A) not instanceof A


### PR DESCRIPTION
I'm not 100% on this, but it seems better than the alternative, which would be to treat the return value of already-defined functions differently when pointed to as an external constructor.

**edit:** I'm pretty comfortable with it now. See my comment below.
