### PR TITLE
Strip UTF-8 BOM when require'ing .coffee modules.

### DIFF
--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -12,10 +12,13 @@ path             = require 'path'
 {parser}         = require './parser'
 vm               = require 'vm'
 
+stripBOM = (content) ->
+  if content.charCodeAt 0 is 0xFEFF then content.substring 1 else content
+
 # TODO: Remove registerExtension when fully deprecated.
 if require.extensions
   require.extensions['.coffee'] = (module, filename) ->
-    content = compile fs.readFileSync(filename, 'utf8'), {filename}
+    content = compile stripBOM fs.readFileSync(filename, 'utf8'), {filename}
     module._compile content, filename
 else if require.registerExtension
   require.registerExtension '.coffee', (content) -> compile content


### PR DESCRIPTION
Allows people to author their .coffee files with UTF-8 BOMs at the start, because sometimes that happens. Fixes #798.
