### PR TITLE
Fixes #2908, add "\n" between pure literal header and function body.

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -475,6 +475,8 @@
             fragments.push(this.makeCode(scope.assignedVariables().join(",\n" + (this.tab + TAB))));
           }
           fragments.push(this.makeCode(";\n" + (this.spaced ? '\n' : '')));
+        } else if (fragments.length && post.length) {
+          fragments.push(this.makeCode("\n"));
         }
       }
       return fragments.concat(post);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -352,6 +352,8 @@ exports.Block = class Block extends Base
           fragments.push @makeCode ",\n#{@tab + TAB}" if declars
           fragments.push @makeCode (scope.assignedVariables().join ",\n#{@tab + TAB}")
         fragments.push @makeCode ";\n#{if @spaced then '\n' else ''}"
+      else if fragments.length and post.length
+        fragments.push @makeCode "\n"
     fragments.concat post
 
   # Wrap up the given nodes as a **Block**, unless it already happens


### PR DESCRIPTION
before patching

```
->
  debugger
  a()
```

is compiled to

```
  (function() {
    debugger;    return a();
  });
```

this commit will add "\n" between pure literal header and function body if neither of them is empty, it will be compiled to

```
  (function() {
    debugger;    
    return a();
  });
```
