### PR TITLE
Source maps in node

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -100,12 +100,14 @@
   };
 
   exports.run = function(code, options) {
-    var answer, mainModule;
+    var answer, mainModule, _ref1;
     if (options == null) {
       options = {};
     }
     mainModule = require.main;
-    options.sourceMap = true;
+    if ((_ref1 = options.sourceMap) == null) {
+      options.sourceMap = true;
+    }
     mainModule.filename = process.argv[1] = options.filename ? fs.realpathSync(options.filename) : '.';
     mainModule.moduleCache && (mainModule.moduleCache = {});
     mainModule.paths = require('module')._nodeModulePaths(path.dirname(fs.realpathSync(options.filename)));

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -96,7 +96,7 @@ exports.nodes = (source, options) ->
 # setting `__filename`, `__dirname`, and relative `require()`.
 exports.run = (code, options = {}) ->
   mainModule = require.main
-  options.sourceMap = true
+  options.sourceMap ?= true
   # Set the filename.
   mainModule.filename = process.argv[1] =
       if options.filename then fs.realpathSync(options.filename) else '.'


### PR DESCRIPTION
Addressing https://github.com/jashkenas/coffee-script/issues/2787
Ported stack trace [patch](https://github.com/michaelficarra/CoffeeScriptRedux/blob/master/src/run.coffee) from Redux.
passed `cake test` on node v0.8.17

This enables source mapping in `exports.run` by default, I would like to know your opinion.
Anybody think it's appropriate?
