### PR TITLE
Cake::printTasks broken in node v0.4

### DIFF
--- a/src/cake.coffee
+++ b/src/cake.coffee
@@ -58,7 +58,8 @@ exports.run = ->
 
 # Display the list of Cake tasks in a format similar to `rake -T`
 printTasks = ->
-  cakefilePath = path.join path.relative(__originalDirname, process.cwd()), 'Cakefile'
+  relative = path.relative or path.resolve
+  cakefilePath = path.join relative(__originalDirname, process.cwd()), 'Cakefile'
   console.log "#{cakefilePath} defines the following tasks:\n"
   for name, task of tasks
     spaces = 20 - name.length


### PR DESCRIPTION
When running `cake` command without parameters, a list of tasks/options should be printed based on current Cakefile. In **v0.4** this is broken:

```
$ cake

node.js:134
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
TypeError: Object #<Object> has no method 'relative'
    at .../node_modules/coffee-script/lib/coffee-script/cake.js:69:35
...
```

The reason for this is that `path.relative` was introduced in **v0.6**. Attached is a suggested workaround.
