### PR TITLE
respect argument order when compiling multiple files to stdout

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -53,7 +53,7 @@
   optionParser = null;
 
   exports.run = function() {
-    var literals, source, _i, _len, _results;
+    var code, err, line, literals, originalPrintLine, queue, source, _i, _j, _k, _len, _len1, _len2, _results, _results1;
     parseOptions();
     if (opts.nodejs) {
       return forkNode();
@@ -82,12 +82,48 @@
     literals = opts.run ? sources.splice(1) : [];
     process.argv = process.argv.slice(0, 2).concat(literals);
     process.argv[0] = 'coffee';
-    _results = [];
-    for (_i = 0, _len = sources.length; _i < _len; _i++) {
-      source = sources[_i];
-      _results.push(compilePath(source, true, path.normalize(source)));
+    if (opts.print) {
+      queue = [];
+      originalPrintLine = printLine;
+      printLine = function(line) {
+        return queue.push(line);
+      };
+      for (_i = 0, _len = sources.length; _i < _len; _i++) {
+        source = sources[_i];
+        try {
+          code = fs.readFileSync(source);
+        } catch (_error) {
+          err = _error;
+          switch (err.code) {
+            case 'ENOENT':
+              printWarn("File not found: " + source);
+              process.exit(1);
+              break;
+            case 'EISDIR':
+              printWarn('Directory enumeration would yield nondeterministic --print output');
+              process.exit(1);
+              break;
+            default:
+              throw err;
+          }
+        }
+        compileScript(source, code.toString(), path.normalize(source));
+      }
+      printLine = originalPrintLine;
+      _results = [];
+      for (_j = 0, _len1 = queue.length; _j < _len1; _j++) {
+        line = queue[_j];
+        _results.push(printLine(line));
+      }
+      return _results;
+    } else {
+      _results1 = [];
+      for (_k = 0, _len2 = sources.length; _k < _len2; _k++) {
+        source = sources[_k];
+        _results1.push(compilePath(source, true, path.normalize(source)));
+      }
+      return _results1;
     }
-    return _results;
   };
 
   compilePath = function(source, topLevel, base) {


### PR DESCRIPTION
I expected this to produce a JavaScript file containing the compiled output of each of the three source files in the specified order:

``` make
dist/quux.js: src/foo.coffee src/bar.coffee src/baz.coffee
    @node_modules/.bin/coffee --compile --print $+ > $@
```

Apparently this usage was not anticipated, as order in which the compiled code is written to stdout in nondeterministic (i.e. not necessarily _foo_ then _bar_ then _baz_).
