### PR TITLE
Fix error reporting for invalid object key.

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1228,7 +1228,7 @@
         join = i === props.length - 1 ? '' : prop === lastNoncom || prop instanceof Comment ? '\n' : ',\n';
         indent = prop instanceof Comment ? '' : idt;
         if (prop instanceof Assign && prop.variable instanceof Value && prop.variable.hasProperties()) {
-          throw new SyntaxError('Invalid object key');
+          prop.variable.error('Invalid object key');
         }
         if (prop instanceof Value && prop["this"]) {
           prop = new Assign(prop.properties[0].name, prop, 'object');

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -897,7 +897,7 @@ exports.Obj = class Obj extends Base
         ',\n'
       indent = if prop instanceof Comment then '' else idt
       if prop instanceof Assign and prop.variable instanceof Value and prop.variable.hasProperties()
-        throw new SyntaxError 'Invalid object key'
+        prop.variable.error 'Invalid object key'
       if prop instanceof Value and prop.this
         prop = new Assign prop.properties[0].name, prop, 'object'
       if prop not instanceof Comment


### PR DESCRIPTION
Use the newfangled `Base::error` method instead of just throwing a SyntaxError.
