### PR TITLE
Added _this and _super to reserved words list

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -579,7 +579,7 @@ RESERVED = [
   'case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum'
   'export', 'import', 'native', '__hasProp', '__extends', '__slice', '__bind'
   '__indexOf', 'implements', 'interface', 'package', 'private', 'protected'
-  'public', 'static', 'yield'
+  'public', 'static', 'yield', '_this', '_this', '_super'
 ]
 
 STRICT_PROSCRIBED = ['arguments', 'eval']


### PR DESCRIPTION
If you use either of these words in your code you are asking for trouble. It will be nice if CoffeeScript does the 2-pass parser thing at some point so this isn't needed but for now this will reduce unexpected annoying things :)
