### PR TITLE
Add noglobals compile option to generate self-contained functions

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -34,7 +34,7 @@
 
   BANNER = 'Usage: coffee [options] path/to/script.coffee -- [args]\n\nIf called without options, `coffee` will run your script.';
 
-  SWITCHES = [['-b', '--bare', 'compile without a top-level function wrapper'], ['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-e', '--eval', 'pass a string from the command line as input'], ['-h', '--help', 'display this help message'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-j', '--join [FILE]', 'concatenate the source CoffeeScript before compiling'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-n', '--nodes', 'print out the parse tree that the parser produces'], ['--nodejs [ARGS]', 'pass options directly to the "node" binary'], ['-o', '--output [DIR]', 'set the output directory for compiled JavaScript'], ['-p', '--print', 'print out the compiled JavaScript'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-t', '--tokens', 'print out the tokens that the lexer/rewriter produce'], ['-v', '--version', 'display the version number'], ['-w', '--watch', 'watch scripts for changes and rerun commands']];
+  SWITCHES = [['-b', '--bare', 'compile without a top-level function wrapper'], ['--noglobals', 'compile without a global scope shared between functions'], ['-c', '--compile', 'compile to JavaScript and save as .js files'], ['-e', '--eval', 'pass a string from the command line as input'], ['-h', '--help', 'display this help message'], ['-i', '--interactive', 'run an interactive CoffeeScript REPL'], ['-j', '--join [FILE]', 'concatenate the source CoffeeScript before compiling'], ['-l', '--lint', 'pipe the compiled JavaScript through JavaScript Lint'], ['-n', '--nodes', 'print out the parse tree that the parser produces'], ['--nodejs [ARGS]', 'pass options directly to the "node" binary'], ['-o', '--output [DIR]', 'set the output directory for compiled JavaScript'], ['-p', '--print', 'print out the compiled JavaScript'], ['-r', '--require [FILE*]', 'require a library before executing your script'], ['-s', '--stdio', 'listen for and compile scripts over stdio'], ['-t', '--tokens', 'print out the tokens that the lexer/rewriter produce'], ['-v', '--version', 'display the version number'], ['-w', '--watch', 'watch scripts for changes and rerun commands']];
 
   opts = {};
 
@@ -475,6 +475,7 @@
     return {
       filename: filename,
       bare: opts.bare,
+      noglobals: opts.noglobals,
       header: opts.compile
     };
   };

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1712,6 +1712,9 @@
 
     Code.prototype.compileNode = function(o) {
       var code, exprs, i, idt, lit, name, p, param, params, ref, splats, uniqs, val, wasEmpty, _i, _j, _k, _l, _len, _len1, _len2, _len3, _len4, _len5, _m, _n, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8;
+      if (o.scope && del(o, 'noglobals')) {
+        delete o.scope;
+      }
       o.scope = new Scope(o.scope, this.body, this);
       o.scope.shared = del(o, 'sharedScope');
       o.indent += TAB;

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -33,6 +33,7 @@ BANNER = '''
 # The list of all the valid option flags that `coffee` knows how to handle.
 SWITCHES = [
   ['-b', '--bare',            'compile without a top-level function wrapper']
+  [      '--noglobals',       'compile without a global scope shared between functions']
   ['-c', '--compile',         'compile to JavaScript and save as .js files']
   ['-e', '--eval',            'pass a string from the command line as input']
   ['-h', '--help',            'display this help message']
@@ -318,7 +319,7 @@ parseOptions = ->
 
 # The compile-time options to pass to the CoffeeScript compiler.
 compileOptions = (filename) ->
-  {filename, bare: opts.bare, header: opts.compile}
+  {filename, bare: opts.bare, noglobals: opts.noglobals, header: opts.compile}
 
 # Start up a new Node.js instance with the arguments in `--nodejs` passed to
 # the `node` binary, preserving the other options.

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1182,6 +1182,7 @@ exports.Code = class Code extends Base
   # arrow, generates a wrapper that saves the current value of `this` through
   # a closure.
   compileNode: (o) ->
+    delete o.scope if o.scope and del(o, 'noglobals')
     o.scope         = new Scope o.scope, @body, this
     o.scope.shared  = del(o, 'sharedScope')
     o.indent        += TAB


### PR DESCRIPTION
### The noglobals compile option

These changes make it easier to to pass generated code on to other systems,
such as MongoDB.

Consider a reduce function:

``` coffeescript
(key, [result, values...]) ->
    for value in values
        result = binop result, value
    result
```

Without noglobals:

``` javascript
var __slice = [].slice;

(function(key, _arg) {
  var result, value, values, _i, _len;
  result = _arg[0], values = 2 <= _arg.length ? __slice.call(_arg, 1) : [];
  for (_i = 0, _len = values.length; _i < _len; _i++) {
    value = values[_i];
    result = binop(result, value);
  }
  return result;
});
```

With noglobals:

``` javascript
(function(key, _arg) {
  var result, value, values, _i, _len,
    __slice = [].slice;
  result = _arg[0], values = 2 <= _arg.length ? __slice.call(_arg, 1) : [];
  for (_i = 0, _len = values.length; _i < _len; _i++) {
    value = values[_i];
    result = binop(result, value);
  }
  return result;
});
```
### Classes with external constructors

Consider:

``` coffeescript
class Foo
    constructor: Whatever
```

Curently this compiles to:

``` javascript
var Foo, _class;

Foo = (function() {

  function Foo() {
    return _class.apply(this, arguments);
  }

  _class = Whatever;

  return Foo;

})();
```

After SHA: 346c2da25f65d738fd833cfecf2688010d7b63f7

``` javascript
var Foo;

Foo = (function() {
  var constructor;

  function Foo() {
    return constructor.apply(this, arguments);
  }

  constructor = Whatever;

  return Foo;

})();
```

While I was at it, I fixed a minor edge case in SHA: 847f9c4e7f8ebefbd9dc0c8a664ec480ee6a9508.
### Potential next steps

It would be nice to be able to tighten down the 'var ...' declarationsin the
generated code too.  However this wasn't necenssary in my current application,
so I note it mainly as an idle curiosity.

I considered introducing a similar constructor closure variable for internal
constructors too, but that seemed a bit like scope creep given my goals.
