### PR TITLE
added warning that repl needs node.js >= 0.8

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -88,9 +88,16 @@
 
   module.exports = {
     start: function(opts) {
-      var repl;
+      var build, major, minor, repl, _ref1;
       if (opts == null) {
         opts = {};
+      }
+      _ref1 = process.version.slice(1).split('.').map(function(n) {
+        return parseInt(n);
+      }), major = _ref1[0], minor = _ref1[1], build = _ref1[2];
+      if (major === 0 && minor <= 7) {
+        console.warn("Node 0.8.0+ required for coffeescript REPL");
+        process.exit(1);
       }
       opts = merge(replDefaults, opts);
       repl = nodeREPL.start(opts);

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -78,6 +78,12 @@ addMultilineHandler = (repl) ->
 
 module.exports =
   start: (opts = {}) ->
+    [major, minor, build] = process.version[1..].split('.').map (n) -> parseInt(n)
+
+    if major is 0 and minor <= 7
+      console.warn "Node 0.8.0+ required for coffeescript REPL"
+      process.exit 1
+
     opts = merge replDefaults, opts
     repl = nodeREPL.start opts
     repl.on 'exit', -> repl.outputStream.write '\n'


### PR DESCRIPTION
while running coffeescript 1.5.0+ works with node 0.6, the repl doesn't, and needs a warning for it, per discussion in issue#2813
