### PR TITLE
fix repl completion and navigation

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -156,7 +156,7 @@
     return repl.prompt();
   };
 
-  if (stdin.readable) {
+  if (stdin.readable && stdin.isRaw) {
     pipedInput = '';
     repl = {
       prompt: function() {

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -115,7 +115,7 @@ run = (buffer) ->
     error err
   repl.prompt()
 
-if stdin.readable
+if stdin.readable and stdin.isRaw
   # handle piped input
   pipedInput = ''
   repl =


### PR DESCRIPTION
The readline interface of node has changed in [aad12d0](https://github.com/joyent/node/commit/aad12d0) and because of
that the autocompletion and key movement didn't work anymore. This
commit fixes this by checking whether stdin is in raw mode (i.e. invoked
as a script) or not (as a repl).
