### PR TITLE
fix block comment format "\n"

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -555,9 +555,9 @@ exports.Comment = class Comment extends Base
   makeReturn:      THIS
 
   compileNode: (o, level) ->
-    code = "/*#{multident @comment, @tab}#{if '\n' in @comment then "\n#{@tab}" else ''}*/\n"
+    code = "/*#{multident @comment, @tab}#{if '\n' in @comment then "\n#{@tab}" else ''}*/"
     code = o.indent + code if (level or o.level) is LEVEL_TOP
-    [@makeCode code]
+    [@makeCode "\n", @makeCode code]
 
 #### Call
 


### PR DESCRIPTION
compile the coffeescript has block comment like:

``` coffeescript
###
test comment
###

define (require, exports, module) ->

  ###
  test comment
  ###
  exports.setName = ->
    "wx"

  ###
  test comment
  ###
  exports.setAge  = ->
    88
```

it will output:

``` javascript
/*
test comment
*/

define(function(require, exports, module) {
  /*
  test comment
  */

  exports.setName = function() {
    return "wx";
  };
  /*
  test comment
  */

  return exports.setAge = function() {
    return 88;
  };

```

the block comment close to the prev statement.
I want to compile coffee output comment close to the next statement.

after the pull request, compile  coffee src will output:

``` javascript
/*
test comment
*/
define(function(require, exports, module) {

  /*
  test comment
  */
  exports.setName = function() {
    return "wx";
  };

  /*
  test comment
  */
  return exports.setAge = function() {
    return 88;
  };
});

```
