### PR TITLE
Fix compiler error when compiling 'super()'

### DIFF
--- a/lib/coffee-script/scope.js
+++ b/lib/coffee-script/scope.js
@@ -39,7 +39,8 @@
     };
 
     Scope.prototype.namedMethod = function() {
-      if (this.method.name || !this.parent) {
+      var _ref1;
+      if (((_ref1 = this.method) != null ? _ref1.name : void 0) || !this.parent) {
         return this.method;
       }
       return this.parent.namedMethod();

--- a/src/scope.litcoffee
+++ b/src/scope.litcoffee
@@ -41,7 +41,7 @@ can get complicated if super is being called from an inner function.
 function object that has a name filled in, or bottoms out.
 
       namedMethod: ->
-        return @method if @method.name or !@parent
+        return @method if @method?.name or !@parent
         @parent.namedMethod()
 
 Look up a variable name in lexical scope, and declare it if it does not


### PR DESCRIPTION
I stumbled upon an unexpected compiler error while compiling `super()`:

```
$ coffee -cs <<<'super()'
TypeError: Cannot read property 'name' of null
    at Scope.exports.Scope.Scope.namedMethod (/usr/lib/node_modules/coffee-script/lib/coffee-script/scope.js:42:22)
    at Call.exports.Call.Call.superReference (/usr/lib/node_modules/coffee-script/lib/coffee-script/nodes.js:805:24)
    at Call.exports.Call.Call.compileNode (/usr/lib/node_modules/coffee-script/lib/coffee-script/nodes.js:927:21)
    at Call.exports.Base.Base.compile (/usr/lib/node_modules/coffee-script/lib/coffee-script/nodes.js:48:21)
...
```

It seems the error has been there for quite some time (since 1.3.2), introduced in commit 34be878257b9206e02046cb4ab10101e6266cd9f.

The error is gone after adding a little `?` in the right place, but really...

![](http://cdn.memegenerator.net/instances/400x/31450812.jpg)

The error message for `super()` now seems good:

```
$ bin/coffee -cs <<<'super()'
SyntaxError: cannot call super outside of a function.
    at SyntaxError (unknown source)
    at Call.exports.Call.Call.superReference (/home/demian/Programming/coffee-script/lib/coffee-script/nodes.js:807:15)
    at Call.exports.Call.Call.compileNode (/home/demian/Programming/coffee-script/lib/coffee-script/nodes.js:927:21)
    at Call.exports.Base.Base.compile (/home/demian/Programming/coffee-script/lib/coffee-script/nodes.js:48:21)
...
```

But the error message for `-> super()` is also "cannot call super outside of a function", which doesn't make any sense, because it's inside a function. And [it seems it should say](https://github.com/jashkenas/coffee-script/blob/5e498ca395d0dc7024c5ea7d9f373c26c4afe941/src/nodes.coffee#L523) "cannot call super on an anonymous function" instead, which would make much more sense. 

So, i have no idea how Scope works or if it's really that class the source of the problem. Could someone more seasoned have a look this?
