### PR TITLE
Patch stack trace optimizations

### DIFF
--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -43,6 +43,10 @@ test "compiler error formatting", ->
                  ^^^^
   '''
 
+test "patchStackTrace line patching", ->
+  err = new Error 'error'
+  ok err.stack.indexOf('test/error_messages.coffee:47:4') >= 0 # should be fixed to the correct line if more lines added to this file
+
 fs = require 'fs'
 
 test "#2849: compilation error in a require()d file", ->


### PR DESCRIPTION
Love the `patchStackTrace` in 1.6.3. However, it's only applied when executing with `coffee` or `cake` because they call `run()`. There are other cases when entry to the application is not `coffee` (for example node-dev, mocha, jasmine, a custom `server.js` for amazon, etc). To be able to utilize patched stack traces, I've exposed the `patchStackTrace` and created `unpatchStackTrace` to reverse it.

Also, I noticed that source maps were being generated during `require()` calls and ONLY used to patch stack traces. I've changed moved source map generation to happen only during stack error patching. There's a tiny bit of penalty there, but it's better to do a little extra work then, rather at boot up time.

Opinions?
