### PR TITLE
Call compile() as the callback for mkdir

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -435,9 +435,10 @@
         return mkdirp(jsDir, function(err) {
           if (err) {
             printLine("Error while creating dir " + jsDir + ": " + err);
-            exec("mkdir -p " + jsDir);
+            return exec("mkdir -p " + jsDir, compile);
+          } else {
+            return compile();
           }
-          return compile();
         });
       }
     });

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -286,8 +286,11 @@ writeJs = (base, sourcePath, js, jsPath, generatedSourceMap = null) ->
           printLine "Could not write source map: #{err.message}"
   exists jsDir, (itExists) ->
     if itExists then compile() else mkdirp jsDir, (err) => 
-      if err then printLine "Error while creating dir #{jsDir}: #{err}"; exec "mkdir -p #{jsDir}"
-      compile()
+      if err 
+        printLine "Error while creating dir #{jsDir}: #{err}"
+        exec "mkdir -p #{jsDir}", compile
+      else
+        compile()
 
 # Convenience for cleaner setTimeouts.
 wait = (milliseconds, func) -> setTimeout func, milliseconds


### PR DESCRIPTION
Sorry @jashkenas, I was too slow (or you were too fast). I have realized that when original `mkdir -p` is used, it should call `compile()` upon its success only. Feel free to ditch this, if such fix is not necessary.
