### PR TITLE
Fix inherited spelling in documentation

### DIFF
--- a/documentation/index.html.erb
+++ b/documentation/index.html.erb
@@ -529,7 +529,7 @@ Expressions
     <p>
       If you would like to iterate over just the keys that are defined on the
       object itself, by adding a <tt>hasOwnProperty</tt>
-      check to avoid properties that may be interited from the prototype, use<br />
+      check to avoid properties that may be inherited from the prototype, use<br />
       <tt>for own key, value of object</tt>
     </p>
     <p>

--- a/index.html
+++ b/index.html
@@ -943,7 +943,7 @@ ages = (function() {
     <p>
       If you would like to iterate over just the keys that are defined on the
       object itself, by adding a <tt>hasOwnProperty</tt>
-      check to avoid properties that may be interited from the prototype, use<br />
+      check to avoid properties that may be inherited from the prototype, use<br />
       <tt>for own key, value of object</tt>
     </p>
     <p>


### PR DESCRIPTION
Was 'interited', changed to 'inherited'. 
