### PR TITLE
add `transient` as a JavaScript keyword

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -594,7 +594,7 @@ RESERVED = [
   'case', 'default', 'function', 'var', 'void', 'with', 'const', 'let', 'enum'
   'export', 'import', 'native', '__hasProp', '__extends', '__slice', '__bind'
   '__indexOf', 'implements', 'interface', 'package', 'private', 'protected'
-  'public', 'static', 'yield'
+  'public', 'static', 'transient', 'yield'
 ]
 
 STRICT_PROSCRIBED = ['arguments', 'eval']


### PR DESCRIPTION
Add `transient` to the list of reserved words in JavaScript
