### PR TITLE
Destructured assignment params incorrectly identified as duplicates.

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1867,7 +1867,7 @@
       for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
         obj = _ref2[_i];
         if (obj instanceof Assign) {
-          names.push(obj.variable.base.value);
+          names.push(obj.value.base.value);
         } else if (obj instanceof Splat) {
           names.push(obj.name.unwrap().value);
         } else if (obj.isArray() || obj.isObject()) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1278,7 +1278,7 @@ exports.Param = class Param extends Base
     for obj in name.objects
       # * assignments within destructured parameters `{foo:bar}`
       if obj instanceof Assign
-        names.push obj.variable.base.value
+        names.push obj.value.base.value
       # * splats within destructured parameters `[xs...]`
       else if obj instanceof Splat
         names.push obj.name.unwrap().value

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -95,6 +95,13 @@ test "splats", ->
   arrayEq [0, 1], (((splat..., _, _1) -> splat) 0, 1, 2, 3)
   arrayEq [2], (((_, _1, splat..., _2) -> splat) 0, 1, 2, 3)
 
+test "destructured splatted parameters", ->
+  arr = [0,1,2]
+  splatArray = ([a...]) -> a
+  splatArrayRest = ([a...],b...) -> arrayEq(a,b); b
+  arrayEq splatArray(arr), arr
+  arrayEq splatArrayRest(arr,0,1,2), arr
+
 test "@-parameters: automatically assign an argument's value to a property of the context", ->
   nonce = {}
 

--- a/test/strict.coffee
+++ b/test/strict.coffee
@@ -60,7 +60,7 @@ test "duplicate property definitions in object literals are prohibited", ->
   strict 'o = {x:1,x:1}'
   strict 'x = 1; o = {x, x: 2}'
 
-test "duplicate formal parameter are prohibited", ->
+test "duplicate formal parameters are prohibited", ->
   nonce = {}
 
   # a Param can be an Identifier, ThisProperty( @-param ), Array, or Object
@@ -87,6 +87,8 @@ test "duplicate formal parameter are prohibited", ->
   strict '(_,[_,{__}])->',   'param, [param, {param2}]'
   strict '(_,[__,{_}])->',   'param, [param2, {param}]'
   strict '(__,[_,{_}])->',   'param, [param2, {param2}]'
+  strict '(0:a,1:a)->',      '0:param,1:param'
+  strict '({0:a,1:a})->',    '{0:param,1:param}'
   # the following function expressions should **not** throw errors
   strictOk '({},_arg)->'
   strictOk '({},{})->'
@@ -99,6 +101,8 @@ test "duplicate formal parameter are prohibited", ->
   strictOk '(@case...,_case)->'
   strictOk '(_case,@case)->'
   strictOk '(_case,@case...)->'
+  strictOk '(a:a)->'
+  strictOk '(a:a,a:b)->'
 
 test "`delete` operand restrictions", ->
   strict 'a = 1; delete a'


### PR DESCRIPTION
After my first pass at #2211, @satyr found a bug in `(0: a, 1: a) ->`. It looks like my original implementation didn't correctly identify the `a` identifier as the (so-to-speak) param name. This patch addresses that issue. I also added a specific test for splatted destructured params (the original issue in #2211).
