### PR TITLE
Editor for the REPL first draft

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -234,8 +234,11 @@
       }
     };
     return getTmpFile(function(filePath) {
-      var editor, eso, pso, stdinListeners;
-      backlog = repl.line = "";
+      var dirty, editor, eso, pso, stdinListeners;
+      dirty = false;
+      fs.watchFile(filePath, function() {
+        return dirty = true;
+      });
       stdinListeners = stdin.listeners('keypress');
       stdin.removeAllListeners('keypress');
       editor = child_process.spawn(process.env.EDITOR || "vi", [filePath]);
@@ -247,6 +250,7 @@
       });
       return editor.on('exit', function(code) {
         var listener, _i, _len;
+        fs.unwatchFile(filePath);
         stdin.removeListener('data', pso);
         editor.stdout.removeListener('data', eso);
         for (_i = 0, _len = stdinListeners.length; _i < _len; _i++) {
@@ -255,10 +259,13 @@
         }
         if (code === 0) {
           return fs.readFile(filePath, function(error, data) {
-            repl.output.write("\n");
-            repl.output.write(data.toString());
-            backlog += data.toString();
-            return repl._line();
+            if (data && dirty) {
+              backlog = repl.line = "";
+              repl.output.write("\n");
+              repl.output.write(data.toString());
+              backlog += data.toString();
+              return repl._line();
+            }
           });
         }
       });


### PR DESCRIPTION
This is regarding [issue 2247](https://github.com/jashkenas/coffee-script/issues/2247#issuecomment-5085258)

I'm still having issues reattaching listeners to the REPL. I'd like some comments though

To invoke the editor press ctrl+e, defaults to vi if $EDITOR is not set.
