### PR TITLE
Allow dashes in identifiers, mangle them.

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -726,7 +726,7 @@
 
   exports.STRICT_PROSCRIBED = STRICT_PROSCRIBED;
 
-  IDENTIFIER = /^([$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff-]*)([^\n\S]*:(?!:))?/;
+  IDENTIFIER = /^([$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*(?:(?:\-[a-zA-Z]+)?)*)([^\n\S]*:(?!:))?/;
 
   NUMBER = /^0b[01]+|^0o[0-7]+|^0x[\da-f]+|^\d*\.?\d+(?:e[+-]?\d+)?/i;
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -598,7 +598,7 @@ exports.STRICT_PROSCRIBED = STRICT_PROSCRIBED
 
 # Token matching regexes.
 IDENTIFIER = /// ^
-  ( [$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff-]* )
+  ( [$A-Za-z_\x7f-\uffff][$\w\x7f-\uffff]*(?:(?:\-[a-zA-Z]+)?)* )
   ( [^\n\S]* : (?!:) )?  # Is this a property name?
 ///
 

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -376,3 +376,6 @@ test 'Identifiers with dashes', ->
   obj.make-greeting = make-greeting
   eq (obj.make-greeting "Ice"), "Hello, Ice"
   eq (obj.makeGreetingSecond "Ice"), "Hello, Ice"
+  number = 10
+  eq number--, 10
+  eq number-- * 2, 18


### PR DESCRIPTION
### Wtf is this shit?

This patch enables using dashes in identifier names and mangles letters after them to uppercase.
E.g. `for-each` would be compiled to `forEach`.

This greatly improves readability sticking to idiomatic js output, because you're able to write code in idiomatic js style and everyone would be able to use it without bullshit.

See [underscores are stupid](http://devblog.avdi.org/2012/05/15/underscores-are-stupid/). tl;dr: you need to use `shift` to write underscores and camelcase etc.
### Simplicity

The main point of this pull request is that when you do shit simply, everything is ok.

One simple rule is used: **identifiers** always mangled. Others aren't.
- `{parse-int}` would be compiled to `{parseInt: parseInt}`.
- `{'parse-int'}` would be compiled to `{'parse-int': 'parse-int'}` because **string ain't an identifier**.
- Same with `object['to-string']`, it's compiled to `object['to-string']`
### What about interoperability with javascript?

> If you always have to do the mental translation between the two names, interoperability suffers

is weak argument because you already need to do mental translation for:
- `yes`, `on` compiles to `true`, `no`, `off` to false
- `return` is automatically applied to every last statement in function and everything is a statement
- there is no `var` so you can accidentally reassign some function and spend a hour looking for the bug
- there are inclusive and exclusive ranges. and `...` / `..` don't give any clarity which one is inclusive.
- there is `isnt` and there is `is not`, but they are not the same
- `for-in` isn't the same as in js, `for-of` isn't the same as in ecmascript 6
- `a- b` vs `a -b`
### Backwards compat

Existing codebases are easy to transfer. Just replace `(\w)([+-*/])(\w)` with `$1 $2 $3` in all files.
### Example 1:

CoffeeScript source rewritten with dashes: https://github.com/paulmillr/coffee-script/tree/topics/use-dashes.

Script used for auto-replacing: https://gist.github.com/2901194.
### Example 2:

``` coffeescript
user = document.query-selector('.user')
user.add-event-listener 'click', ((event) -> console.log event), yes

id = window.set-interval ->
  console.log 'hello'
, 1000
window.set-timeout (-> window.clear-timeout id), 1500

encoded = encode-URI-component string
number = parse-int '5'
string = number.to-string()

page-text = document.query-selector('body').inner-text
logged-in = $('body').has-class 'logged-in'
obj = {a: 1, b: 2}
descriptors = Object.get-own-property-names(obj)
  .map((name) -> Object.get-property-descriptor obj, name)
```

compiles to

``` javascript
var descriptors, encoded, id, loggedIn, number, obj, pageText, string, user;

user = document.querySelector('.user');

user.addEventListener('click', (function(event) {
  return console.log(event);
}), true);

id = window.setInterval(function() {
  return console.log('hello');
}, 1000);

window.setTimeout((function() {
  return window.clearTimeout(id);
}), 1500);

encoded = encodeURIComponent(string);
number = parseInt('5');
string = number.toString();

pageText = document.querySelector('body').innerText;

loggedIn = $('body').hasClass('logged-in');

obj = {
  a: 1,
  b: 2
};

descriptors = Object.getOwnPropertyNames(obj).map(function(name) {
  return Object.getPropertyDescriptor(obj, name);
});
```

Closes #2345. Thanks @goatslacker for initial work.
