### PR TITLE
Fixes #2782: non-alphanumeric bound member names

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1401,7 +1401,7 @@
         for (_i = 0, _len = _ref4.length; _i < _len; _i++) {
           _ref5 = _ref4[_i], name = _ref5[0], func = _ref5[1];
           lhs = new Value(new Literal("this"), [new Access(name)]);
-          body = new Block([new Return(new Literal("" + this.ctor.name + ".prototype." + name.value + ".apply(_this, arguments)"))]);
+          body = new Block([new Return(new Literal("" + this.ctor.name + ".prototype[\"" + name.value + "\"].apply(_this, arguments)"))]);
           rhs = new Code(func.params, body, 'boundfunc');
           bound = new Assign(lhs, rhs);
           this.ctor.body.push(bound);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -987,7 +987,7 @@ exports.Class = class Class extends Base
       o.scope.assign '_this', 'this'
       for [name, func] in @boundFuncs
         lhs = new Value (new Literal "this"), [new Access name]
-        body = new Block [new Return new Literal "#{@ctor.name}.prototype.#{name.value}.apply(_this, arguments)"]
+        body = new Block [new Return new Literal "#{@ctor.name}.prototype[\"#{name.value}\"].apply(_this, arguments)"]
         rhs = new Code func.params, body, 'boundfunc'
         bound = new Assign lhs, rhs
         @ctor.body.push bound

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -169,6 +169,13 @@ test "classes with JS-keyword properties", ->
   ok instance.name() is 'class'
 
 
+test "classes with bound functions with non-alphanumeric properties", ->
+
+  class Class
+    'multi:word/member!name': =>
+
+  instance = new Class
+
 test "Classes with methods that are pre-bound to the instance, or statically, to the class", ->
 
   class Dog


### PR DESCRIPTION
Non-alphanumeric bound members were causing an error during
construction. This fixes that.
