### PR TITLE
build on Windows - fix spawn command by calling node explicitly

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -34,7 +34,7 @@ sources = [
 
 # Run a CoffeeScript through our node/coffee interpreter.
 run = (args, cb) ->
-  proc =         spawn 'bin/coffee', args
+  proc =         spawn 'node', ['bin/coffee'].concat(args)
   proc.stderr.on 'data', (buffer) -> console.log buffer.toString()
   proc.on        'exit', (status) ->
     process.exit(1) if status != 0


### PR DESCRIPTION
One possible fix for issue 2217 https://github.com/jashkenas/coffee-script/issues/2217
