### PR TITLE
Issue #2054 "{arguments}"

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1338,13 +1338,14 @@
     Assign.name = 'Assign';
 
     function Assign(variable, value, context, options) {
-      var name, _ref3;
+      var forbidden, name, _ref3;
       this.variable = variable;
       this.value = value;
       this.context = context;
       this.param = options && options.param;
       this.subpattern = options && options.subpattern;
-      if (name = (_ref3 = this.variable.unwrapAll().value, __indexOf.call(STRICT_PROSCRIBED, _ref3) >= 0)) {
+      forbidden = (_ref3 = (name = this.variable.unwrapAll().value), __indexOf.call(STRICT_PROSCRIBED, _ref3) >= 0);
+      if (forbidden && this.context !== 'object') {
         throw SyntaxError("variable name may not be \"" + name + "\"");
       }
     }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -993,7 +993,8 @@ exports.Assign = class Assign extends Base
   constructor: (@variable, @value, @context, options) ->
     @param = options and options.param
     @subpattern = options and options.subpattern
-    if name = @variable.unwrapAll().value in STRICT_PROSCRIBED
+    forbidden = (name = @variable.unwrapAll().value) in STRICT_PROSCRIBED
+    if forbidden and @context isnt 'object'
       throw SyntaxError "variable name may not be \"#{name}\""
 
   children: ['variable', 'value']

--- a/test/strict.coffee
+++ b/test/strict.coffee
@@ -117,6 +117,9 @@ test "`Future Reserved Word`s, `eval` and `arguments` restrictions", ->
     check "++{keyword}"
     check "{keyword}--"
     check "--{keyword}"
+  destruct = (keyword, check = strict) ->
+    check "{#{keyword}}"
+    check "o = {#{keyword}}"
   invoke = (keyword, check = strict) ->  
     check "#{keyword} yes"
     check "do #{keyword}"
@@ -134,6 +137,7 @@ test "`Future Reserved Word`s, `eval` and `arguments` restrictions", ->
   for keyword in future
     access   keyword
     assign   keyword
+    destruct keyword
     invoke   keyword
     fnDecl   keyword
     param    keyword
@@ -143,6 +147,7 @@ test "`Future Reserved Word`s, `eval` and `arguments` restrictions", ->
   for keyword in ['eval', 'arguments']
     access   keyword, strictOk
     assign   keyword
+    destruct keyword, strictOk
     invoke   keyword, strictOk
     fnDecl   keyword
     param    keyword


### PR DESCRIPTION
Address's #2054
Opened by @satyr

`bin/coffee -bpe "{arguments}"`

incorrectly resulted in:

```
SyntaxError: variable name may not be "true"
```

---

Fixes error message: 'SyntaxError: variable name may not be "true"'

Permits assigning to "arguments" and "eval" properties in object literals. (`eval` and `arguments` as property names is legal in `strict`.

Updated tests for destructuring assignments.

Thanks @satyr!
