### PR TITLE
baseDir truncated when running coffee compiler with options 'coffee -co ../js ./

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -258,9 +258,11 @@ removeSource = (source, base, removeJs) ->
 # Get the corresponding output JavaScript path for a source file.
 outputPath = (source, base) ->
   filename  = path.basename(source, path.extname(source)) + '.js'
+  cwdDir = process.cwd()
   srcDir    = path.dirname source
-  baseDir   = if base is '.' or base is './' then srcDir else srcDir.substring base.length
-  dir       = if opts.output then path.join opts.output, baseDir else srcDir
+  baseDir = path.resolve(cwdDir, srcDir)
+  srcSubDir = path.relative(base, baseDir)
+  dir       = if opts.output then path.resolve(cwdDir, opts.output, srcSubDir) else srcDir
   path.join dir, filename
 
 # Write out a JavaScript source file with the compiled code. By default, files


### PR DESCRIPTION
I used those directory structure in my projects:

```
 ./
├── js
└── src
    ├── collections
    │   └── init.coffee
    ├── models
    │   └── init.coffee
    └── views
        └── init.coffee
```

I changed current directory to src and run coffee compiler with options `-co ../js ./`

And got truncated directories names:

```
./
├── js
│   ├── dels
│   │   └── init.js
│   ├── ews
│   │   └── init.js
│   └── llections
│       └── init.js
└── src
    ├── collections
    │   └── init.coffee
    ├── models
    │   └── init.coffee
    └── views
        └── init.coffee
```

As I know _dot-slash_ also (as is _dot_) used for reference to current directory.
