### PR TITLE
When odd number representations are used, preserve original in comment

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -128,6 +128,7 @@
       if (binaryLiteral = /^0b([01]+)/.exec(number)) {
         number = '0x' + (parseInt(binaryLiteral[1], 2)).toString(16);
       }
+      if (octalLiteral || binaryLiteral) number += " /* " + this.chunk + " */";
       this.token('NUMBER', number);
       return lexedLength;
     };

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -146,6 +146,8 @@ exports.Lexer = class Lexer
       number = '0x' + (parseInt octalLiteral[1], 8).toString 16
     if binaryLiteral = /^0b([01]+)/.exec number
       number = '0x' + (parseInt binaryLiteral[1], 2).toString 16
+    if octalLiteral or binaryLiteral
+      number += " /* #{@chunk} */"
     @token 'NUMBER', number
     lexedLength
 


### PR DESCRIPTION
Pretty simple:

```
$ coffee -bpe 0o644
0x1a4 /* 0o644 */;
$ 
```

I expect some pushback from @jashkenas, so I'll open a pull request for it.
