### PR TITLE
Keep REPL running on runtime errors

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -24,11 +24,11 @@
           bare: true,
           locals: Object.keys(context)
         });
+        return cb(null, vm.runInContext(js, context, filename));
       } catch (_error) {
         err = _error;
-        console.log(prettyErrorMessage(err, filename, input, true));
+        return cb(prettyErrorMessage(err, filename, input, true));
       }
-      return cb(null, vm.runInContext(js, context, filename));
     }
   };
 

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -23,9 +23,9 @@ replDefaults =
         new Assign (new Value new Literal '_'), ast, '='
       ]
       js = ast.compile bare: yes, locals: Object.keys(context)
+      cb null, vm.runInContext(js, context, filename)
     catch err
-      console.log prettyErrorMessage err, filename, input, yes
-    cb null, vm.runInContext(js, context, filename)
+      cb prettyErrorMessage(err, filename, input, yes)
 
 addMultilineHandler = (repl) ->
   {rli, inputStream, outputStream} = repl

--- a/test/repl.coffee
+++ b/test/repl.coffee
@@ -91,3 +91,9 @@ testRepl "existential assignment of previously declared variable", (input, outpu
   input.emitLine 'a = null'
   input.emitLine 'a ?= 42'
   eq '42', output.lastWrite()
+
+testRepl "keeps running after runtime error", (input, output) ->
+  input.emitLine 'a = b'
+  eq 0, output.lastWrite().indexOf 'ReferenceError: b is not defined'
+  input.emitLine 'a'
+  eq 'undefined', output.lastWrite()


### PR DESCRIPTION
I don't know if there's an open issue for this, but basically this patch makes the REPL keep running after runtime errors instead of terminating (which i've found quite annoying a couple of times).
