### PR TITLE
fix warning in REPL tests about memory leak.

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -118,8 +118,8 @@
         return lastLine = code;
       }
     });
-    process.on('exit', function() {
-      return fs.closeSync(fd);
+    repl.rli.on('exit', function() {
+      return fs.close(fd);
     });
     return repl.commands['.history'] = {
       help: 'Show command history',

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -108,8 +108,7 @@ addHistory = (repl, filename, maxSize) ->
       fs.write fd, "#{code}\n"
       lastLine = code
 
-  process.on 'exit', ->
-    fs.closeSync fd
+  repl.rli.on 'exit', -> fs.close fd
 
   # Add a command to show the history stack
   repl.commands['.history'] =


### PR DESCRIPTION
The history file was set to close on process exit, when it
should close on REPL exit. Listening to the process exit
event causes a warning when more than 10 CoffeeScript REPL
instances are opened in the same program, which happens in
the test.
