### PR TITLE
Fixes #1829. Preserve variable scope in the REPL

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -395,19 +395,24 @@
     };
 
     Block.prototype.compileRoot = function(o) {
-      var exp, fragments, i, prelude, preludeExps, rest;
+      var exp, fragments, i, name, prelude, preludeExps, rest, _i, _len, _ref2;
       o.indent = o.bare ? '' : TAB;
-      o.scope = new Scope(null, this, null);
       o.level = LEVEL_TOP;
       this.spaced = true;
+      o.scope = new Scope(null, this, null);
+      _ref2 = o.locals || [];
+      for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
+        name = _ref2[_i];
+        o.scope.parameter(name);
+      }
       prelude = [];
       if (!o.bare) {
         preludeExps = (function() {
-          var _i, _len, _ref2, _results;
-          _ref2 = this.expressions;
+          var _j, _len1, _ref3, _results;
+          _ref3 = this.expressions;
           _results = [];
-          for (i = _i = 0, _len = _ref2.length; _i < _len; i = ++_i) {
-            exp = _ref2[i];
+          for (i = _j = 0, _len1 = _ref3.length; _j < _len1; i = ++_j) {
+            exp = _ref3[i];
             if (!(exp.unwrap() instanceof Comment)) {
               break;
             }

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -21,7 +21,8 @@
         ast = CoffeeScript.nodes(input);
         ast = new Block([new Assign(new Value(new Literal('_')), ast, '=')]);
         js = ast.compile({
-          bare: true
+          bare: true,
+          locals: Object.keys(context)
         });
       } catch (_error) {
         err = _error;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -303,9 +303,12 @@ exports.Block = class Block extends Base
   # clean up obvious double-parentheses.
   compileRoot: (o) ->
     o.indent  = if o.bare then '' else TAB
-    o.scope   = new Scope null, this, null
     o.level   = LEVEL_TOP
     @spaced   = yes
+    o.scope   = new Scope null, this, null
+    # Mark given local variables in the root scope as parameters so they don't
+    # end up being declared on this block.
+    o.scope.parameter name for name in o.locals or []
     prelude   = []
     unless o.bare
       preludeExps = for exp, i in @expressions

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -15,7 +15,6 @@ replDefaults =
     # Require AST nodes to do some AST manipulation.
     {Block, Assign, Value, Literal} = require './nodes'
 
-    # TODO: fix #1829: pass in-scope vars and avoid accidentally shadowing them by omitting those declarations
     try
       # Generate the AST of the clean input.
       ast = CoffeeScript.nodes input
@@ -23,7 +22,7 @@ replDefaults =
       ast = new Block [
         new Assign (new Value new Literal '_'), ast, '='
       ]
-      js = ast.compile bare: yes
+      js = ast.compile bare: yes, locals: Object.keys(context)
     catch err
       console.log prettyErrorMessage err, filename, input, yes
     cb null, vm.runInContext(js, context, filename)


### PR DESCRIPTION
This little fix should make variable declarations work properly on the REPL.

Before this patch:

```
coffee> a = 1
1
coffee> do -> a = 2
2
coffee> a
1
```

Now:

```
coffee> a = 1
1
coffee> do -> a = 2
2
coffee> a
2
```

And, probably more important, before:

```
coffee> b = null
null
coffee> b ?= 42
repl:1:1: error: the variable "b" can't be assigned with ?= because it has not been declared before
b ?= 42
^
```

After:

```
coffee> b = null
null
coffee> b ?= 42
42
```
