### PR TITLE
Cake 'invoke' callback

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -57,15 +57,15 @@ task 'install', 'install CoffeeScript into /usr/local (or --prefix)', (options) 
   )
 
 
-task 'build', 'build the CoffeeScript language from source', build = (cb) ->
+task 'build', 'build the CoffeeScript language from source', (options, cb) ->
   files = fs.readdirSync 'src'
   files = ('src/' + file for file in files when file.match(/\.(lit)?coffee$/))
   run ['-c', '-o', 'lib/coffee-script'].concat(files), cb
 
 
 task 'build:full', 'rebuild the source twice, and run the tests', ->
-  build ->
-    build ->
+  invoke 'build', ->
+    invoke 'build', ->
       csPath = './lib/coffee-script'
       csDir  = path.dirname require.resolve csPath
 

--- a/lib/coffee-script/cake.js
+++ b/lib/coffee-script/cake.js
@@ -37,11 +37,11 @@
     option: function(letter, flag, description) {
       return switches.push([letter, flag, description]);
     },
-    invoke: function(name) {
+    invoke: function(name, cb) {
       if (!tasks[name]) {
         missingTask(name);
       }
-      return tasks[name].action(options);
+      return tasks[name].action(options, cb || (function() {}));
     }
   });
 

--- a/src/cake.coffee
+++ b/src/cake.coffee
@@ -37,9 +37,9 @@ helpers.extend global,
     switches.push [letter, flag, description]
 
   # Invoke another task in the current Cakefile.
-  invoke: (name) ->
+  invoke: (name, cb) ->
     missingTask name unless tasks[name]
-    tasks[name].action options
+    tasks[name].action options, cb or (->)
 
 # Run `cake`. Executes all of the tasks you pass, in order. Note that Node's
 # asynchrony may cause tasks to execute in a different order than you'd expect.


### PR DESCRIPTION
Hi, I know that this topic has already been discussed:
https://github.com/jashkenas/coffee-script/issues/2404
https://github.com/jashkenas/coffee-script/pull/1822
https://github.com/jashkenas/coffee-script/pull/1030

And your opinion is that _cake_ should be a pretty simple.
But this small fix (2 lines of code) solves the previous issues and some more
_Cakefile_ in this repository will be better:

```
task 'build', 'build the CoffeeScript language from source', (options, cb) ->
  files = fs.readdirSync 'src'
  files = ('src/' + file for file in files when file.match(/\.(lit)?coffee$/))
  run ['-c', '-o', 'lib/coffee-script'].concat(files), cb


task 'build:full', 'rebuild the source twice, and run the tests', ->
  invoke 'build', ->
    invoke 'build', ->
      csPath = './lib/coffee-script'
      csDir  = path.dirname require.resolve csPath

      for mod of require.cache when csDir is mod[0 ... csDir.length]
        delete require.cache[mod]

      unless runTests require csPath
        process.exit 1
```

instead:

```
task 'build', 'build the CoffeeScript language from source', build = (cb) ->
  files = fs.readdirSync 'src'
  files = ('src/' + file for file in files when file.match(/\.(lit)?coffee$/))
  run ['-c', '-o', 'lib/coffee-script'].concat(files), cb


task 'build:full', 'rebuild the source twice, and run the tests', ->
  build ->
    build ->
      csPath = './lib/coffee-script'
      csDir  = path.dirname require.resolve csPath

      for mod of require.cache when csDir is mod[0 ... csDir.length]
        delete require.cache[mod]

      unless runTests require csPath
        process.exit 1
```

_build = (cb) ->_ - is not simply and breaks "option" argument 
