### PR TITLE
Avoid excessive AST traversal in `updateLocationDataIfMissing`.

### DIFF
--- a/lib/coffee-script/grammar.js
+++ b/lib/coffee-script/grammar.js
@@ -514,9 +514,9 @@
           type: $1
         });
       }), o('IfBlock ELSE IF Expression Block', function() {
-        return $1.addElse(new If($4, $5, {
+        return $1.addElse(LOC(3, 5)(new If($4, $5, {
           type: $3
-        }));
+        })));
       })
     ],
     If: [

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -229,7 +229,10 @@
     Base.prototype.assigns = NO;
 
     Base.prototype.updateLocationDataIfMissing = function(locationData) {
-      this.locationData || (this.locationData = locationData);
+      if (this.locationData) {
+        return this;
+      }
+      this.locationData = locationData;
       return this.eachChild(function(child) {
         return child.updateLocationDataIfMissing(locationData);
       });
@@ -2852,6 +2855,7 @@
       } else {
         this.isChain = elseBody instanceof If;
         this.elseBody = this.ensureBlock(elseBody);
+        this.elseBody.updateLocationDataIfMissing(elseBody.locationData);
       }
       return this;
     };

--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -486,9 +486,9 @@ case 180:this.$ = yy.addLocationDataFn(_$[$0-2], _$[$0])(new yy.If($$[$0-1], $$[
           type: $$[$0-2]
         }));
 break;
-case 181:this.$ = yy.addLocationDataFn(_$[$0-4], _$[$0])($$[$0-4].addElse(new yy.If($$[$0-1], $$[$0], {
+case 181:this.$ = yy.addLocationDataFn(_$[$0-4], _$[$0])($$[$0-4].addElse(yy.addLocationDataFn(_$[$0-2], _$[$0])(new yy.If($$[$0-1], $$[$0], {
           type: $$[$0-2]
-        })));
+        }))));
 break;
 case 182:this.$ = $$[$0];
 break;

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -511,7 +511,7 @@ grammar =
   # ambiguity.
   IfBlock: [
     o 'IF Expression Block',                    -> new If $2, $3, type: $1
-    o 'IfBlock ELSE IF Expression Block',       -> $1.addElse new If $4, $5, type: $3
+    o 'IfBlock ELSE IF Expression Block',       -> $1.addElse LOC(3,5) new If $4, $5, type: $3
   ]
 
   # The full complement of *if* expressions, including postfix one-liner

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -176,7 +176,8 @@ exports.Base = class Base
   # For this node and all descendents, set the location data to `locationData`
   # if the location data is not already set.
   updateLocationDataIfMissing: (locationData) ->
-    @locationData or= locationData
+    return this if @locationData
+    @locationData = locationData
 
     @eachChild (child) ->
       child.updateLocationDataIfMissing locationData
@@ -2006,6 +2007,7 @@ exports.If = class If extends Base
     else
       @isChain  = elseBody instanceof If
       @elseBody = @ensureBlock elseBody
+      @elseBody.updateLocationDataIfMissing elseBody.locationData
     this
 
   # The **If** only compiles into a statement if either of its bodies needs


### PR DESCRIPTION
Fixes #2844 by not searching for missing `locationData` on nodes that (provably) have it already set.

The effect (on my humble computing machine):

```
$ cake bench                          $ cake bench
Lex      426 ms (28534 tokens)        Lex      418 ms (28534 tokens)
Rewrite  775 ms (31761 tokens)  ___\  Rewrite  644 ms (31761 tokens)
Parse   4946 ms                    /  Parse    629 ms
Compile  717 ms (177853 chars)        Compile  723 ms (177853 chars)
total   6864 ms                       total   2414 ms
```

Because the relevant code is somewhat complex, here's a lengthy discussion as to how everything works, what goes wrong and how this PR fixes it:
### `locationData` on AST nodes - Theory of Operation

AST nodes are constructed by:
- parser actions
- node constructors
- `If.addElse` via `@ensureBlock`
- compilation-methods of nodes

The `locationData` on AST nodes is set (solely) by the `updateLocationDataIfMissing` method which in turn is (only) invoked by the `addLocationDataFn` helper. The helper is used in parser actions implicitly for each action result or explicitly by `LOC`.

`updateLocationDataIfMissing` sets the `locationData` on a node and then recursively traverses down its child nodes. The latter ensures that all child nodes have their `locationData` set, allowing for simpler parser actions (not littered with `LOC` invocations).
### The speed bump

While the behaviour described above might seem innocuous, it means that for almost every production all subjacent AST fragments are wholly traversed, in search of a missing `locationData` attribute.
### Fixing it

This PR fixes one issue (see below) to ensure that for all nodes that have `locationData`, all of their child nodes do too. Thus `updateLocationDataIfMissing` only needs to operate on "location-less" nodes.

This is fairly simple: We don't need to care about nodes constructed during compilation at all (as they are not involved in any of this).

Almost all nodes constructed in parser actions and subsequently in constructors are (part of) the return value and will be processed by `LOC`/`addLocationDataFn`.

The only exception is the second `if` of `IfBlock ELSE IF ...` which is added to `IfBlock` via `If::addElse` which returns the (first) `IfBlock` (that already has a `locationData`). This is fixed by explicitly calling `LOC`.

`If::addElse` does also construct a `Block` node. Its `locationData` is now set to that of the wrapped `elseBody`. This is just for completeness sake, so that all AST nodes always have `locationData`.
