### PR TITLE
quick-fix for 2891

### DIFF
--- a/test/cluster.coffee
+++ b/test/cluster.coffee
@@ -1,7 +1,9 @@
 # Cluster Module
 # ---------
-
-return if testingBrowser?
+# Currently `fork()` for `.coffee` files requires Node.js 0.9+
+# Ignore the test when process.version does not match the requirement.
+[major, minor, build] = process.version[1..].split('.').map (n) -> parseInt(n)
+return if testingBrowser? or (major is 0 and minor < 9)
 
 cluster = require 'cluster'
 


### PR DESCRIPTION
Addressing https://github.com/jashkenas/coffee-script/issues/2891
Currently `fork()` for `.coffee` files requires Node.js 0.9+
Ignore the test when process.version does not match the requirement.
