### PR TITLE
Bump engines.node version on package.json to 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url":        "https://raw.github.com/jashkenas/coffee-script/master/LICENSE"
   }],
   "engines":      {
-    "node":       ">=0.4.0"
+    "node":       ">=0.8.0"
   },
   "directories" : {
     "lib" : "./lib/coffee-script"


### PR DESCRIPTION
The CoffeeScript REPL does not work for Node versions lower than 0.8 (#2813). 

This PR bumps the version number on `engines.node` on the `package.json` file so that a warning is raised if someone tries to install CoffeeScript with an older Node version (CS is still installed though, [as long as the field `enginesStrict` is not set to `true`](https://npmjs.org/doc/json.html)). 

This is how the warning looks like:

```
$ nvm use 0.6
Now using node v0.6.21
$ npm install /home/demian/Programming/coffee-script/
npm WARN engine coffee-script@1.6.1: wanted: {"node":">=0.8.0"} (current: {"node":"0.6.21-pre","npm":"1.1.37"})
coffee-script@1.6.1 node_modules/coffee-script
```

I totally understand if this change is not acceptable though :relaxed: 
