### PR TITLE
Issue #2359 fix: avoid "other typed" constructors

### DIFF
--- a/lib/coffee-script/grammar.js
+++ b/lib/coffee-script/grammar.js
@@ -15,6 +15,7 @@
     action = (match = unwrap.exec(action)) ? match[1] : "(" + action + "())";
     action = action.replace(/\bnew /g, '$&yy.');
     action = action.replace(/\b(?:Block\.wrap|extend)\b/g, 'yy.$&');
+    action = action.replace(/\b(Op|Value\.create)\b/g, 'yy.$&');
     return [patternString, "$$ = " + action + ";", options];
   };
 
@@ -83,12 +84,12 @@
     ],
     AssignObj: [
       o('ObjAssignable', function() {
-        return new Value($1);
+        return Value.create($1);
       }), o('ObjAssignable : Expression', function() {
-        return new Assign(new Value($1), $3, 'object');
+        return new Assign(Value.create($1), $3, 'object');
       }), o('ObjAssignable :\
        INDENT Expression OUTDENT', function() {
-        return new Assign(new Value($1), $4, 'object');
+        return new Assign(Value.create($1), $4, 'object');
       }), o('Comment')
     ],
     ObjAssignable: [o('Identifier'), o('AlphaNumeric'), o('ThisProperty')],
@@ -149,27 +150,27 @@
     ],
     SimpleAssignable: [
       o('Identifier', function() {
-        return new Value($1);
+        return Value.create($1);
       }), o('Value Accessor', function() {
         return $1.add($2);
       }), o('Invocation Accessor', function() {
-        return new Value($1, [].concat($2));
+        return Value.create($1, [].concat($2));
       }), o('ThisProperty')
     ],
     Assignable: [
       o('SimpleAssignable'), o('Array', function() {
-        return new Value($1);
+        return Value.create($1);
       }), o('Object', function() {
-        return new Value($1);
+        return Value.create($1);
       })
     ],
     Value: [
       o('Assignable'), o('Literal', function() {
-        return new Value($1);
+        return Value.create($1);
       }), o('Parenthetical', function() {
-        return new Value($1);
+        return Value.create($1);
       }), o('Range', function() {
-        return new Value($1);
+        return Value.create($1);
       }), o('This')
     ],
     Accessor: [
@@ -263,14 +264,14 @@
     ],
     This: [
       o('THIS', function() {
-        return new Value(new Literal('this'));
+        return Value.create(new Literal('this'));
       }), o('@', function() {
-        return new Value(new Literal('this'));
+        return Value.create(new Literal('this'));
       })
     ],
     ThisProperty: [
       o('@ Identifier', function() {
-        return new Value(new Literal('this'), [new Access($2)], 'this');
+        return Value.create(new Literal('this'), [new Access($2)], 'this');
       })
     ],
     Array: [
@@ -337,7 +338,7 @@
       o('CATCH Identifier Block', function() {
         return [$2, $3];
       }), o('CATCH Object Block', function() {
-        return [new Value($2), $3];
+        return [Value.create($2), $3];
       })
     ],
     Throw: [
@@ -400,7 +401,7 @@
     ForBody: [
       o('FOR Range', function() {
         return {
-          source: new Value($2)
+          source: Value.create($2)
         };
       }), o('ForStart ForSource', function() {
         $2.own = $1.own;
@@ -419,9 +420,9 @@
     ],
     ForValue: [
       o('Identifier'), o('ThisProperty'), o('Array', function() {
-        return new Value($1);
+        return Value.create($1);
       }), o('Object', function() {
-        return new Value($1);
+        return Value.create($1);
       })
     ],
     ForVariables: [
@@ -522,42 +523,42 @@
     ],
     Operation: [
       o('UNARY Expression', function() {
-        return new Op($1, $2);
+        return Op.create($1, $2);
       }), o('-     Expression', (function() {
-        return new Op('-', $2);
+        return Op.create('-', $2);
       }), {
         prec: 'UNARY'
       }), o('+     Expression', (function() {
-        return new Op('+', $2);
+        return Op.create('+', $2);
       }), {
         prec: 'UNARY'
       }), o('-- SimpleAssignable', function() {
-        return new Op('--', $2);
+        return Op.create('--', $2);
       }), o('++ SimpleAssignable', function() {
-        return new Op('++', $2);
+        return Op.create('++', $2);
       }), o('SimpleAssignable --', function() {
-        return new Op('--', $1, null, true);
+        return Op.create('--', $1, null, true);
       }), o('SimpleAssignable ++', function() {
-        return new Op('++', $1, null, true);
+        return Op.create('++', $1, null, true);
       }), o('Expression ?', function() {
         return new Existence($1);
       }), o('Expression +  Expression', function() {
-        return new Op('+', $1, $3);
+        return Op.create('+', $1, $3);
       }), o('Expression -  Expression', function() {
-        return new Op('-', $1, $3);
+        return Op.create('-', $1, $3);
       }), o('Expression MATH     Expression', function() {
-        return new Op($2, $1, $3);
+        return Op.create($2, $1, $3);
       }), o('Expression SHIFT    Expression', function() {
-        return new Op($2, $1, $3);
+        return Op.create($2, $1, $3);
       }), o('Expression COMPARE  Expression', function() {
-        return new Op($2, $1, $3);
+        return Op.create($2, $1, $3);
       }), o('Expression LOGIC    Expression', function() {
-        return new Op($2, $1, $3);
+        return Op.create($2, $1, $3);
       }), o('Expression RELATION Expression', function() {
         if ($2.charAt(0) === '!') {
-          return new Op($2.slice(1), $1, $3).invert();
+          return Op.create($2.slice(1), $1, $3).invert();
         } else {
-          return new Op($2, $1, $3);
+          return Op.create($2, $1, $3);
         }
       }), o('SimpleAssignable COMPOUND_ASSIGN\
        Expression', function() {

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -170,7 +170,7 @@
     };
 
     Base.prototype.invert = function() {
-      return new Op('!', this);
+      return Op.create('!', this);
     };
 
     Base.prototype.unwrapAll = function() {
@@ -583,16 +583,21 @@
 
     __extends(Value, _super);
 
-    function Value(base, props, tag) {
+    Value.create = function(base, props, tag) {
       if (!props && base instanceof Value) {
         return base;
+      } else {
+        return new Value(base, props, tag);
       }
+    };
+
+    function Value(base, properties, tag) {
       this.base = base;
-      this.properties = props || [];
+      this.properties = properties;
+      this.properties || (this.properties = []);
       if (tag) {
         this[tag] = true;
       }
-      return this;
     }
 
     Value.prototype.children = ['base', 'properties'];
@@ -675,10 +680,10 @@
       if (this.properties.length < 2 && !this.base.isComplex() && !(name != null ? name.isComplex() : void 0)) {
         return [this, this];
       }
-      base = new Value(this.base, this.properties.slice(0, -1));
+      base = Value.create(this.base, this.properties.slice(0, -1));
       if (base.isComplex()) {
         bref = new Literal(o.scope.freeVariable('base'));
-        base = new Value(new Parens(new Assign(bref, base)));
+        base = Value.create(new Parens(new Assign(bref, base)));
       }
       if (!name) {
         return [base, bref];
@@ -688,7 +693,7 @@
         name = new Index(new Assign(nref, name.index));
         nref = new Index(nref);
       }
-      return [base.add(name), new Value(bref || base.base, [nref || name])];
+      return [base.add(name), Value.create(bref || base.base, [nref || name])];
     };
 
     Value.prototype.compileNode = function(o) {
@@ -725,8 +730,8 @@
             continue;
           }
           prop.soak = false;
-          fst = new Value(_this.base, _this.properties.slice(0, i));
-          snd = new Value(_this.base, _this.properties.slice(i));
+          fst = Value.create(_this.base, _this.properties.slice(0, i));
+          snd = Value.create(_this.base, _this.properties.slice(i));
           if (fst.isComplex()) {
             ref = new Literal(o.scope.freeVariable('ref'));
             fst = new Parens(new Assign(ref, fst));
@@ -811,7 +816,7 @@
           accesses.push(new Access(new Literal('constructor')));
         }
         accesses.push(new Access(new Literal(name)));
-        return (new Value(new Literal(method.klass), accesses)).compile(o);
+        return (Value.create(new Literal(method.klass), accesses)).compile(o);
       } else {
         return "" + name + ".__super__.constructor";
       }
@@ -830,15 +835,15 @@
           if (ifn = unfoldSoak(o, this, 'variable')) {
             return ifn;
           }
-          _ref2 = new Value(this.variable).cacheReference(o), left = _ref2[0], rite = _ref2[1];
+          _ref2 = Value.create(this.variable).cacheReference(o), left = _ref2[0], rite = _ref2[1];
         } else {
           left = new Literal(this.superReference(o));
-          rite = new Value(left);
+          rite = Value.create(left);
         }
         rite = new Call(rite, this.args);
         rite.isNew = this.isNew;
         left = new Literal("typeof " + (left.compile(o)) + " === \"function\"");
-        return new If(left, new Value(rite), {
+        return new If(left, Value.create(rite), {
           soak: true
         });
       }
@@ -938,7 +943,7 @@
         idt = this.tab + TAB;
         return "(function(func, args, ctor) {\n" + idt + "ctor.prototype = func.prototype;\n" + idt + "var child = new ctor, result = func.apply(child, args);\n" + idt + "return Object(result) === result ? result : child;\n" + this.tab + "})(" + (this.variable.compile(o, LEVEL_LIST)) + ", " + splatArgs + ", function(){})";
       }
-      base = new Value(this.variable);
+      base = Value.create(this.variable);
       if ((name = base.properties.pop()) && base.isComplex()) {
         ref = o.scope.freeVariable('ref');
         fun = "(" + ref + " = " + (base.compile(o, LEVEL_LIST)) + ")" + (name.compile(o));
@@ -973,7 +978,7 @@
     Extends.prototype.children = ['child', 'parent'];
 
     Extends.prototype.compile = function(o) {
-      return new Call(new Value(new Literal(utility('extends'))), [this.child, this.parent]).compile(o);
+      return new Call(Value.create(new Literal(utility('extends'))), [this.child, this.parent]).compile(o);
     };
 
     return Extends;
@@ -1332,7 +1337,7 @@
         _results = [];
         for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
           bvar = _ref2[_i];
-          lhs = (new Value(new Literal("this"), [new Access(bvar)])).compile(o);
+          lhs = (Value.create(new Literal("this"), [new Access(bvar)])).compile(o);
           _results.push(this.ctor.body.unshift(new Literal("" + lhs + " = " + (utility('bind')) + "(" + lhs + ", this)")));
         }
         return _results;
@@ -1370,7 +1375,7 @@
                   func.context = name;
                 }
               } else {
-                assign.variable = new Value(new Literal(name), [new Access(new Literal('prototype')), new Access(base)]);
+                assign.variable = Value.create(new Literal(name), [new Access(new Literal('prototype')), new Access(base)]);
                 if (func instanceof Code && func.bound) {
                   this.boundFuncs.push(base);
                   func.bound = false;
@@ -1415,7 +1420,8 @@
       return this.directives = expressions.splice(0, index);
     };
 
-    Class.prototype.ensureConstructor = function(name) {
+    Class.prototype.ensureConstructor = function(name, o) {
+      var returnExpr;
       if (!this.ctor) {
         this.ctor = new Code;
         if (this.parent) {
@@ -1428,7 +1434,16 @@
       }
       this.ctor.ctor = this.ctor.name = name;
       this.ctor.klass = null;
-      return this.ctor.noReturn = true;
+      this.ctor.noReturn = true;
+      returnExpr = null;
+      this.ctor.body.traverseChildren(false, function(node) {
+        if (node instanceof Return && (returnExpr = node.expression)) {
+          return false;
+        }
+      });
+      if (returnExpr) {
+        throw SyntaxError("cannot return a value from a constructor: \"" + (returnExpr.compileNode(o)) + "\" in class " + name);
+      }
     };
 
     Class.prototype.compileNode = function(o) {
@@ -1442,7 +1457,7 @@
       this.hoistDirectivePrologue();
       this.setContext(name);
       this.walkBody(name, o);
-      this.ensureConstructor(name);
+      this.ensureConstructor(name, o);
       this.body.spaced = true;
       if (!(this.ctor instanceof Code)) {
         this.body.expressions.unshift(this.ctor);
@@ -1563,13 +1578,13 @@
           _ref2 = obj, (_ref3 = _ref2.variable, idx = _ref3.base), obj = _ref2.value;
         } else {
           if (obj.base instanceof Parens) {
-            _ref4 = new Value(obj.unwrapAll()).cacheReference(o), obj = _ref4[0], idx = _ref4[1];
+            _ref4 = Value.create(obj.unwrapAll()).cacheReference(o), obj = _ref4[0], idx = _ref4[1];
           } else {
             idx = isObject ? obj["this"] ? obj.properties[0].name : obj : new Literal(0);
           }
         }
         acc = IDENTIFIER.test(idx.unwrap().value || 0);
-        value = new Value(value);
+        value = Value.create(value);
         value.properties.push(new (acc ? Access : Index)(idx));
         if (_ref5 = obj.unwrap().value, __indexOf.call(RESERVED, _ref5) >= 0) {
           throw new SyntaxError("assignment to a reserved word: " + (obj.compile(o)) + " = " + (value.compile(o)));
@@ -1593,7 +1608,7 @@
             _ref6 = obj, (_ref7 = _ref6.variable, idx = _ref7.base), obj = _ref6.value;
           } else {
             if (obj.base instanceof Parens) {
-              _ref8 = new Value(obj.unwrapAll()).cacheReference(o), obj = _ref8[0], idx = _ref8[1];
+              _ref8 = Value.create(obj.unwrapAll()).cacheReference(o), obj = _ref8[0], idx = _ref8[1];
             } else {
               idx = obj["this"] ? obj.properties[0].name : obj;
             }
@@ -1623,7 +1638,7 @@
           } else {
             acc = isObject && IDENTIFIER.test(idx.unwrap().value || 0);
           }
-          val = new Value(new Literal(vvar), [new (acc ? Access : Index)(idx)]);
+          val = Value.create(new Literal(vvar), [new (acc ? Access : Index)(idx)]);
         }
         if ((name != null) && __indexOf.call(RESERVED, name) >= 0) {
           throw new SyntaxError("assignment to a reserved word: " + (obj.compile(o)) + " = " + (val.compile(o)));
@@ -1653,7 +1668,7 @@
       if (__indexOf.call(this.context, "?") >= 0) {
         o.isExistentialEquals = true;
       }
-      return new Op(this.context.slice(0, -1), left, new Assign(right, this.value, '=')).compile(o);
+      return Op.create(this.context.slice(0, -1), left, new Assign(right, this.value, '=')).compile(o);
     };
 
     Assign.prototype.compileSplice = function(o) {
@@ -1742,7 +1757,7 @@
             o.scope.add(p.value, 'var', true);
           }
         }
-        splats = new Assign(new Value(new Arr((function() {
+        splats = new Assign(Value.create(new Arr((function() {
           var _l, _len3, _ref5, _results;
           _ref5 = this.params;
           _results = [];
@@ -1751,7 +1766,7 @@
             _results.push(p.asReference(o));
           }
           return _results;
-        }).call(this))), new Value(new Literal('arguments')));
+        }).call(this))), Value.create(new Literal('arguments')));
         break;
       }
       _ref5 = this.params;
@@ -1760,16 +1775,16 @@
         if (param.isComplex()) {
           val = ref = param.asReference(o);
           if (param.value) {
-            val = new Op('?', ref, param.value);
+            val = Op.create('?', ref, param.value);
           }
-          exprs.push(new Assign(new Value(param.name), val, '=', {
+          exprs.push(new Assign(Value.create(param.name), val, '=', {
             param: true
           }));
         } else {
           ref = param;
           if (param.value) {
             lit = new Literal(ref.name.value + ' == null');
-            val = new Assign(new Value(param.name), param.value, '=');
+            val = new Assign(Value.create(param.name), param.value, '=');
             exprs.push(new If(lit, val));
           }
         }
@@ -1882,7 +1897,7 @@
       } else if (node.isComplex()) {
         node = new Literal(o.scope.freeVariable('arg'));
       }
-      node = new Value(node);
+      node = Value.create(node);
       if (this.splat) {
         node = new Splat(node);
       }
@@ -2095,7 +2110,7 @@
 
     __extends(Op, _super);
 
-    function Op(op, first, second, flip) {
+    Op.create = function(op, first, second, flip) {
       if (op === 'in') {
         return new In(first, second);
       }
@@ -2110,11 +2125,14 @@
           first = new Parens(first);
         }
       }
-      this.operator = CONVERSIONS[op] || op;
+      return new Op(op, first, second, flip);
+    };
+
+    function Op(op, first, second, flip) {
       this.first = first;
       this.second = second;
+      this.operator = CONVERSIONS[op] || op;
       this.flip = !!flip;
-      return this;
     }
 
     CONVERSIONS = {
@@ -2176,7 +2194,7 @@
       } else if (this.operator === '!' && (fst = this.first.unwrap()) instanceof Op && ((_ref2 = fst.operator) === '!' || _ref2 === 'in' || _ref2 === 'instanceof')) {
         return fst;
       } else {
-        return new Op('!', this);
+        return Op.create('!', this);
       }
     };
 
@@ -2185,7 +2203,7 @@
       return ((_ref2 = this.operator) === '++' || _ref2 === '--' || _ref2 === 'delete') && unfoldSoak(o, this, 'first');
     };
 
-    Op.prototype.generateDo = function(exp) {
+    Op.generateDo = function(exp) {
       var call, func, param, passedParams, ref, _i, _len, _ref2;
       passedParams = [];
       func = exp instanceof Assign && (ref = exp.value.unwrap()) instanceof Code ? ref : exp;
@@ -2662,7 +2680,7 @@
         }
         fn = ((_ref6 = val.base) != null ? _ref6.unwrapAll() : void 0) || val;
         ref = new Literal(o.scope.freeVariable('fn'));
-        base = new Value(ref);
+        base = Value.create(ref);
         if (val.base) {
           _ref7 = [base, val], val.base = _ref7[0], base = _ref7[1];
         }
@@ -2890,7 +2908,7 @@
         if (mentionsArgs) {
           args.push(new Literal('arguments'));
         }
-        func = new Value(func, [new Access(meth)]);
+        func = Value.create(func, [new Access(meth)]);
       }
       func.noReturn = noReturn;
       call = new Call(func, args);
@@ -2914,7 +2932,7 @@
       return;
     }
     parent[name] = ifn.body;
-    ifn.body = new Value(parent);
+    ifn.body = Value.create(parent);
     return ifn;
   };
 

--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -1,6 +1,5 @@
 /* Jison generated parser */
 var parser = (function(){
-undefined
 var parser = {trace: function trace() { },
 yy: {},
 symbols_: {"error":2,"Root":3,"Body":4,"Block":5,"TERMINATOR":6,"Line":7,"Expression":8,"Statement":9,"Return":10,"Comment":11,"STATEMENT":12,"Value":13,"Invocation":14,"Code":15,"Operation":16,"Assign":17,"If":18,"Try":19,"While":20,"For":21,"Switch":22,"Class":23,"Throw":24,"INDENT":25,"OUTDENT":26,"Identifier":27,"IDENTIFIER":28,"AlphaNumeric":29,"NUMBER":30,"STRING":31,"Literal":32,"JS":33,"REGEX":34,"DEBUGGER":35,"UNDEFINED":36,"NULL":37,"BOOL":38,"Assignable":39,"=":40,"AssignObj":41,"ObjAssignable":42,":":43,"ThisProperty":44,"RETURN":45,"HERECOMMENT":46,"PARAM_START":47,"ParamList":48,"PARAM_END":49,"FuncGlyph":50,"->":51,"=>":52,"OptComma":53,",":54,"Param":55,"ParamVar":56,"...":57,"Array":58,"Object":59,"Splat":60,"SimpleAssignable":61,"Accessor":62,"Parenthetical":63,"Range":64,"This":65,".":66,"?.":67,"::":68,"Index":69,"INDEX_START":70,"IndexValue":71,"INDEX_END":72,"INDEX_SOAK":73,"Slice":74,"{":75,"AssignList":76,"}":77,"CLASS":78,"EXTENDS":79,"OptFuncExist":80,"Arguments":81,"SUPER":82,"FUNC_EXIST":83,"CALL_START":84,"CALL_END":85,"ArgList":86,"THIS":87,"@":88,"[":89,"]":90,"RangeDots":91,"..":92,"Arg":93,"SimpleArgs":94,"TRY":95,"Catch":96,"FINALLY":97,"CATCH":98,"THROW":99,"(":100,")":101,"WhileSource":102,"WHILE":103,"WHEN":104,"UNTIL":105,"Loop":106,"LOOP":107,"ForBody":108,"FOR":109,"ForStart":110,"ForSource":111,"ForVariables":112,"OWN":113,"ForValue":114,"FORIN":115,"FOROF":116,"BY":117,"SWITCH":118,"Whens":119,"ELSE":120,"When":121,"LEADING_WHEN":122,"IfBlock":123,"IF":124,"POST_IF":125,"UNARY":126,"-":127,"+":128,"--":129,"++":130,"?":131,"MATH":132,"SHIFT":133,"COMPARE":134,"LOGIC":135,"RELATION":136,"COMPOUND_ASSIGN":137,"$accept":0,"$end":1},
@@ -86,11 +85,11 @@ case 37:this.$ = new yy.Assign($$[$0-3], $$[$0]);
 break;
 case 38:this.$ = new yy.Assign($$[$0-4], $$[$0-1]);
 break;
-case 39:this.$ = new yy.Value($$[$0]);
+case 39:this.$ = yy.Value.create($$[$0]);
 break;
-case 40:this.$ = new yy.Assign(new yy.Value($$[$0-2]), $$[$0], 'object');
+case 40:this.$ = new yy.Assign(yy.Value.create($$[$0-2]), $$[$0], 'object');
 break;
-case 41:this.$ = new yy.Assign(new yy.Value($$[$0-4]), $$[$0-1], 'object');
+case 41:this.$ = new yy.Assign(yy.Value.create($$[$0-4]), $$[$0-1], 'object');
 break;
 case 42:this.$ = $$[$0];
 break;
@@ -144,27 +143,27 @@ case 66:this.$ = $$[$0];
 break;
 case 67:this.$ = new yy.Splat($$[$0-1]);
 break;
-case 68:this.$ = new yy.Value($$[$0]);
+case 68:this.$ = yy.Value.create($$[$0]);
 break;
 case 69:this.$ = $$[$0-1].add($$[$0]);
 break;
-case 70:this.$ = new yy.Value($$[$0-1], [].concat($$[$0]));
+case 70:this.$ = yy.Value.create($$[$0-1], [].concat($$[$0]));
 break;
 case 71:this.$ = $$[$0];
 break;
 case 72:this.$ = $$[$0];
 break;
-case 73:this.$ = new yy.Value($$[$0]);
+case 73:this.$ = yy.Value.create($$[$0]);
 break;
-case 74:this.$ = new yy.Value($$[$0]);
+case 74:this.$ = yy.Value.create($$[$0]);
 break;
 case 75:this.$ = $$[$0];
 break;
-case 76:this.$ = new yy.Value($$[$0]);
+case 76:this.$ = yy.Value.create($$[$0]);
 break;
-case 77:this.$ = new yy.Value($$[$0]);
+case 77:this.$ = yy.Value.create($$[$0]);
 break;
-case 78:this.$ = new yy.Value($$[$0]);
+case 78:this.$ = yy.Value.create($$[$0]);
 break;
 case 79:this.$ = $$[$0];
 break;
@@ -232,11 +231,11 @@ case 109:this.$ = [];
 break;
 case 110:this.$ = $$[$0-2];
 break;
-case 111:this.$ = new yy.Value(new yy.Literal('this'));
+case 111:this.$ = yy.Value.create(new yy.Literal('this'));
 break;
-case 112:this.$ = new yy.Value(new yy.Literal('this'));
+case 112:this.$ = yy.Value.create(new yy.Literal('this'));
 break;
-case 113:this.$ = new yy.Value(new yy.Literal('this'), [new yy.Access($$[$0])], 'this');
+case 113:this.$ = yy.Value.create(new yy.Literal('this'), [new yy.Access($$[$0])], 'this');
 break;
 case 114:this.$ = new yy.Arr([]);
 break;
@@ -284,7 +283,7 @@ case 135:this.$ = new yy.Try($$[$0-3], $$[$0-2][0], $$[$0-2][1], $$[$0]);
 break;
 case 136:this.$ = [$$[$0-1], $$[$0]];
 break;
-case 137:this.$ = [new yy.Value($$[$0-1]), $$[$0]];
+case 137:this.$ = [yy.Value.create($$[$0-1]), $$[$0]];
 break;
 case 138:this.$ = new yy.Throw($$[$0]);
 break;
@@ -326,7 +325,7 @@ break;
 case 153:this.$ = new yy.For($$[$0], $$[$0-1]);
 break;
 case 154:this.$ = {
-          source: new yy.Value($$[$0])
+          source: yy.Value.create($$[$0])
         };
 break;
 case 155:this.$ = (function () {
@@ -347,9 +346,9 @@ case 158:this.$ = $$[$0];
 break;
 case 159:this.$ = $$[$0];
 break;
-case 160:this.$ = new yy.Value($$[$0]);
+case 160:this.$ = yy.Value.create($$[$0]);
 break;
-case 161:this.$ = new yy.Value($$[$0]);
+case 161:this.$ = yy.Value.create($$[$0]);
 break;
 case 162:this.$ = [$$[$0]];
 break;
@@ -430,39 +429,39 @@ case 184:this.$ = new yy.If($$[$0], yy.Block.wrap([$$[$0-2]]), {
           statement: true
         });
 break;
-case 185:this.$ = new yy.Op($$[$0-1], $$[$0]);
+case 185:this.$ = yy.Op.create($$[$0-1], $$[$0]);
 break;
-case 186:this.$ = new yy.Op('-', $$[$0]);
+case 186:this.$ = yy.Op.create('-', $$[$0]);
 break;
-case 187:this.$ = new yy.Op('+', $$[$0]);
+case 187:this.$ = yy.Op.create('+', $$[$0]);
 break;
-case 188:this.$ = new yy.Op('--', $$[$0]);
+case 188:this.$ = yy.Op.create('--', $$[$0]);
 break;
-case 189:this.$ = new yy.Op('++', $$[$0]);
+case 189:this.$ = yy.Op.create('++', $$[$0]);
 break;
-case 190:this.$ = new yy.Op('--', $$[$0-1], null, true);
+case 190:this.$ = yy.Op.create('--', $$[$0-1], null, true);
 break;
-case 191:this.$ = new yy.Op('++', $$[$0-1], null, true);
+case 191:this.$ = yy.Op.create('++', $$[$0-1], null, true);
 break;
 case 192:this.$ = new yy.Existence($$[$0-1]);
 break;
-case 193:this.$ = new yy.Op('+', $$[$0-2], $$[$0]);
+case 193:this.$ = yy.Op.create('+', $$[$0-2], $$[$0]);
 break;
-case 194:this.$ = new yy.Op('-', $$[$0-2], $$[$0]);
+case 194:this.$ = yy.Op.create('-', $$[$0-2], $$[$0]);
 break;
-case 195:this.$ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+case 195:this.$ = yy.Op.create($$[$0-1], $$[$0-2], $$[$0]);
 break;
-case 196:this.$ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+case 196:this.$ = yy.Op.create($$[$0-1], $$[$0-2], $$[$0]);
 break;
-case 197:this.$ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+case 197:this.$ = yy.Op.create($$[$0-1], $$[$0-2], $$[$0]);
 break;
-case 198:this.$ = new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+case 198:this.$ = yy.Op.create($$[$0-1], $$[$0-2], $$[$0]);
 break;
 case 199:this.$ = (function () {
         if ($$[$0-1].charAt(0) === '!') {
-          return new yy.Op($$[$0-1].slice(1), $$[$0-2], $$[$0]).invert();
+          return yy.Op.create($$[$0-1].slice(1), $$[$0-2], $$[$0]).invert();
         } else {
-          return new yy.Op($$[$0-1], $$[$0-2], $$[$0]);
+          return yy.Op.create($$[$0-1], $$[$0-2], $$[$0]);
         }
       }());
 break;
@@ -480,202 +479,125 @@ parseError: function parseError(str, hash) {
     throw new Error(str);
 },
 parse: function parse(input) {
-    var self = this,
-        stack = [0],
-        vstack = [null], // semantic value stack
-        lstack = [], // location stack
-        table = this.table,
-        yytext = '',
-        yylineno = 0,
-        yyleng = 0,
-        recovering = 0,
-        TERROR = 2,
-        EOF = 1;
-
-    //this.reductionCount = this.shiftCount = 0;
-
+    var self = this, stack = [0], vstack = [null], lstack = [], table = this.table, yytext = "", yylineno = 0, yyleng = 0, recovering = 0, TERROR = 2, EOF = 1;
     this.lexer.setInput(input);
     this.lexer.yy = this.yy;
     this.yy.lexer = this.lexer;
-    if (typeof this.lexer.yylloc == 'undefined')
+    this.yy.parser = this;
+    if (typeof this.lexer.yylloc == "undefined")
         this.lexer.yylloc = {};
     var yyloc = this.lexer.yylloc;
     lstack.push(yyloc);
-
-    if (typeof this.yy.parseError === 'function')
+    var ranges = this.lexer.options && this.lexer.options.ranges;
+    if (typeof this.yy.parseError === "function")
         this.parseError = this.yy.parseError;
-
-    function popStack (n) {
-        stack.length = stack.length - 2*n;
+    function popStack(n) {
+        stack.length = stack.length - 2 * n;
         vstack.length = vstack.length - n;
         lstack.length = lstack.length - n;
     }
-
     function lex() {
         var token;
-        token = self.lexer.lex() || 1; // $end = 1
-        // if token isn't its numeric value, convert
-        if (typeof token !== 'number') {
+        token = self.lexer.lex() || 1;
+        if (typeof token !== "number") {
             token = self.symbols_[token] || token;
         }
         return token;
     }
-
-    var symbol, preErrorSymbol, state, action, a, r, yyval={},p,len,newState, expected;
+    var symbol, preErrorSymbol, state, action, a, r, yyval = {}, p, len, newState, expected;
     while (true) {
-        // retreive state number from top of stack
-        state = stack[stack.length-1];
-
-        // use default actions if available
+        state = stack[stack.length - 1];
         if (this.defaultActions[state]) {
             action = this.defaultActions[state];
         } else {
-            if (symbol == null)
+            if (symbol === null || typeof symbol == "undefined") {
                 symbol = lex();
-            // read action for current state and first input
+            }
             action = table[state] && table[state][symbol];
         }
-
-        // handle parse error
-        _handle_error:
-        if (typeof action === 'undefined' || !action.length || !action[0]) {
-
+        if (typeof action === "undefined" || !action.length || !action[0]) {
+            var errStr = "";
             if (!recovering) {
-                // Report error
                 expected = [];
-                for (p in table[state]) if (this.terminals_[p] && p > 2) {
-                    expected.push("'"+this.terminals_[p]+"'");
-                }
-                var errStr = '';
+                for (p in table[state])
+                    if (this.terminals_[p] && p > 2) {
+                        expected.push("'" + this.terminals_[p] + "'");
+                    }
                 if (this.lexer.showPosition) {
-                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+"\nExpecting "+expected.join(', ') + ", got '" + this.terminals_[symbol]+ "'";
+                    errStr = "Parse error on line " + (yylineno + 1) + ":\n" + this.lexer.showPosition() + "\nExpecting " + expected.join(", ") + ", got '" + (this.terminals_[symbol] || symbol) + "'";
                 } else {
-                    errStr = 'Parse error on line '+(yylineno+1)+": Unexpected " +
-                                  (symbol == 1 /*EOF*/ ? "end of input" :
-                                              ("'"+(this.terminals_[symbol] || symbol)+"'"));
+                    errStr = "Parse error on line " + (yylineno + 1) + ": Unexpected " + (symbol == 1?"end of input":"'" + (this.terminals_[symbol] || symbol) + "'");
                 }
-                this.parseError(errStr,
-                    {text: this.lexer.match, token: this.terminals_[symbol] || symbol, line: this.lexer.yylineno, loc: yyloc, expected: expected});
+                this.parseError(errStr, {text: this.lexer.match, token: this.terminals_[symbol] || symbol, line: this.lexer.yylineno, loc: yyloc, expected: expected});
             }
-
-            // just recovered from another error
-            if (recovering == 3) {
-                if (symbol == EOF) {
-                    throw new Error(errStr || 'Parsing halted.');
-                }
-
-                // discard current lookahead and grab another
+        }
+        if (action[0] instanceof Array && action.length > 1) {
+            throw new Error("Parse Error: multiple actions possible at state: " + state + ", token: " + symbol);
+        }
+        switch (action[0]) {
+        case 1:
+            stack.push(symbol);
+            vstack.push(this.lexer.yytext);
+            lstack.push(this.lexer.yylloc);
+            stack.push(action[1]);
+            symbol = null;
+            if (!preErrorSymbol) {
                 yyleng = this.lexer.yyleng;
                 yytext = this.lexer.yytext;
                 yylineno = this.lexer.yylineno;
                 yyloc = this.lexer.yylloc;
-                symbol = lex();
+                if (recovering > 0)
+                    recovering--;
+            } else {
+                symbol = preErrorSymbol;
+                preErrorSymbol = null;
             }
-
-            // try to recover from error
-            while (1) {
-                // check for error recovery rule in this state
-                if ((TERROR.toString()) in table[state]) {
-                    break;
-                }
-                if (state == 0) {
-                    throw new Error(errStr || 'Parsing halted.');
-                }
-                popStack(1);
-                state = stack[stack.length-1];
+            break;
+        case 2:
+            len = this.productions_[action[1]][1];
+            yyval.$ = vstack[vstack.length - len];
+            yyval._$ = {first_line: lstack[lstack.length - (len || 1)].first_line, last_line: lstack[lstack.length - 1].last_line, first_column: lstack[lstack.length - (len || 1)].first_column, last_column: lstack[lstack.length - 1].last_column};
+            if (ranges) {
+                yyval._$.range = [lstack[lstack.length - (len || 1)].range[0], lstack[lstack.length - 1].range[1]];
             }
-
-            preErrorSymbol = symbol; // save the lookahead token
-            symbol = TERROR;         // insert generic error symbol as new lookahead
-            state = stack[stack.length-1];
-            action = table[state] && table[state][TERROR];
-            recovering = 3; // allow 3 real symbols to be shifted before reporting a new error
+            r = this.performAction.call(yyval, yytext, yyleng, yylineno, this.yy, action[1], vstack, lstack);
+            if (typeof r !== "undefined") {
+                return r;
+            }
+            if (len) {
+                stack = stack.slice(0, -1 * len * 2);
+                vstack = vstack.slice(0, -1 * len);
+                lstack = lstack.slice(0, -1 * len);
+            }
+            stack.push(this.productions_[action[1]][0]);
+            vstack.push(yyval.$);
+            lstack.push(yyval._$);
+            newState = table[stack[stack.length - 2]][stack[stack.length - 1]];
+            stack.push(newState);
+            break;
+        case 3:
+            return true;
         }
-
-        // this shouldn't happen, unless resolve defaults are off
-        if (action[0] instanceof Array && action.length > 1) {
-            throw new Error('Parse Error: multiple actions possible at state: '+state+', token: '+symbol);
-        }
-
-        switch (action[0]) {
-
-            case 1: // shift
-                //this.shiftCount++;
-
-                stack.push(symbol);
-                vstack.push(this.lexer.yytext);
-                lstack.push(this.lexer.yylloc);
-                stack.push(action[1]); // push state
-                symbol = null;
-                if (!preErrorSymbol) { // normal execution/no error
-                    yyleng = this.lexer.yyleng;
-                    yytext = this.lexer.yytext;
-                    yylineno = this.lexer.yylineno;
-                    yyloc = this.lexer.yylloc;
-                    if (recovering > 0)
-                        recovering--;
-                } else { // error just occurred, resume old lookahead f/ before error
-                    symbol = preErrorSymbol;
-                    preErrorSymbol = null;
-                }
-                break;
-
-            case 2: // reduce
-                //this.reductionCount++;
-
-                len = this.productions_[action[1]][1];
-
-                // perform semantic action
-                yyval.$ = vstack[vstack.length-len]; // default to $$ = $1
-                // default location, uses first token for firsts, last for lasts
-                yyval._$ = {
-                    first_line: lstack[lstack.length-(len||1)].first_line,
-                    last_line: lstack[lstack.length-1].last_line,
-                    first_column: lstack[lstack.length-(len||1)].first_column,
-                    last_column: lstack[lstack.length-1].last_column
-                };
-                r = this.performAction.call(yyval, yytext, yyleng, yylineno, this.yy, action[1], vstack, lstack);
-
-                if (typeof r !== 'undefined') {
-                    return r;
-                }
-
-                // pop off stack
-                if (len) {
-                    stack = stack.slice(0,-1*len*2);
-                    vstack = vstack.slice(0, -1*len);
-                    lstack = lstack.slice(0, -1*len);
-                }
-
-                stack.push(this.productions_[action[1]][0]);    // push nonterminal (reduce)
-                vstack.push(yyval.$);
-                lstack.push(yyval._$);
-                // goto new state = table[STATE][NONTERMINAL]
-                newState = table[stack[stack.length-2]][stack[stack.length-1]];
-                stack.push(newState);
-                break;
-
-            case 3: // accept
-                return true;
-        }
-
     }
-
     return true;
-}};
-return parser;
+}
+};
+undefined
+function Parser () { this.yy = {}; }Parser.prototype = parser;parser.Parser = Parser;
+return new Parser;
 })();
 if (typeof require !== 'undefined' && typeof exports !== 'undefined') {
 exports.parser = parser;
+exports.Parser = parser.Parser;
 exports.parse = function () { return parser.parse.apply(parser, arguments); }
 exports.main = function commonjsMain(args) {
     if (!args[1])
         throw new Error('Usage: '+args[0]+' FILE');
+    var source, cwd;
     if (typeof process !== 'undefined') {
-        var source = require('fs').readFileSync(require('path').join(process.cwd(), args[1]), "utf8");
+        source = require('fs').readFileSync(require('path').resolve(args[1]), "utf8");
     } else {
-        var cwd = require("file").path(require("file").cwd());
-        var source = cwd.join(args[1]).read({charset: "utf-8"});
+        source = require("file").path(require("file").cwd()).join(args[1]).read({charset: "utf-8"});
     }
     return exports.parser.parse(source);
 }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -127,7 +127,7 @@ exports.Base = class Base
       child.traverseChildren crossScope, func
 
   invert: ->
-    new Op '!', this
+    Op.create '!', this
 
   unwrapAll: ->
     node = this
@@ -378,12 +378,15 @@ exports.Return = class Return extends Base
 # A value, variable or literal or parenthesized, indexed or dotted into,
 # or vanilla.
 exports.Value = class Value extends Base
-  constructor: (base, props, tag) ->
-    return base if not props and base instanceof Value
-    @base       = base
-    @properties = props or []
-    @[tag]      = true if tag
-    return this
+  @create: (base, props, tag) ->
+    if not props and base instanceof Value
+      base
+    else
+      new Value base, props, tag
+
+  constructor: (@base, @properties, tag) ->
+    @properties or= []
+    @[tag] = true if tag
 
   children: ['base', 'properties']
 
@@ -429,16 +432,16 @@ exports.Value = class Value extends Base
     name = last @properties
     if @properties.length < 2 and not @base.isComplex() and not name?.isComplex()
       return [this, this]  # `a` `a.b`
-    base = new Value @base, @properties[...-1]
+    base = Value.create @base, @properties[...-1]
     if base.isComplex()  # `a().b`
       bref = new Literal o.scope.freeVariable 'base'
-      base = new Value new Parens new Assign bref, base
+      base = Value.create new Parens new Assign bref, base
     return [base, bref] unless name  # `a()`
     if name.isComplex()  # `a[b()]`
       nref = new Literal o.scope.freeVariable 'name'
       name = new Index new Assign nref, name.index
       nref = new Index nref
-    [base.add(name), new Value(bref or base.base, [nref or name])]
+    [base.add(name), Value.create(bref or base.base, [nref or name])]
 
   # We compile a value to JavaScript by compiling and joining each property.
   # Things get much more interesting if the chain of properties has *soak*
@@ -461,8 +464,8 @@ exports.Value = class Value extends Base
         return ifn
       for prop, i in @properties when prop.soak
         prop.soak = off
-        fst = new Value @base, @properties[...i]
-        snd = new Value @base, @properties[i..]
+        fst = Value.create @base, @properties[...i]
+        snd = Value.create @base, @properties[i..]
         if fst.isComplex()
           ref = new Literal o.scope.freeVariable 'ref'
           fst = new Parens new Assign ref, fst
@@ -518,7 +521,7 @@ exports.Call = class Call extends Base
       accesses = [new Access(new Literal '__super__')]
       accesses.push new Access new Literal 'constructor' if method.static
       accesses.push new Access new Literal name
-      (new Value (new Literal method.klass), accesses).compile o
+      (Value.create (new Literal method.klass), accesses).compile o
     else
       "#{name}.__super__.constructor"
 
@@ -532,14 +535,14 @@ exports.Call = class Call extends Base
     if @soak
       if @variable
         return ifn if ifn = unfoldSoak o, this, 'variable'
-        [left, rite] = new Value(@variable).cacheReference o
+        [left, rite] = Value.create(@variable).cacheReference o
       else
         left = new Literal @superReference o
-        rite = new Value left
+        rite = Value.create left
       rite = new Call rite, @args
       rite.isNew = @isNew
       left = new Literal "typeof #{ left.compile o } === \"function\""
-      return new If left, new Value(rite), soak: yes
+      return new If left, Value.create(rite), soak: yes
     call = this
     list = []
     loop
@@ -609,7 +612,7 @@ exports.Call = class Call extends Base
         #{idt}return Object(result) === result ? result : child;
         #{@tab}})(#{ @variable.compile o, LEVEL_LIST }, #{splatArgs}, function(){})
       """
-    base = new Value @variable
+    base = Value.create @variable
     if (name = base.properties.pop()) and base.isComplex()
       ref = o.scope.freeVariable 'ref'
       fun = "(#{ref} = #{ base.compile o, LEVEL_LIST })#{ name.compile o }"
@@ -635,7 +638,7 @@ exports.Extends = class Extends extends Base
 
   # Hooks one constructor into another's prototype chain.
   compile: (o) ->
-    new Call(new Value(new Literal utility 'extends'), [@child, @parent]).compile o
+    new Call(Value.create(new Literal utility 'extends'), [@child, @parent]).compile o
 
 #### Access
 
@@ -894,7 +897,7 @@ exports.Class = class Class extends Base
   addBoundFunctions: (o) ->
     if @boundFuncs.length
       for bvar in @boundFuncs
-        lhs = (new Value (new Literal "this"), [new Access bvar]).compile o
+        lhs = (Value.create (new Literal "this"), [new Access bvar]).compile o
         @ctor.body.unshift new Literal "#{lhs} = #{utility 'bind'}(#{lhs}, this)"
 
   # Merge the properties from a top-level object as prototypal properties
@@ -922,7 +925,7 @@ exports.Class = class Class extends Base
             if func.bound
               func.context = name
           else
-            assign.variable = new Value(new Literal(name), [(new Access new Literal 'prototype'), new Access base ])
+            assign.variable = Value.create(new Literal(name), [(new Access new Literal 'prototype'), new Access base ])
             if func instanceof Code and func.bound
               @boundFuncs.push base
               func.bound = no
@@ -951,7 +954,7 @@ exports.Class = class Class extends Base
 
   # Make sure that a constructor is defined for the class, and properly
   # configured.
-  ensureConstructor: (name) ->
+  ensureConstructor: (name, o) ->
     if not @ctor
       @ctor = new Code
       @ctor.body.push new Literal "#{name}.__super__.constructor.apply(this, arguments)" if @parent
@@ -960,6 +963,13 @@ exports.Class = class Class extends Base
     @ctor.ctor     = @ctor.name = name
     @ctor.klass    = null
     @ctor.noReturn = yes
+
+    # Prevent constructor from returning a value.
+    returnExpr = null
+    @ctor.body.traverseChildren no, (node) ->
+      return no if node instanceof Return and (returnExpr = node.expression)
+    if returnExpr
+      throw SyntaxError "cannot return a value from a constructor: \"#{returnExpr.compileNode o}\" in class #{name}"
 
   # Instead of generating the JavaScript string directly, we build up the
   # equivalent syntax tree and compile that, in pieces. You can see the
@@ -973,7 +983,7 @@ exports.Class = class Class extends Base
     @hoistDirectivePrologue()
     @setContext name
     @walkBody name, o
-    @ensureConstructor name
+    @ensureConstructor name, o
     @body.spaced = yes
     @body.expressions.unshift @ctor unless @ctor instanceof Code
     @body.expressions.push lname
@@ -1060,14 +1070,14 @@ exports.Assign = class Assign extends Base
         {variable: {base: idx}, value: obj} = obj
       else
         if obj.base instanceof Parens
-          [obj, idx] = new Value(obj.unwrapAll()).cacheReference o
+          [obj, idx] = Value.create(obj.unwrapAll()).cacheReference o
         else
           idx = if isObject
             if obj.this then obj.properties[0].name else obj
           else
             new Literal 0
       acc   = IDENTIFIER.test idx.unwrap().value or 0
-      value = new Value value
+      value = Value.create value
       value.properties.push new (if acc then Access else Index) idx
       if obj.unwrap().value in RESERVED
         throw new SyntaxError "assignment to a reserved word: #{obj.compile o} = #{value.compile o}"
@@ -1088,7 +1098,7 @@ exports.Assign = class Assign extends Base
         else
           # A shorthand `{a, b, @c} = val` pattern-match.
           if obj.base instanceof Parens
-            [obj, idx] = new Value(obj.unwrapAll()).cacheReference o
+            [obj, idx] = Value.create(obj.unwrapAll()).cacheReference o
           else
             idx = if obj.this then obj.properties[0].name else obj
       if not splat and obj instanceof Splat
@@ -1113,7 +1123,7 @@ exports.Assign = class Assign extends Base
           acc = no
         else
           acc = isObject and IDENTIFIER.test idx.unwrap().value or 0
-        val = new Value new Literal(vvar), [new (if acc then Access else Index) idx]
+        val = Value.create new Literal(vvar), [new (if acc then Access else Index) idx]
       if name? and name in RESERVED
         throw new SyntaxError "assignment to a reserved word: #{obj.compile o} = #{val.compile o}"
       assigns.push new Assign(obj, val, null, param: @param, subpattern: yes).compile o, LEVEL_LIST
@@ -1131,7 +1141,7 @@ exports.Assign = class Assign extends Base
            left.base.value != "this" and not o.scope.check left.base.value
       throw new Error "the variable \"#{left.base.value}\" can't be assigned with #{@context} because it has not been defined."
     if "?" in @context then o.isExistentialEquals = true
-    new Op(@context[...-1], left, new Assign(right, @value, '=') ).compile o
+    Op.create(@context[...-1], left, new Assign(right, @value, '=') ).compile o
 
   # Compile the assignment from an array splice literal, using JavaScript's
   # `Array#splice` method.
@@ -1189,19 +1199,19 @@ exports.Code = class Code extends Base
       for {name: p} in @params
         if p.this then p = p.properties[0].name
         if p.value then o.scope.add p.value, 'var', yes
-      splats = new Assign new Value(new Arr(p.asReference o for p in @params)),
-                          new Value new Literal 'arguments'
+      splats = new Assign Value.create(new Arr(p.asReference o for p in @params)),
+                          Value.create new Literal 'arguments'
       break
     for param in @params
       if param.isComplex()
         val = ref = param.asReference o
-        val = new Op '?', ref, param.value if param.value
-        exprs.push new Assign new Value(param.name), val, '=', param: yes
+        val = Op.create '?', ref, param.value if param.value
+        exprs.push new Assign Value.create(param.name), val, '=', param: yes
       else
         ref = param
         if param.value
           lit = new Literal ref.name.value + ' == null'
-          val = new Assign new Value(param.name), param.value, '='
+          val = new Assign Value.create(param.name), param.value, '='
           exprs.push new If lit, val
       params.push ref unless splats
     wasEmpty = @body.isEmpty()
@@ -1262,7 +1272,7 @@ exports.Param = class Param extends Base
         node = new Literal o.scope.freeVariable node.value
     else if node.isComplex()
       node = new Literal o.scope.freeVariable 'arg'
-    node = new Value node
+    node = Value.create node
     node = new Splat node if @splat
     @reference = node
 
@@ -1406,18 +1416,19 @@ exports.While = class While extends Base
 # Simple Arithmetic and logical operations. Performs some conversion from
 # CoffeeScript operations into their JavaScript equivalents.
 exports.Op = class Op extends Base
-  constructor: (op, first, second, flip ) ->
-    return new In first, second if op is 'in'
+  @create: (op, first, second, flip) ->
+    if op is 'in'
+      return new In first, second
     if op is 'do'
       return @generateDo first
     if op is 'new'
       return first.newInstance() if first instanceof Call and not first.do and not first.isNew
       first = new Parens first   if first instanceof Code and first.bound or first.do
+    return new Op op, first, second, flip
+
+  constructor: (op, @first, @second, flip ) ->
     @operator = CONVERSIONS[op] or op
-    @first    = first
-    @second   = second
     @flip     = !!flip
-    return this
 
   # The map of conversions from CoffeeScript to JavaScript symbols.
   CONVERSIONS =
@@ -1470,12 +1481,12 @@ exports.Op = class Op extends Base
                                   fst.operator in ['!', 'in', 'instanceof']
       fst
     else
-      new Op '!', this
+      Op.create '!', this
 
   unfoldSoak: (o) ->
     @operator in ['++', '--', 'delete'] and unfoldSoak o, this, 'first'
 
-  generateDo: (exp) ->
+  @generateDo: (exp) ->
     passedParams = []
     func = if exp instanceof Assign and (ref = exp.value.unwrap()) instanceof Code
       ref
@@ -1790,7 +1801,7 @@ exports.For = class For extends While
                       val.properties[0].name?.value in ['call', 'apply'])
       fn    = val.base?.unwrapAll() or val
       ref   = new Literal o.scope.freeVariable 'fn'
-      base  = new Value ref
+      base  = Value.create ref
       if val.base
         [val.base, base] = [base, val]
       body.expressions[idx] = new Call base, expr.args
@@ -1936,7 +1947,7 @@ Closure =
       meth = new Literal if mentionsArgs then 'apply' else 'call'
       args = [new Literal 'this']
       args.push new Literal 'arguments' if mentionsArgs
-      func = new Value func, [new Access meth]
+      func = Value.create func, [new Access meth]
     func.noReturn = noReturn
     call = new Call func, args
     if statement then Block.wrap [call] else call
@@ -1953,7 +1964,7 @@ Closure =
 unfoldSoak = (o, parent, name) ->
   return unless ifn = parent[name].unfoldSoak o
   parent[name] = ifn.body
-  ifn.body = new Value parent
+  ifn.body = Value.create parent
   ifn
 
 # Constants

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -682,3 +682,13 @@ test '#2359: external constructors returning "other typed" objets', ->
   ok new A instanceof A
   ok new ctor not instanceof A
   ok new ctor not instanceof ctor
+
+test "#2359: constructors should not return an explicit value", ->
+  throws -> CoffeeScript.run "class then constructor: -> return 5"
+  throws -> CoffeeScript.run """
+    class
+      constructor: ->
+        if foo
+          return bar: 7
+        baz()
+  """


### PR DESCRIPTION
Here's an attempt to fix #2359. 

I opened the original issue quite long ago, but procrastinated ad-infinitum after feeling intimidated with `nodes.coffee`. #2596 encouraged me to give it another shot :)

This pull request basically re-introduces the ability to extend native objects without defining a constructor:

``` coffeescript
class MyError extends Error
console.log new MyError instanceof MyError # -> true

class Foo extends Object
console.log new Foo instanceof Foo # -> true
```

And also forbids returning any value from the constructor. This throws a SyntaxError:

``` coffeescript
class Foo
  constructor: -> 
    return 5
```

Empty returns are allowed though:

``` coffeescript
class Foo
  constructor: ->
    if mustReturnEarly
      return # OK
    @doSomeWork()
```

This is, however, at the expense of losing the ability to define "other typed" constructors. That is, constructors that return objects other than `this`. So it's a backward-incompatible change ([one test](https://github.com/jashkenas/coffee-script/blob/40431241357e04bda357e59139c2d8403102feb4/test/classes.coffee#L598-601) had to be removed).
