### PR TITLE
Stack trace patch optimizations

### DIFF
--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -100,7 +100,7 @@ exports.run = (code, options = {}) ->
   # Compile.
   if not helpers.isCoffee(mainModule.filename) or require.extensions
     answer = compile code, options
-    code = answer.js? and answer.js or answer
+    code = answer.js ? answer
 
   mainModule._compile code, mainModule.filename
 

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -45,7 +45,7 @@ test "compiler error formatting", ->
 
 test "patchStackTrace line patching", ->
   err = new Error 'error'
-  ok err.stack.indexOf('test/error_messages.coffee:47:4') >= 0 # should be fixed to the correct line if more lines added to this file
+  ok err.stack.match /test\/error_messages\.coffee:\d+:\d+\b/
 
 fs = require 'fs'
 


### PR DESCRIPTION
As per discussion in https://github.com/jashkenas/coffee-script/pull/3026. The patch:
- enables stack line patching to be on by default 
- optimizes source map generation required for line numbers 
- changes generated stack line number to be the same format as original JS
