### PR TITLE
add simple startup file support to REPL (.coffeerc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ raw
 presentation
 test.coffee
 parser.output
+.coffeerc
 test/fixtures/underscore
 test/*.js
 examples/beautiful_code/parse.coffee

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -1,5 +1,5 @@
 (function() {
-  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, dir, enableColours, error, fs, getCompletions, inspect, readline, repl, run, stdin, stdout, _i, _len, _ref;
+  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, dir, enableColours, error, fs, getCompletions, inspect, path, readline, repl, run, stdin, stdout, _i, _len, _ref;
 
   CoffeeScript = require('./coffee-script');
 
@@ -12,6 +12,8 @@
   Module = require('module');
 
   fs = require('fs');
+
+  path = require('path');
 
   REPL_PROMPT = 'coffee> ';
 
@@ -148,10 +150,10 @@
 
   repl.on('line', run);
 
-  _ref = [process.env['HOME'], process.cwd()];
+  _ref = [process.env['USERPROFILE'], process.env['HOME'], process.cwd()];
   for (_i = 0, _len = _ref.length; _i < _len; _i++) {
     dir = _ref[_i];
-    fs.readFile("" + dir + "/.coffeerc", function(err, data) {
+    fs.readFile(path.normalize("" + dir + "/.coffeerc"), function(err, data) {
       if (!err) return run(data, false);
     });
   }

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -1,5 +1,5 @@
 (function() {
-  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, enableColours, error, fs, getCompletions, inspect, readline, repl, run, stdin, stdout;
+  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, dir, enableColours, error, fs, getCompletions, inspect, readline, repl, run, stdin, stdout, _i, _len, _ref;
 
   CoffeeScript = require('./coffee-script');
 
@@ -33,9 +33,9 @@
 
   backlog = '';
 
-  run = function(buffer, echo_output) {
+  run = function(buffer, echoOutput) {
     var code, returnValue, _;
-    if (echo_output == null) echo_output = true;
+    if (echoOutput == null) echoOutput = true;
     if (!buffer.toString().trim() && !backlog) {
       repl.prompt();
       return;
@@ -56,7 +56,7 @@
         modulename: 'repl'
       });
       if (returnValue === void 0) global._ = _;
-      if (echo_output) {
+      if (echoOutput) {
         process.stdout.write(inspect(returnValue, false, 2, enableColours) + '\n');
       }
     } catch (err) {
@@ -148,9 +148,13 @@
 
   repl.on('line', run);
 
-  fs.readFile('.coffeerc', function(err, data) {
-    if (!err) return run(data, false);
-  });
+  _ref = [process.env['HOME'], process.cwd()];
+  for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+    dir = _ref[_i];
+    fs.readFile("" + dir + "/.coffeerc", function(err, data) {
+      if (!err) return run(data, false);
+    });
+  }
 
   repl.setPrompt(REPL_PROMPT);
 

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -1,5 +1,5 @@
 (function() {
-  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, dir, enableColours, error, fs, getCompletions, inspect, path, readline, repl, run, stdin, stdout, _i, _len, _ref;
+  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, data, dir, enableColours, error, fs, getCompletions, homedir, inspect, os, path, rcfile, readline, repl, run, stdin, stdout, _i, _len, _ref;
 
   CoffeeScript = require('./coffee-script');
 
@@ -14,6 +14,8 @@
   fs = require('fs');
 
   path = require('path');
+
+  os = require('os');
 
   REPL_PROMPT = 'coffee> ';
 
@@ -35,9 +37,8 @@
 
   backlog = '';
 
-  run = function(buffer, echoOutput) {
+  run = function(buffer) {
     var code, returnValue, _;
-    if (echoOutput == null) echoOutput = true;
     if (!buffer.toString().trim() && !backlog) {
       repl.prompt();
       return;
@@ -58,9 +59,7 @@
         modulename: 'repl'
       });
       if (returnValue === void 0) global._ = _;
-      if (echoOutput) {
-        process.stdout.write(inspect(returnValue, false, 2, enableColours) + '\n');
-      }
+      process.stdout.write(inspect(returnValue, false, 2, enableColours) + '\n');
     } catch (err) {
       error(err);
     }
@@ -150,11 +149,16 @@
 
   repl.on('line', run);
 
-  _ref = [process.env['USERPROFILE'], process.env['HOME'], process.cwd()];
+  homedir = os.platform() === 'win32' ? process.env.USERPROFILE : process.env.HOME;
+
+  _ref = [homedir, process.cwd()];
   for (_i = 0, _len = _ref.length; _i < _len; _i++) {
     dir = _ref[_i];
-    fs.readFile(path.normalize("" + dir + "/.coffeerc"), function(err, data) {
-      if (!err) return run(data, false);
+    rcfile = path.join(dir, '.coffeerc');
+    data = fs.readFileSync(rcfile, 'utf8');
+    CoffeeScript.eval(data, {
+      filename: rcfile,
+      module: '.coffeerc'
     });
   }
 

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -1,5 +1,5 @@
 (function() {
-  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, enableColours, error, getCompletions, inspect, readline, repl, run, stdin, stdout;
+  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, enableColours, error, fs, getCompletions, inspect, readline, repl, run, stdin, stdout;
 
   CoffeeScript = require('./coffee-script');
 
@@ -10,6 +10,8 @@
   Script = require('vm').Script;
 
   Module = require('module');
+
+  fs = require('fs');
 
   REPL_PROMPT = 'coffee> ';
 
@@ -31,8 +33,9 @@
 
   backlog = '';
 
-  run = function(buffer) {
+  run = function(buffer, echo_output) {
     var code, returnValue, _;
+    if (echo_output == null) echo_output = true;
     if (!buffer.toString().trim() && !backlog) {
       repl.prompt();
       return;
@@ -53,7 +56,9 @@
         modulename: 'repl'
       });
       if (returnValue === void 0) global._ = _;
-      process.stdout.write(inspect(returnValue, false, 2, enableColours) + '\n');
+      if (echo_output) {
+        process.stdout.write(inspect(returnValue, false, 2, enableColours) + '\n');
+      }
     } catch (err) {
       error(err);
     }
@@ -142,6 +147,10 @@
   });
 
   repl.on('line', run);
+
+  fs.readFile('.coffeerc', function(err, data) {
+    if (!err) return run(data, false);
+  });
 
   repl.setPrompt(REPL_PROMPT);
 

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -11,6 +11,7 @@ readline     = require 'readline'
 {Script}     = require 'vm'
 Module       = require 'module'
 fs           = require 'fs'
+path         = require 'path'
 
 
 # REPL Setup
@@ -123,8 +124,8 @@ repl.on 'close', ->
 
 repl.on 'line', run
 
-for dir in [process.env['HOME'], process.cwd()]
-  fs.readFile "#{dir}/.coffeerc", 
+for dir in [process.env['USERPROFILE'], process.env['HOME'], process.cwd()]
+  fs.readFile path.normalize("#{dir}/.coffeerc"), 
     (err, data) ->
       unless err
         run data, false

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -10,6 +10,7 @@ readline     = require 'readline'
 {inspect}    = require 'util'
 {Script}     = require 'vm'
 Module       = require 'module'
+fs           = require 'fs'
 
 # REPL Setup
 
@@ -34,7 +35,7 @@ backlog = ''
 # The main REPL function. **run** is called every time a line of code is entered.
 # Attempt to evaluate the command. If there's an exception, print it out instead
 # of exiting.
-run = (buffer) ->
+run = (buffer, echo_output=true) ->
   if !buffer.toString().trim() and !backlog
     repl.prompt()
     return
@@ -54,7 +55,8 @@ run = (buffer) ->
     }
     if returnValue is undefined
       global._ = _
-    process.stdout.write inspect(returnValue, no, 2, enableColours) + '\n'
+    if echo_output
+      process.stdout.write inspect(returnValue, no, 2, enableColours) + '\n'
   catch err
     error err
   repl.prompt()
@@ -119,6 +121,11 @@ repl.on 'close', ->
   stdin.destroy()
 
 repl.on 'line', run
+
+fs.readFile '.coffeerc',
+  (err, data) ->
+    unless err
+      run data, false
 
 repl.setPrompt REPL_PROMPT
 repl.prompt()

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -12,6 +12,7 @@ readline     = require 'readline'
 Module       = require 'module'
 fs           = require 'fs'
 
+
 # REPL Setup
 
 # Config
@@ -35,7 +36,7 @@ backlog = ''
 # The main REPL function. **run** is called every time a line of code is entered.
 # Attempt to evaluate the command. If there's an exception, print it out instead
 # of exiting.
-run = (buffer, echo_output=true) ->
+run = (buffer, echoOutput = true) ->
   if !buffer.toString().trim() and !backlog
     repl.prompt()
     return
@@ -55,7 +56,7 @@ run = (buffer, echo_output=true) ->
     }
     if returnValue is undefined
       global._ = _
-    if echo_output
+    if echoOutput
       process.stdout.write inspect(returnValue, no, 2, enableColours) + '\n'
   catch err
     error err
@@ -122,10 +123,11 @@ repl.on 'close', ->
 
 repl.on 'line', run
 
-fs.readFile '.coffeerc',
-  (err, data) ->
-    unless err
-      run data, false
+for dir in [process.env['HOME'], process.cwd()]
+  fs.readFile "#{dir}/.coffeerc", 
+    (err, data) ->
+      unless err
+        run data, false
 
 repl.setPrompt REPL_PROMPT
 repl.prompt()


### PR DESCRIPTION
When starting REPL, loads and runs the file `.coffeerc` if present in the current directory.
