### PR TITLE
repl history implementation improvements

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -115,8 +115,8 @@
     repl.rli.addListener('line', function(code) {
       if (code && code.length && code !== '.history' && lastLine !== code) {
         fs.write(fd, "" + code + "\n");
+        return lastLine = code;
       }
-      return lastLine = code;
     });
     process.on('exit', function() {
       return fs.closeSync(fd);

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -106,7 +106,7 @@ addHistory = (repl, filename, maxSize) ->
     if code and code.length and code isnt '.history' and lastLine isnt code
       # Save the latest command in the file
       fs.write fd, "#{code}\n"
-    lastLine = code
+      lastLine = code
 
   process.on 'exit', ->
     fs.closeSync fd


### PR DESCRIPTION
Addresses comments in #2886
- Replace large comprehension with much simpler code
- fix comment to reference maxSize instead of previous 10KB limit
- only pop a history entry if the file size is actually bigger than maxSize
- only add items to the history if they are different from the last item by storing the last line and loading it on startup.
