### PR TITLE
Depend on uglify-js 1, 2 has new API

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "git://github.com/jashkenas/coffee-script.git"
   },
   "devDependencies": {
-    "uglify-js":  ">=1.0.0",
+    "uglify-js":  ">=1.0.0 <2.0.0",
     "jison":      ">=0.2.0"
   }
 }


### PR DESCRIPTION
Hi,

When cake build:browser will fail because of the incompatibility with the new uglify-js, this is a quick workaround.
