### PR TITLE
Add version information and a line about help in the coffeescript interactive shell

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -11,6 +11,7 @@
   _ref = require('./helpers'), merge = _ref.merge, prettyErrorMessage = _ref.prettyErrorMessage;
 
   replDefaults = {
+    welcome: "CoffeeScript version " + CoffeeScript.VERSION + " on Node " + process.versions.node + "\nType '.help' for more information\n",
     prompt: 'coffee> ',
     "eval": function(input, context, filename, cb) {
       var Assign, Block, Literal, Value, ast, err, js, _ref1;
@@ -88,7 +89,7 @@
 
   module.exports = {
     start: function(opts) {
-      var build, major, minor, repl, _ref1;
+      var build, major, minor, outputStream, repl, _ref1;
       if (opts == null) {
         opts = {};
       }
@@ -100,6 +101,10 @@
         process.exit(1);
       }
       opts = merge(replDefaults, opts);
+      if (opts.welcome) {
+        outputStream = opts.outputStream || process.stdout;
+        outputStream.write(opts.welcome);
+      }
       repl = nodeREPL.start(opts);
       repl.on('exit', function() {
         return repl.outputStream.write('\n');

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -4,6 +4,7 @@ CoffeeScript = require './coffee-script'
 {merge, prettyErrorMessage} = require './helpers'
 
 replDefaults =
+  welcome: "CoffeeScript version #{CoffeeScript.VERSION} on Node #{process.versions.node}\nType '.help' for more information\n"
   prompt: 'coffee> ',
   eval: (input, context, filename, cb) ->
     # XXX: multiline hack.
@@ -85,6 +86,11 @@ module.exports =
       process.exit 1
 
     opts = merge replDefaults, opts
+
+    if opts.welcome
+      outputStream = opts.outputStream or process.stdout
+      outputStream.write opts.welcome
+
     repl = nodeREPL.start opts
     repl.on 'exit', -> repl.outputStream.write '\n'
     addMultilineHandler repl


### PR DESCRIPTION
This makes it dead simple to see which version of CoffeeScript and Node you are using, as well as providing some extra information about possible commands. Can be disabled in the code by passing { welcome: '' } in the options to repl.start.

Example output:

```
$ coffee
CoffeeScript 1.6.2 on Node 0.10.0
Type '.help' for more information
coffee> 
```
