### PR TITLE
Parse error when returning object literals from array/object comprehensions

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -176,7 +176,7 @@
       return this.scanTokens(function(token, i, tokens) {
         var callObject, current, next, prev, tag, _ref, _ref2, _ref3;
         tag = token[0];
-        if (tag === 'CLASS' || tag === 'IF') noCall = true;
+        if (tag === 'CLASS' || tag === 'IF' || tag === 'FOR') noCall = true;
         _ref = tokens.slice(i - 1, (i + 1) + 1 || 9e9), prev = _ref[0], current = _ref[1], next = _ref[2];
         callObject = !noCall && tag === 'INDENT' && next && next.generated && next[0] === '{' && prev && (_ref2 = prev[0], __indexOf.call(IMPLICIT_FUNC, _ref2) >= 0);
         seenSingle = false;

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -167,7 +167,7 @@ class exports.Rewriter
 
     @scanTokens (token, i, tokens) ->
       tag     = token[0]
-      noCall  = yes if tag in ['CLASS', 'IF']
+      noCall  = yes if tag in ['CLASS', 'IF', 'FOR']
       [prev, current, next] = tokens[i - 1 .. i + 1]
       callObject  = not noCall and tag is 'INDENT' and
                     next and next.generated and next[0] is '{' and

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -269,4 +269,10 @@ test "#1961, #1974, regression with compound assigning to an implicit object", -
     four: 4
     
   eq obj.four, 4
-  
+
+test "#2007: Return object literal from comprehension", ->
+  y = for x in [1, 2]
+    foo: "foo"
+    bar: "bar"
+
+  eq y[0].foo, "foo"


### PR DESCRIPTION
The following returns a compile error (Parse error on line 3: Unexpected 'TERMINATOR'):

```
y = for x in [1,2]
  foo: "foo"
  bar: "bar"
```

This works, however:

```
y = for x in [1,2]
  null
  foo: "foo"
  bar: "bar"
```

And compiles to:

```
var x, y;

y = (function() {
  var _i, _len, _ref, _results;
  _ref = [1, 2];
  _results = [];
  for (_i = 0, _len = _ref.length; _i < _len; _i++) {
    x = _ref[_i];
    null;
    _results.push({
      foo: "foo",
      bar: "bar"
    });
  }
  return _results;
})();
```

I'd expect the first example to convert to the same code, except without the `null` statement in between.

Any idea what might be going on? I'd be happy to attempt to create a patch, but for now I'm not sure where to start.
