### PR TITLE
Issue #2211 -- splats in destructured parameters

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1740,6 +1740,8 @@
         obj = _ref2[_i];
         if (obj instanceof Assign) {
           names.push(obj.variable.base.value);
+        } else if (obj instanceof Splat) {
+          names.push(obj.name.unwrap().value);
         } else if (obj.isArray() || obj.isObject()) {
           names.push.apply(names, this.names(obj.base));
         } else if (obj["this"]) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1278,6 +1278,9 @@ exports.Param = class Param extends Base
       # * assignments within destructured parameters `{foo:bar}`
       if obj instanceof Assign
         names.push obj.variable.base.value
+      # * splats within destructured parameters `[xs...]`
+      else if obj instanceof Splat
+        names.push obj.name.unwrap().value
       # * destructured parameters within destructured parameters `[{a}]`
       else if obj.isArray() or obj.isObject()
         names.push @names(obj.base)...

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -343,3 +343,10 @@ test "#1838: Regression with variable assignment", ->
   'dave'
 
   eq name, 'dave'
+
+test '#2211: splats in destructured parameters', ->
+  doesNotThrow -> CoffeeScript.compile '([a...]) ->'
+  doesNotThrow -> CoffeeScript.compile '([a...],b) ->'
+  doesNotThrow -> CoffeeScript.compile '([a...],[b...]) ->'
+  throws -> CoffeeScript.compile '([a...,[a...]]) ->'
+  doesNotThrow -> CoffeeScript.compile '([a...,[b...]]) ->'


### PR DESCRIPTION
#2211 **Splat Value "xx" has no method 'isArray'**

Opened by @nikita-volkov on **March 22, 2012**

The problem:

``` bash
coffee -bpe '([a...]) ->'
```

would throw the following error:

``` bash
TypeError: Object 
Splat
  Value "a" has no method 'isArray'
  at Param.names (.../nodes.js:1738:24)
```

The solution: A check for `Splat`s in the `Parameter::names` method. If a splat is detected, its base name is added to the array of parameter names.
