### PR TITLE
Fix implicit calls with try/catch/finally as arguments

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -230,7 +230,7 @@
           tokens.splice(i, 0, generate('}', '}'));
           return i += 1;
         };
-        if (inImplicitCall() && (tag === 'IF' || tag === 'CLASS' || tag === 'SWITCH' || tag === 'CATCH')) {
+        if (inImplicitCall() && (tag === 'IF' || tag === 'TRY' || tag === 'FINALLY' || tag === 'CATCH' || tag === 'CLASS' || tag === 'SWITCH' || tag === 'CATCH')) {
           stack.push([
             'CONTROL', i, {
               ours: true

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -179,7 +179,8 @@ class exports.Rewriter
         i += 1
 
       # Don't end an implicit call on next indent if any of these are in an argument
-      if inImplicitCall() and tag in ['IF', 'CLASS', 'SWITCH', 'CATCH']
+      if inImplicitCall() and tag in ['IF', 'TRY', 'FINALLY', 'CATCH',
+        'CLASS', 'SWITCH', 'CATCH']
         stack.push ['CONTROL', i, ours: true]
         return forward(1)
 

--- a/test/exception_handling.coffee
+++ b/test/exception_handling.coffee
@@ -99,17 +99,39 @@ test "try/catch with a reused variable name.", ->
     catch inner
       # nothing
   eq typeof inner, 'undefined'
-  
-  
+
+
 # Allowed to destructure exceptions: #2580
 
 test "try/catch with destructuring the exception object", ->
-  
+
   result = try
     missing.object
   catch {message}
     message
-    
-  eq message, 'missing is not defined'
-    
 
+  eq message, 'missing is not defined'
+
+
+
+test "Try catch finally as implicit arguments", ->
+  first = (x) -> x
+
+  foo = no
+  try
+    first try iamwhoiam() finally foo = yes
+  catch e
+  eq foo, yes
+
+  bar = no
+  try
+    first try iamwhoiam() catch e finally
+    bar = yes
+  catch e
+  eq bar, yes
+
+  baz = first
+    try iamwhoiam() catch e
+      "bar"
+    try iamwhoiam() catch e
+  eq baz, "bar"


### PR DESCRIPTION
Attempt to fix @satyr 's newly found issue with #2712

There may be more constructs that should be saved from being broken up, when only encountering a perhaps legitimate INDENT. If you find them, please make tests, and I will take a look at them.
