### PR TITLE
Fix 'propeties' typo in docs

### DIFF
--- a/documentation/index.html.erb
+++ b/documentation/index.html.erb
@@ -801,7 +801,7 @@ Expressions
     <%= code_for('patterns_and_splats', 'contents.join("")') %>
     <p>
       Destructuring assignment is also useful when combined with class constructors
-      to assign propeties to your instance from an options object passed to the constructor.
+      to assign properties to your instance from an options object passed to the constructor.
     </p>
     <%= code_for('constructor_destructuring', 'contents.join("")') %>
 


### PR DESCRIPTION
Does what it says on the tin.
