### PR TITLE
Made a separate file where third-parties can add their extensions...

### DIFF
--- a/src/grammar-extensions.coffee
+++ b/src/grammar-extensions.coffee
@@ -1,0 +1,9 @@
+# This file is where third-parties should add their modifications to the
+# CoffeeScript grammar. Keeping modifications in a separate file makes it easier
+# to pull in updates from the "official" version of CoffeeScript without having
+# to deal with complex merges.
+
+# Takes a single argument, which is an object with two properties: grammar and
+# operators. These are the objects of same name defined in grammar.coffee.
+# They can be modified in-memory here before they are used to create the Parser.
+exports.modifyGrammar = ->

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -16,6 +16,7 @@
 
 # The only dependency is on the **Jison.Parser**.
 {Parser} = require 'jison'
+{modifyGrammar} = require 'grammar-extensions'
 
 # Jison DSL
 # ---------
@@ -575,6 +576,9 @@ operators = [
   ['right',     'IF', 'ELSE', 'FOR', 'WHILE', 'UNTIL', 'LOOP', 'SUPER', 'CLASS']
   ['right',     'POST_IF']
 ]
+
+# Give third-party extensions a chance to modify the CoffeeScript grammar.
+modifyGrammar({grammar, operators})
 
 # Wrapping Up
 # -----------


### PR DESCRIPTION
...to CoffeeScript's grammar.

This is my first step in an attempt to create a maintainable fork of CoffeeScript that supports Closure Library-style annotations. For example, the following CoffeeScript:

```
class Animal
  constructor: (`string` @name) ->

  move: (`number` meters) ->
    alert @name + " moved #{meters}m."
```

Would ideally become:

```
goog.provide('Animal');

/**
 * @param {string} name
 * @constructor
 */
Animal = function(name) {
  this.name = name;
};

/** @param {number} meters */
Animal.prototype.move = function(meters) {
  return alert(this.name + (" moved " + meters + "m."));
};
```
