### PR TITLE
Reapply the removed patch from bugfix_1183 in PR 2252.  Include a test case to show it's required.

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2846,7 +2846,7 @@
       return node instanceof Literal && node.value === 'arguments' && !node.asKey;
     },
     literalThis: function(node) {
-      return (node instanceof Literal && node.value === 'this' && !node.asKey) || (node instanceof Code && node.bound);
+      return (node instanceof Literal && node.value === 'this' && !node.asKey) || (node instanceof Code && node.bound) || (node instanceof Call && node.isSuper);
     }
   };
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1931,7 +1931,8 @@ Closure =
 
   literalThis: (node) ->
     (node instanceof Literal and node.value is 'this' and not node.asKey) or
-      (node instanceof Code and node.bound)
+      (node instanceof Code and node.bound) or
+      (node instanceof Call and node.isSuper)
 
 # Unfold a node's child if soak, then tuck the node under created `If`
 unfoldSoak = (o, parent, name) ->

--- a/test/scope.coffee
+++ b/test/scope.coffee
@@ -77,4 +77,18 @@ test "#1183: super + wrap", ->
     constructor : -> super
   B::m = -> r = try super()
   eq (new B()).m(), 10
+
+test "#1183: super + closures", ->
+  class A
+    constructor: ->
+      @i = 10
+    foo : -> @i
+  class B extends A
+    foo : ->
+      ret = switch 1
+        when 0 then 0
+        when 1 then super()
+      ret
+  eq (new B()).foo(), 10
+ 
   


### PR DESCRIPTION
What's going on: inside of Coffee-generated closures, calling `super()` is implicitly making use of `this` (or explicitly doing so if you look at the output code).  Whenever we use `super()` within a closure, we have to pass `this` through closures as if `@` is being accessed.  The solution is just add one more condition to the list in `Closure::literalThis`
