### PR TITLE
Keep a single-line herecomment as a single-line js comment.

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -821,7 +821,7 @@
 
     Comment.prototype.compileNode = function(o, level) {
       var code;
-      code = '/*' + multident(this.comment, this.tab) + ("\n" + this.tab + "*/\n");
+      code = "/*" + (multident(this.comment, this.tab)) + (__indexOf.call(this.comment, '\n') >= 0 ? "\n" + this.tab : '') + "*/\n";
       if ((level || o.level) === LEVEL_TOP) {
         code = o.indent + code;
       }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -553,7 +553,7 @@ exports.Comment = class Comment extends Base
   makeReturn:      THIS
 
   compileNode: (o, level) ->
-    code = '/*' + multident(@comment, @tab) + "\n#{@tab}*/\n"
+    code = "/*#{multident @comment, @tab}#{if '\n' in @comment then "\n#{@tab}" else ''}*/\n"
     code = o.indent + code if (level or o.level) is LEVEL_TOP
     [@makeCode code]
 


### PR DESCRIPTION
### Before:

``` coffee
###Foobar###
###
baz
###
```

becomes

``` js
/*Foobar
*/
/*
baz
*/
```
### After:

``` coffee
###Foobar###
###
baz
###
```

becomes

``` js
/*Foobar*/
/*
baz
*/
```
### The reason...

...for this is that some [frameworks](http://docs.turbulenz.com/starter/getting_started_guide.html#using-javascript-libraries)/[tools](http://www.stack.nl/~dimitri/doxygen/helpers.html) use specially crafted comments as directives. In the former case, since they use `/*{` and `}*/` as delimiters, it is impossible to use coffeescript because of the current behavior. With this pull-request, it becomes possible by using `###{` and `}###` on one line.

Last and least,

``` js
/* Foo
*/
```

just looks wrong.
