### PR TITLE
base path for compilation can be './' as well as '.'

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -257,7 +257,7 @@ removeSource = (source, base, removeJs) ->
 outputPath = (source, base, extension=".js") ->
   basename  = helpers.baseFileName source, yes, useWinPathSep
   srcDir    = path.dirname source
-  baseDir   = if base is '.' then srcDir else srcDir.substring base.length
+  baseDir   = if base in ['.', './'] then srcDir else srcDir.substring base.length
   dir       = if opts.output then path.join opts.output, baseDir else srcDir
   path.join dir, basename + extension
 


### PR DESCRIPTION
Hi, this is a fix for unexpected behaviour when compiling with the -c switch and './' value. See below, please. Thanks.

When coffee is invoked with the -c parameter and './' value, first two characters of the directory into which the compiled files are stored get chopped off.
Example: if compilation invoked like this: 'coffee -o ../lib/ -cw ./', then
Source file: ./OutputFolder/file.coffee, compiled output: ./../lib/tputFolder/
The code only expected '.' to mark the local folder. However, './' is equally valid.
