### PR TITLE
Added detection for Windows builds and modified execution of mkdir comma...

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -5,6 +5,7 @@
 # interactive REPL.
 
 # External dependencies.
+os             = require 'os'
 fs             = require 'fs'
 path           = require 'path'
 helpers        = require './helpers'
@@ -272,7 +273,10 @@ writeJs = (source, js, base) ->
       else if opts.compile and opts.watch
         timeLog "compiled #{source}"
   path.exists jsDir, (exists) ->
-    if exists then compile() else exec "mkdir -p #{jsDir}", compile
+    if os.isWindows() then
+      if exists then compile() else exec "mkdir #{jsDir}", compile
+    else
+      if exists then compile() else exec "mkdir -p #{jsDir}", compile
 
 # Convenience for cleaner setTimeouts.
 wait = (milliseconds, func) -> setTimeout func, milliseconds


### PR DESCRIPTION
I've added a couple of lines to command.coffee to detect whether or not node is running on Windows so the correct mkdir command is executed. Without this, when using the full file path the build process creates a '-p' folder.
