### PR TITLE
Default constructor for subclass now returns returned value from parent

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -896,8 +896,10 @@ exports.Class = class Class extends Base
   ensureConstructor: (name) ->
     if not @ctor
       @ctor = new Code
-      @ctor.body.push new Literal "#{name}.__super__.constructor.apply(this, arguments)" if @parent
+      @ctor.body.push new Literal "var instance = this"
+      @ctor.body.push new Literal "instance = #{name}.__super__.constructor.apply(this, arguments)" if @parent
       @ctor.body.push new Literal "#{@externalCtor}.apply(this, arguments)" if @externalCtor
+      @ctor.body.push new Literal "return instance"
       @body.expressions.unshift @ctor
     @ctor.ctor     = @ctor.name = name
     @ctor.klass    = null

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -66,6 +66,28 @@ test "constructors with inheritance and super", ->
   ok (new SubClass).prop is 'top-super-sub'
 
 
+test "default constructors for subclasses return value from constructor", ->
+  class SuperClass
+    @__identityMap: {}
+    
+    constructor: (@id) ->
+      instance = SuperClass.__identityMap[@id]
+      return instance ?= SuperClass.__identityMap[@id] = this # explicit return required here
+  
+  class SubClass extends SuperClass
+  
+  one = new SuperClass(1)
+  
+  ok (new SuperClass(1) is one)
+  ok (new SubClass(1)   is one)
+  ok (new SuperClass(2) isnt one)
+  ok (new SubClass(2)   isnt one)
+  
+  instanceCount = 0
+  instanceCount += 1 for own key, value of SuperClass.__identityMap
+  ok (instanceCount is 2)
+
+
 test "Overriding the static property new doesn't clobber Function::new", ->
 
   class OneClass


### PR DESCRIPTION
This simple change makes it easy to implement identity maps (see included tests for example).  Been needing something like this for my work with Backbone recently.

I left external constructors alone for now, as I don't fully understand their purpose as defined by the current test suite (external constructors return their own instances but are expected to behave as the calling class?):

```
  #1182: external constructors with bound functions 
  TypeError: Cannot call method 'call' of undefined
    at Function.<anonymous> (/Volumes/HD2/devel/opensource/coffee-script/test/classes.coffee:1042:30)
    at /Volumes/HD2/devel/opensource/coffee-script/Cakefile:203:12
    at Object.<anonymous> (/Volumes/HD2/devel/opensource/coffee-script/test/classes.coffee:1007:3)
    at Object.<anonymous> (/Volumes/HD2/devel/opensource/coffee-script/test/classes.coffee:1232:4)
    at Module._compile (module.js:432:26)
    at Object.run (/Volumes/HD2/devel/opensource/coffee-script/lib/coffee-script/coffee-script.js:66:25)
    at /Volumes/HD2/devel/opensource/coffee-script/Cakefile:271:22
    at Object.action (/Volumes/HD2/devel/opensource/coffee-script/Cakefile:285:12)
    at /Volumes/HD2/devel/opensource/coffee-script/lib/coffee-script/cake.js:39:26
    at Object.run (/Volumes/HD2/devel/opensource/coffee-script/lib/coffee-script/cake.js:62:21) 
  test/classes.js: line unknown, column unknown 
  function () {
    var A, B, fn, _class;
    fn = function() {
      return {
        one: 1
      };
    };
    B = (function() {

      function B() {
        var instance = this;
        return instance;
      }

      return B;

    })();
    A = (function() {

      function A() {
        this.method = __bind(this.method, this);
        var instance = this;
        instance = _class.apply(this, arguments);
        return instance;
      }

      _class = fn;

      A.prototype.method = function() {
        return this instanceof A;
      };

      return A;

    })();
    return ok((new A).method.call(new B));
  }
```
