### PR TITLE
Allow calling functions with a bang!

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -206,6 +206,10 @@
         if (prev && !prev.spaced && tag === '?') {
           token.call = true;
         }
+        if (tag === 'UNARY' && token[1] === '!' && (prev != null) && prev[0] === 'IDENTIFIER' && !prev.spaced) {
+          callObject = true;
+          tokens.splice(i, 1);
+        }
         if (token.fromThen) {
           return 1;
         }

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -181,6 +181,11 @@ class exports.Rewriter
       seenControl = no
       noCall      = no if tag in LINEBREAKS
       token.call  = yes if prev and not prev.spaced and tag is '?'
+
+      if tag is 'UNARY' and token[1] is '!' and prev? and prev[0] is 'IDENTIFIER' and not prev.spaced
+        callObject = true
+        tokens.splice i, 1
+
       return 1 if token.fromThen
       return 1 unless callObject or
         prev?.spaced and (prev.call or prev[0] in IMPLICIT_FUNC) and

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -550,3 +550,12 @@ test "#960: improved 'do'", ->
     eq two, 2
     func
   eq ret, func
+
+test "bang calling a function", ->
+  class Foo
+    bar: -> 3
+
+  foo = new Foo()
+
+  eq 3, foo.bar!
+


### PR DESCRIPTION
This commit adds a little loophole into the rewriter to allow syntax like:

```
class Foo
  bar: ->
    "Bang!"

faz = new Foo!
faz.bar! # Bang!
```

I think it makes extending into objects when you need to use functions a
lot cleaner:

```
Number.prototype.seconds = ->
   this * 1000

4.seconds! # 4000
```

Perhaps it's a case of parens-itis. Or perhaps it's awesome! I
think it'll end up making quick little calls to methods a little less
painful. One character less.

This was originally inspired by @joshuaclayton's tweet:

https://twitter.com/#!/joshuaclayton/statuses/190496586533576705
