### PR TITLE
Fix #1435 by amending away sign reversal.

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -309,7 +309,7 @@ exports.Lexer = class Lexer
         @outdebt -= @indents[len]
         moveOut  -= @indents[len]
       else
-        dent = @indents.pop() - @outdebt
+        dent = @indents.pop() + @outdebt
         moveOut -= dent
         @outdebt = 0
         @pair 'OUTDENT'

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -213,3 +213,15 @@ test "#2621: fancy destructuring in parameter lists", ->
     eq(a, 'a')
 
   func({prop1: {key1: 'key1'}, prop2: {key2: 'key2', key3: ['a', 'b', 'c']}})
+
+test "#1435 Indented property access", ->
+  rec = -> rec: rec
+
+  eq 1, do ->
+    rec()
+      .rec ->
+        rec()
+          .rec ->
+            rec.rec()
+          .rec()
+    1


### PR DESCRIPTION
Apparently #1435 is caused by a tiny typo. This should fix it.
