### PR TITLE
Disallow implicit calls in cases like:

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -162,7 +162,7 @@
       var stack;
       stack = [];
       return this.scanTokens(function(token, i, tokens) {
-        var endImplicitCall, endImplicitObject, forward, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, nextTag, prevTag, s, sameLine, stackIdx, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6;
+        var endImplicitCall, endImplicitObject, forward, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, nextTag, prevTag, s, sameLine, stackIdx, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag, _ref, _ref1, _ref2, _ref3, _ref4, _ref5;
         tag = token[0];
         prevTag = (i > 0 ? tokens[i - 1] : [])[0];
         nextTag = (i < tokens.length - 1 ? tokens[i + 1] : [])[0];
@@ -273,7 +273,7 @@
           startImplicitCall(i + 1);
           return forward(2);
         }
-        if (this.matchTags(i, IMPLICIT_FUNC, 'INDENT') && ((_ref2 = stackTop()) != null ? _ref2[0] : void 0) !== '[' && !this.findTagsBackwards(i, ['CLASS', 'EXTENDS', 'IF', 'CATCH', 'SWITCH', 'LEADING_WHEN', 'FOR', 'WHILE', 'UNTIL'])) {
+        if (this.matchTags(i, IMPLICIT_FUNC, 'INDENT', null, ':') && !this.findTagsBackwards(i, ['CLASS', 'EXTENDS', 'IF', 'CATCH', 'SWITCH', 'LEADING_WHEN', 'FOR', 'WHILE', 'UNTIL'])) {
           startImplicitCall(i + 1);
           stack.push(['INDENT', i + 2]);
           return forward(3);
@@ -287,9 +287,9 @@
           while (this.tag(s - 2) === 'HERECOMMENT') {
             s -= 2;
           }
-          startsLine = s === 0 || (_ref3 = this.tag(s - 1), __indexOf.call(LINEBREAKS, _ref3) >= 0) || tokens[s - 1].newLine;
+          startsLine = s === 0 || (_ref2 = this.tag(s - 1), __indexOf.call(LINEBREAKS, _ref2) >= 0) || tokens[s - 1].newLine;
           if (stackTop()) {
-            _ref4 = stackTop(), stackTag = _ref4[0], stackIdx = _ref4[1];
+            _ref3 = stackTop(), stackTag = _ref3[0], stackIdx = _ref3[1];
             if ((stackTag === '{' || stackTag === 'INDENT' && this.tag(stackIdx - 1) === '{') && (startsLine || this.tag(s - 1) === ',' || this.tag(s - 1) === '{')) {
               return forward(1);
             }
@@ -306,7 +306,7 @@
         }
         if (__indexOf.call(IMPLICIT_END, tag) >= 0) {
           while (inImplicit()) {
-            _ref5 = stackTop(), stackTag = _ref5[0], stackIdx = _ref5[1], (_ref6 = _ref5[2], sameLine = _ref6.sameLine, startsLine = _ref6.startsLine);
+            _ref4 = stackTop(), stackTag = _ref4[0], stackIdx = _ref4[1], (_ref5 = _ref4[2], sameLine = _ref5.sameLine, startsLine = _ref5.startsLine);
             if (inImplicitCall() && prevTag !== ',') {
               endImplicitCall();
             } else if (inImplicitObject() && sameLine && !startsLine) {

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -239,8 +239,7 @@ class exports.Rewriter
       # which is probably always unintended.
       # Furthermore don't allow this in literal arrays, as
       # that creates grammatical ambiguities.
-      if @matchTags(i, IMPLICIT_FUNC, 'INDENT') and
-         stackTop()?[0] isnt '[' and
+      if @matchTags(i, IMPLICIT_FUNC, 'INDENT', null, ':') and
          not @findTagsBackwards(i, ['CLASS', 'EXTENDS', 'IF', 'CATCH',
           'SWITCH', 'LEADING_WHEN', 'FOR', 'WHILE', 'UNTIL'])
         startImplicitCall i + 1

--- a/test/exception_handling.coffee
+++ b/test/exception_handling.coffee
@@ -129,9 +129,3 @@ test "Try catch finally as implicit arguments", ->
     bar = yes
   catch e
   eq bar, yes
-
-  baz = first
-    try iamwhoiam() catch e
-      "bar"
-    try iamwhoiam() catch e
-  eq baz, "bar"

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -605,15 +605,6 @@ test "#2297, Different behaviors on interpreting literal", ->
   eq xyzzy.four, 4
   eq xyzzy.h, 2
 
-  thud = foo
-    1
-    one: 1
-    two: 2
-    three: 3
-    2
-    3
-  eq thud.two, 2
-
 test "#2715, Chained implicit calls", ->
   first  = (x)    -> x
   second = (x, y) -> y
@@ -631,30 +622,6 @@ test "#2715, Chained implicit calls", ->
     2
   eq baz, 2
 
-  qux = first second
-    1
-    2
-    3
-    4
-  eq qux, 2
-
-
-test "More implicit calls", ->
-  first  = (x) -> x
-  second = (x, y) -> y
-
-  foo = no
-  if (first
-    yes)
-    foo = yes
-  eq foo, yes
-
-  foo = no
-  if not first
-    no
-    foo = yes
-  eq foo, no
-
 test "Implicit calls and new", ->
   first = (x) -> x
   foo = (@x) ->
@@ -662,12 +629,23 @@ test "Implicit calls and new", ->
   eq bar.x, 1
 
   third = (x, y, z) -> z
-  baz = first new foo
-    new
-      foo third
+  baz = first new foo new foo third
         one: 1
         two: 2
         1
         three: 3
         2
   eq baz.x.x.three, 3
+
+test "Loose tokens inside of explicit call lists", ->
+  first = (x) -> x
+  second = (x, y) -> y
+  one = 1
+
+  foo = second( one
+                2)
+  eq foo, 2
+
+  bar = first( first
+               one: 1)
+  eq bar.one, 1


### PR DESCRIPTION
f
  a

and only allow cases like:

f
  a: 1
