### PR TITLE
Wraps up #2211 -- addresses invocations within destructured params

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1872,15 +1872,19 @@
       for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
         obj = _ref2[_i];
         if (obj instanceof Assign) {
-          names.push(obj.value.base.value);
+          names.push(obj.value.unwrap().value);
         } else if (obj instanceof Splat) {
           names.push(obj.name.unwrap().value);
-        } else if (obj.isArray() || obj.isObject()) {
-          names.push.apply(names, this.names(obj.base));
-        } else if (obj["this"]) {
-          names.push.apply(names, atParam(obj));
+        } else if (obj instanceof Value) {
+          if (obj.isArray() || obj.isObject()) {
+            names.push.apply(names, this.names(obj.base));
+          } else if (obj["this"]) {
+            names.push.apply(names, atParam(obj));
+          } else {
+            names.push(obj.base.value);
+          }
         } else {
-          names.push(obj.base.value);
+          throw SyntaxError("illegal parameter " + (obj.compile()));
         }
       }
       return names;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1282,18 +1282,21 @@ exports.Param = class Param extends Base
     for obj in name.objects
       # * assignments within destructured parameters `{foo:bar}`
       if obj instanceof Assign
-        names.push obj.value.base.value
+        names.push obj.value.unwrap().value
       # * splats within destructured parameters `[xs...]`
       else if obj instanceof Splat
         names.push obj.name.unwrap().value
-      # * destructured parameters within destructured parameters `[{a}]`
-      else if obj.isArray() or obj.isObject()
-        names.push @names(obj.base)...
-      # * at-params within destructured parameters `{@foo}`
-      else if obj.this
-        names.push atParam(obj)...
-      # * simple destructured parameters {foo}
-      else names.push obj.base.value
+      else if obj instanceof Value
+        # * destructured parameters within destructured parameters `[{a}]`
+        if obj.isArray() or obj.isObject()
+          names.push @names(obj.base)...
+        # * at-params within destructured parameters `{@foo}`
+        else if obj.this
+          names.push atParam(obj)...
+        # * simple destructured parameters {foo}
+        else names.push obj.base.value
+      else
+        throw SyntaxError "illegal parameter #{obj.compile()}"
     names
 
 #### Splat

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -357,3 +357,11 @@ test '#2211: splats in destructured parameters', ->
   doesNotThrow -> CoffeeScript.compile '([a...],[b...]) ->'
   throws -> CoffeeScript.compile '([a...,[a...]]) ->'
   doesNotThrow -> CoffeeScript.compile '([a...,[b...]]) ->'
+
+test '#2213: invocations within destructured parameters', ->
+  throws -> CoffeeScript.compile '([a()])->'
+  throws -> CoffeeScript.compile '([a:b()])->'
+  throws -> CoffeeScript.compile '([a:b.c()])->'
+  throws -> CoffeeScript.compile '({a()})->'
+  throws -> CoffeeScript.compile '({a:b()})->'
+  throws -> CoffeeScript.compile '({a:b.c()})->'


### PR DESCRIPTION
([2213](https://github.com/jashkenas/coffee-script/pull/2213) refers to the pull request where the remaining issues with the #2211 were discussed.)

Addresses @satyr's `([f()])->` case.

Checks for `Value`s, `Splat`s and `Assigns` as params, and errors on any other type of `node`.
