### PR TITLE
encode unicode src, test added

### DIFF
--- a/src/browser.coffee
+++ b/src/browser.coffee
@@ -21,14 +21,15 @@ CoffeeScript.run = (code, options = {}) ->
 # If we're not in a browser environment, we're finished with the public API.
 return unless window?
 
-# Include source maps where possible. If we've got a base64 encoder, and a
-# JSON serializer, we're good to go.
-if btoa? and JSON?
+# Include source maps where possible. If we've got a base64 encoder, a
+# JSON serializer, and tools for escaping unicode characters, we're good to go.
+# Ported from https://developer.mozilla.org/en-US/docs/DOM/window.btoa
+if btoa? and JSON? and unescape? and encodeURIComponent?
   compile = (code, options = {}) ->
     options.sourceMap = true
     options.inline = true
     {js, v3SourceMap} = CoffeeScript.compile code, options
-    "#{js}\n//@ sourceMappingURL=data:application/json;base64,#{btoa v3SourceMap}\n//@ sourceURL=coffeescript"
+    "#{js}\n//@ sourceMappingURL=data:application/json;base64,#{btoa unescape encodeURIComponent v3SourceMap}\n//@ sourceURL=coffeescript"
 
 # Load a remote script from the current domain via XHR.
 CoffeeScript.load = (url, callback, options = {}) ->

--- a/test/test.html
+++ b/test/test.html
@@ -112,6 +112,8 @@
     'soaks'
     'strings'
   ]
+  # allow utf-8 chars in comments
+  # 智に働けば角が立つ、情に掉させば流される。
   </script>
 
 </body>


### PR DESCRIPTION
Addressing https://github.com/jashkenas/coffee-script/issues/2853,

This change escapes unicode characters in the source code for base64 encoding.
Although the unicode characters themselves are **not recoverable** in the web inspector, any ascii characters will be intact.

After a quick reading of the web inspector [source code](http://goo.gl/cbPE4), I don't think it is possible to safely encode unicode characters for now.

Also added a test that ensures that unicode characters are properly escaped from now on.
