### PR TITLE
Add support for UTF8 byte order marker

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -16,7 +16,7 @@
   if (require.extensions) {
     require.extensions['.coffee'] = function(module, filename) {
       var content;
-      content = compile(fs.readFileSync(filename, 'utf8'), {
+      content = compile(fs.readFileSync(filename, 'utf8').replace(/^\uEFBBBF/, ''), {
         filename: filename
       });
       return module._compile(content, filename);

--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -32,7 +32,7 @@
 
   BANNER = 'Usage: coffee [options] path/to/script.coffee -- [args]\n\nIf called without options, `coffee` will run your script.';
 
-  SWITCHES = [['-b', '--bare', 'compile without a top-level function wrapper'], ['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-e', '--eval', 'pass a string from the command line as input'], ['-h', '--help', 'display this help message'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-j', '--join [FILE]', 'concatenate the source CoffeeScript before compiling'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-n', '--nodes', 'print out the parse tree that the parser produces'], ['--nodejs [ARGS]', 'pass options directly to the "node" binary'], ['-o', '--output [DIR]', 'set the output directory for compiled JavaScript'], ['-p', '--print', 'print out the compiled JavaScript'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-t', '--tokens', 'print out the tokens that the lexer/rewriter produce'], ['-v', '--version', 'display the version number'], ['-w', '--watch', 'watch scripts for changes and rerun commands']];
+  SWITCHES = [['-b', '--bare', 'compile without a top-level function wrapper'], ['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-e', '--eval', 'pass a string from the command line as input'], ['-h', '--help', 'display this help message'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-j', '--join [FILE]', 'concatenate the source CoffeeScript before compiling'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-u', '--utf8bom', 'add a UTF8 BOM to the generated JavaScript file'], ['-n', '--nodes', 'print out the parse tree that the parser produces'], ['--nodejs [ARGS]', 'pass options directly to the "node" binary'], ['-o', '--output [DIR]', 'set the output directory for compiled JavaScript'], ['-p', '--print', 'print out the compiled JavaScript'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-t', '--tokens', 'print out the tokens that the lexer/rewriter produce'], ['-v', '--version', 'display the version number'], ['-w', '--watch', 'watch scripts for changes and rerun commands']];
 
   opts = {};
 
@@ -399,8 +399,18 @@
     jsPath = outputPath(source, base);
     jsDir = path.dirname(jsPath);
     compile = function() {
+      var buffer, jsBuffer;
       if (js.length <= 0) {
         js = ' ';
+      }
+      if (opts.utf8bom) {
+        jsBuffer = new Buffer(js);
+        buffer = new Buffer(jsBuffer.length + 3);
+        buffer.writeUInt8(0xEF, 0);
+        buffer.writeUInt8(0xBB, 1);
+        buffer.writeUInt8(0xBF, 2);
+        jsBuffer.copy(buffer, 3);
+        js = buffer;
       }
       return fs.writeFile(jsPath, js, function(err) {
         if (err) {

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -15,7 +15,7 @@ vm               = require 'vm'
 # TODO: Remove registerExtension when fully deprecated.
 if require.extensions
   require.extensions['.coffee'] = (module, filename) ->
-    content = compile fs.readFileSync(filename, 'utf8'), {filename}
+    content = compile fs.readFileSync(filename, 'utf8').replace(/^\uEFBBBF/, ''), {filename}
     module._compile content, filename
 else if require.registerExtension
   require.registerExtension '.coffee', (content) -> compile content

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -37,6 +37,7 @@ SWITCHES = [
   ['-i', '--interactive',     'run an interactive CoffeeScript REPL']
   ['-j', '--join [FILE]',     'concatenate the source CoffeeScript before compiling']
   ['-l', '--lint',            'pipe the compiled JavaScript through JavaScript Lint']
+  ['-u', '--utf8bom',         'add a UTF8 BOM to the generated JavaScript file']
   ['-n', '--nodes',           'print out the parse tree that the parser produces']
   [      '--nodejs [ARGS]',   'pass options directly to the "node" binary']
   ['-o', '--output [DIR]',    'set the output directory for compiled JavaScript']
@@ -269,6 +270,15 @@ writeJs = (source, js, base) ->
   jsDir  = path.dirname jsPath
   compile = ->
     js = ' ' if js.length <= 0
+    if opts.utf8bom
+      jsBuffer = new Buffer(js)
+      buffer = new Buffer(jsBuffer.length+3)
+      buffer.writeUInt8 0xEF, 0
+      buffer.writeUInt8 0xBB, 1
+      buffer.writeUInt8 0xBF, 2
+      jsBuffer.copy(buffer, 3)
+      js = buffer
+
     fs.writeFile jsPath, js, (err) ->
       if err
         printLine err.message


### PR DESCRIPTION
This commits adds support for UTF8 byte order markers. It works in two ways:
- .coffee files containing a BOM will filter it out, preventing it from appearing in the middle of the generated JavaScript
- when writing .js files, an optional command line switch -u or --utf8bom will prepend a BOM to the generated file

This is somewhat of a hot fix because post-processing the generated files with iconv takes too much time out of our build process, but maybe some other users find this useful, too.

CC @pke @superquadratic @doo 
