### PR TITLE
Fixes #2001: Allow piped input to coffee

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -1,5 +1,5 @@
 (function() {
-  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, REPL_PROMPT_MULTILINE, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, enableColours, error, getCompletions, inspect, multilineMode, readline, repl, stdin, stdout;
+  var ACCESSOR, CoffeeScript, Module, REPL_PROMPT, REPL_PROMPT_CONTINUATION, REPL_PROMPT_MULTILINE, SIMPLEVAR, Script, autocomplete, backlog, completeAttribute, completeVariable, enableColours, error, getCompletions, inspect, multilineMode, pipedInput, readline, repl, stdin, stdout;
 
   stdin = process.openStdin();
 
@@ -31,13 +31,34 @@
     return stdout.write((err.stack || err.toString()) + '\n');
   };
 
-  if (readline.createInterface.length < 3) {
-    repl = readline.createInterface(stdin, autocomplete);
-    stdin.on('data', function(buffer) {
-      return repl.write(buffer);
+  if (stdin.readable) {
+    pipedInput = '';
+    stdout.write(REPL_PROMPT);
+    stdin.on('data', function(chunk) {
+      pipedInput += chunk;
+      return stdout.write(chunk);
     });
+    stdin.on('end', function() {
+      stdout.write('\n');
+      try {
+        return CoffeeScript.eval(pipedInput, {
+          filename: 'pipe',
+          modulename: 'pipe'
+        });
+      } catch (e) {
+        return error(e);
+      }
+    });
+    return;
   } else {
-    repl = readline.createInterface(stdin, stdout, autocomplete);
+    if (readline.createInterface.length < 3) {
+      repl = readline.createInterface(stdin, autocomplete);
+      stdin.on('data', function(buffer) {
+        return repl.write(buffer);
+      });
+    } else {
+      repl = readline.createInterface(stdin, stdout, autocomplete);
+    }
   }
 
   process.on('uncaughtException', error);


### PR DESCRIPTION
This is a fairly simple patch that allows you to write

```
echo "console.log 'foo'" | coffee
```

and get the output

```
coffee> console.log 'foo'

foo
```

This patch isn't ideal; it just passes all of the piped input straight to `CoffeeScript.eval`. Unfortunately, the `readline` module that we're using for the REPL doesn't seem to take anything but a true `stdin`, so there's no easy way that I can think of to allow an arbitrary pipe to interact with the REPL. Still, it's an improvement compared to the error Michael reported at #2001.
