### PR TITLE
Build:full sometimes uses old code when running tests.

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -67,7 +67,11 @@ task 'build:full', 'rebuild the source twice, and run the tests', ->
   build ->
     build ->
       csPath = './lib/coffee-script'
-      delete require.cache[require.resolve csPath]
+      csDir  = path.dirname require.resolve csPath
+
+      for mod of require.cache when csDir is mod[0 ... csDir.length]
+        delete require.cache[mod]
+
       unless runTests require csPath
         process.exit 1
 


### PR DESCRIPTION
I've noticed that build:full sometimes doesn't run tests with the newly compiled compiler. This patch makes a thorough cleansing of node.js's cache making sure that all modules in the coffee-script dir (and below if exist) get thrown out, to be loaded again when required the next time. 
