### PR TITLE
copy properties, not just fields

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2992,7 +2992,7 @@
 
   UTILITIES = {
     "extends": function() {
-      return "function(child, parent) { for (var key in parent) { if (" + (utility('hasES5Properties')) + ") { if (" + (utility('hasProp')) + ".call(parent, key)) " + (utility('copyProp')) + "(child, parent, key); } else child[key] = parent[key]; function ctor() { this.constructor = child; } } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }";
+      return "function(child, parent) { for (var key in parent) { if (" + (utility('hasES5Properties')) + ") { if (" + (utility('hasProp')) + ".call(parent, key)) " + (utility('copyProp')) + "(child, parent, key); } else child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }";
     },
     bind: function() {
       return 'function(fn, me){ return function(){ return fn.apply(me, arguments); }; }';

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2112,7 +2112,7 @@ UTILITIES =
   # Correctly set up a prototype chain for inheritance, including a reference
   # to the superclass for `super()` calls, and copies of any static properties.
   extends: -> """
-    function(child, parent) { for (var key in parent) { if (#{utility 'hasES5Properties'}) { if (#{utility 'hasProp'}.call(parent, key)) #{utility 'copyProp'}(child, parent, key); } else child[key] = parent[key]; function ctor() { this.constructor = child; } } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }
+    function(child, parent) { for (var key in parent) { if (#{utility 'hasES5Properties'}) { if (#{utility 'hasProp'}.call(parent, key)) #{utility 'copyProp'}(child, parent, key); } else child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }
   """
 
   # Create a function bound to the current value of "this".


### PR DESCRIPTION
Right now if class A extends class B, and there are accessor properties defined on A, the getter is invoked and the returned value set on B, instead of the property being copied.

this patch copies properties using effectively:

``` js
  Object.defineProperty(B, propName, Object.getOwnPropertyDescriptor(A, propName))
```
