### PR TITLE
Fix path separator issues in tests.

### DIFF
--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -45,9 +45,10 @@ test "compiler error formatting", ->
 
 test "patchStackTrace line patching", ->
   err = new Error 'error'
-  ok err.stack.match /test\/error_messages\.coffee:\d+:\d+\b/
+  ok err.stack.match /test[\/\\]error_messages\.coffee:\d+:\d+\b/
 
-fs = require 'fs'
+fs   = require 'fs'
+path = require 'path'
 
 test "#2849: compilation error in a require()d file", ->
   # Create a temporary file to require().
@@ -59,7 +60,7 @@ test "#2849: compilation error in a require()d file", ->
       require './test/syntax-error'
     ''',
     """
-      #{__dirname}/syntax-error.coffee:1:15: error: unexpected RELATION
+      #{path.join __dirname, 'syntax-error.coffee'}:1:15: error: unexpected RELATION
       foo in bar or in baz
                     ^^
     """


### PR DESCRIPTION
Some tests fail under Windows due to hardcoded *nix path separators.
