### PR TITLE
this != window in "Try CoffeeScript"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 
 
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -2951,7 +2950,7 @@ task(<span class="String"><span class="String">'</span>build:parser<span class="
     closeMenus = ->
       $('.navigation.active').removeClass 'active'
 
-    $('.minibutton.run').click evalJS
+    $('.minibutton.run').click -> evalJS()
 
     # Bind navigation buttons to open the menus.
     $('.navigation').click (e) ->


### PR DESCRIPTION
`this` should be `window` rather than clicked "Run" button in "Try CoffeeScript" interpreter.

On current coffeescript.org website, click "TRY COFFEESCRIPT" and enter:

```
 alert [this == window, this, window]
 console.assert this == window, "this is ", this, "instead of of window", window
```

and then click the "Run" button. 

```
false,[object HTMLDivElement],[object DOMWindow]
```

**Assertion failed**: this is  &lt;div class=​"minibutton dark run" title=​"Ctrl-Enter"&gt;​Run​&lt;/div&gt;
 instead of of window DOMWindow 

Confusing to people coming to the site for the first time or trying to check values in the Web Console.

jQuery bound `this` to the html element clicked. Now unbound so `this == window`.
