### PR TITLE
Fix #2489 again: preserve bound methods length property

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1376,12 +1376,26 @@
     };
 
     Class.prototype.addBoundFunctions = function(o) {
-      var bvar, lhs, _i, _len, _ref4;
-      _ref4 = this.boundFuncs;
-      for (_i = 0, _len = _ref4.length; _i < _len; _i++) {
-        bvar = _ref4[_i];
-        lhs = (new Value(new Literal("this"), [new Access(bvar)])).compile(o);
-        this.ctor.body.unshift(new Literal("" + lhs + " = " + (utility('bind')) + "(" + lhs + ", this)"));
+      var body, bound, expr, exprs, func, lhs, name, rhs, scope, varDecl, varName, _i, _j, _len, _ref4, _ref5;
+      if (this.boundFuncs.length) {
+        scope = new Scope(o.scope, this.ctor.body);
+        exprs = [];
+        _ref4 = this.boundFuncs;
+        for (_i = 0, _len = _ref4.length; _i < _len; _i++) {
+          _ref5 = _ref4[_i], name = _ref5[0], func = _ref5[1];
+          varName = scope.freeVariable(IDENTIFIER.test(name.value) ? name.value : 'bound');
+          varDecl = new Assign(new Literal(varName), new Value(new Literal("this"), [new Access(name)]));
+          exprs.push(varDecl);
+          lhs = new Value(new Literal("this"), [new Access(name)]);
+          body = new Block([new Return(new Literal("" + varName + ".apply(_this, arguments)"))]);
+          rhs = new Code(func.params, body, 'boundfunc');
+          bound = new Assign(lhs, rhs);
+          exprs.push(bound);
+        }
+        for (_j = exprs.length - 1; _j >= 0; _j += -1) {
+          expr = exprs[_j];
+          this.ctor.body.unshift(expr);
+        }
       }
     };
 
@@ -1418,7 +1432,7 @@
               } else {
                 assign.variable = new Value(new Literal(name), [new Access(new Literal('prototype')), new Access(base)]);
                 if (func instanceof Code && func.bound) {
-                  this.boundFuncs.push(base);
+                  this.boundFuncs.push([base, func]);
                   func.bound = false;
                 }
               }
@@ -1773,7 +1787,7 @@
     Code.prototype.jumps = NO;
 
     Code.prototype.compileNode = function(o) {
-      var answer, code, exprs, i, idt, lit, p, param, params, ref, splats, uniqs, val, wasEmpty, _i, _j, _k, _l, _len, _len1, _len2, _len3, _len4, _m, _ref4, _ref5, _ref6, _ref7, _ref8;
+      var answer, code, exprs, i, idt, lit, p, param, params, ref, splats, uniqs, val, wasEmpty, _i, _j, _k, _l, _len, _len1, _len2, _len3, _len4, _len5, _m, _n, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
       o.scope = new Scope(o.scope, this.body, this);
       o.scope.shared = del(o, 'sharedScope');
       o.indent += TAB;
@@ -1781,20 +1795,25 @@
       delete o.isExistentialEquals;
       params = [];
       exprs = [];
+      _ref4 = this.params;
+      for (_i = 0, _len = _ref4.length; _i < _len; _i++) {
+        param = _ref4[_i];
+        delete param.reference;
+      }
       this.eachParamName(function(name) {
         if (!o.scope.check(name)) {
           return o.scope.parameter(name);
         }
       });
-      _ref4 = this.params;
-      for (_i = 0, _len = _ref4.length; _i < _len; _i++) {
-        param = _ref4[_i];
+      _ref5 = this.params;
+      for (_j = 0, _len1 = _ref5.length; _j < _len1; _j++) {
+        param = _ref5[_j];
         if (!param.splat) {
           continue;
         }
-        _ref5 = this.params;
-        for (_j = 0, _len1 = _ref5.length; _j < _len1; _j++) {
-          p = _ref5[_j].name;
+        _ref6 = this.params;
+        for (_k = 0, _len2 = _ref6.length; _k < _len2; _k++) {
+          p = _ref6[_k].name;
           if (p["this"]) {
             p = p.properties[0].name;
           }
@@ -1803,20 +1822,20 @@
           }
         }
         splats = new Assign(new Value(new Arr((function() {
-          var _k, _len2, _ref6, _results;
-          _ref6 = this.params;
+          var _l, _len3, _ref7, _results;
+          _ref7 = this.params;
           _results = [];
-          for (_k = 0, _len2 = _ref6.length; _k < _len2; _k++) {
-            p = _ref6[_k];
+          for (_l = 0, _len3 = _ref7.length; _l < _len3; _l++) {
+            p = _ref7[_l];
             _results.push(p.asReference(o));
           }
           return _results;
         }).call(this))), new Value(new Literal('arguments')));
         break;
       }
-      _ref6 = this.params;
-      for (_k = 0, _len2 = _ref6.length; _k < _len2; _k++) {
-        param = _ref6[_k];
+      _ref7 = this.params;
+      for (_l = 0, _len3 = _ref7.length; _l < _len3; _l++) {
+        param = _ref7[_l];
         if (param.isComplex()) {
           val = ref = param.asReference(o);
           if (param.value) {
@@ -1842,9 +1861,9 @@
         exprs.unshift(splats);
       }
       if (exprs.length) {
-        (_ref7 = this.body.expressions).unshift.apply(_ref7, exprs);
+        (_ref8 = this.body.expressions).unshift.apply(_ref8, exprs);
       }
-      for (i = _l = 0, _len3 = params.length; _l < _len3; i = ++_l) {
+      for (i = _m = 0, _len4 = params.length; _m < _len4; i = ++_m) {
         p = params[i];
         params[i] = p.compileToFragments(o);
         o.scope.parameter(fragmentsToText(params[i]));
@@ -1860,7 +1879,7 @@
         this.body.makeReturn();
       }
       if (this.bound) {
-        if ((_ref8 = o.scope.parent.method) != null ? _ref8.bound : void 0) {
+        if ((_ref9 = o.scope.parent.method) != null ? _ref9.bound : void 0) {
           this.bound = this.context = o.scope.parent.method.context;
         } else if (!this["static"]) {
           o.scope.parent.assign('_this', 'this');
@@ -1873,7 +1892,7 @@
       }
       code += '(';
       answer = [this.makeCode(code)];
-      for (i = _m = 0, _len4 = params.length; _m < _len4; i = ++_m) {
+      for (i = _n = 0, _len5 = params.length; _n < _len5; i = ++_n) {
         p = params[i];
         if (i) {
           answer.push(this.makeCode(", "));
@@ -2989,9 +3008,6 @@
   UTILITIES = {
     "extends": function() {
       return "function(child, parent) { for (var key in parent) { if (" + (utility('hasProp')) + ".call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }";
-    },
-    bind: function() {
-      return 'function(fn, me){ return function(){ return fn.apply(me, arguments); }; }';
     },
     indexOf: function() {
       return "[].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; }";

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -730,30 +730,34 @@ test "#2359: extending native objects that use other typed constructors requires
   eq 'yes!', workingArray.method()
 
 
+test "#2489: removing __bind", ->
+
+  class Thing
+    foo: (a, b, c) ->
+    bar: (a, b, c) =>
+
+  thing = new Thing
+
+  eq thing.foo.length, 3
+  eq thing.bar.length, 3
+
+
+test "#2773: overriding bound functions", ->
+  class Foo
+    method: => 'Foo'
+
+  class Bar extends Foo
+    method: => 'Bar'
+
+  eq (new Bar).method(), 'Bar'
+
+
 test "#2782: non-alphanumeric-named bound functions", ->
   class A
     'b:c': =>
       'd'
 
   eq (new A)['b:c'](), 'd'
-
-
-test "#2781: overriding bound functions", ->
-  class A
-    a: ->
-        @b()
-    b: =>
-        1
-
-  class B extends A
-    b: =>
-        2
-
-  b = (new A).b
-  eq b(), 1
-
-  b = (new B).b
-  eq b(), 2
 
 
 test "#2791: bound function with destructured argument", ->


### PR DESCRIPTION
So, here's another attempt at fixing #2489. This one has a more straightforward output, it's basically the old `__bind` but inlined.

Sample input:

``` coffeescript
class Foo 
  method: (a, b) => one

  'bar:baz': (bar) => two

  '--more crazy methods--': (lol) => tres
```

Old bare output:

``` javascript
var Foo,
  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };

Foo = (function() {
  function Foo() {
    this['--more crazy methods--'] = __bind(this['--more crazy methods--'], this);
    this['bar:baz'] = __bind(this['bar:baz'], this);
    this.method = __bind(this.method, this);
  }

  Foo.prototype.method = function(a, b) {
    return one;
  };

  Foo.prototype['bar:baz'] = function(bar) {
    return two;
  };

  Foo.prototype['--more crazy methods--'] = function(lol) {
    return tres;
  };

  return Foo;

})();
```

This PR's output:

``` javascript
var Foo;

Foo = (function() {
  function Foo() {
    var _bound, _bound1, _method,
      _this = this;
    _method = this.method;
    this.method = function(a, b) {
      return _method.apply(_this, arguments);
    };
    _bound = this['bar:baz'];
    this['bar:baz'] = function(bar) {
      return _bound.apply(_this, arguments);
    };
    _bound1 = this['--more crazy methods--'];
    this['--more crazy methods--'] = function(lol) {
      return _bound1.apply(_this, arguments);
    };
  }

  Foo.prototype.method = function(a, b) {
    return one;
  };

  Foo.prototype['bar:baz'] = function(bar) {
    return two;
  };

  Foo.prototype['--more crazy methods--'] = function(lol) {
    return tres;
  };

  return Foo;

})();
```

As you can see, the parameter names and number is preserved in the bound version of the method, thus making `length` work as expected.

Now, this PR works, but the code is _very bad_ :poop:. Or at least it contains a couple of really ugly hacks that i'm not proud of having produced. When i started with this i though that it would be just a matter of reverting this commit 67de35ff2959038018a71a917a24ad1a853d97e0 and then changing the `Class#addBoundFunctions` method a bit to make the compiled output match what i wanted. But things got pretty hairy pretty quick. Scoping issues, mutable state in destructuring parameters that prevented them from being used in more than one function (BTW, as of now, this produces some unnecessary code for bound methods with destructuring parameters), etc.

So, it's not production ready, but i wanted to open the PR to see if it would be a reasonable change or not. I personally wouldn't mind this being included or not, as i don't have much sympathy for bound methods.
