### PR TITLE
Fixes tabbed code test in literate

### DIFF
--- a/test/literate.litcoffee
+++ b/test/literate.litcoffee
@@ -53,5 +53,5 @@ and unordered lists, are fine:
 
 Tabs work too:
 
-	test "tabbed code", ->
-		ok yes
+				test "tabbed code", ->
+					ok yes


### PR DESCRIPTION
Makes this test run. The test has been ignored thanks to #2981, and until that is fixed, we can't be sure whether all tests run or not (but in fact this is the only test ignored by this bug at the moment).
