### PR TITLE
Fix formatting in underscore.coffee documentation (generated html)

### DIFF
--- a/documentation/docs/underscore.html
+++ b/documentation/docs/underscore.html
@@ -1,295 +1,1892 @@
-<!DOCTYPE html>  <html> <head>   <title>underscore.coffee</title>   <meta http-equiv="content-type" content="text/html; charset=UTF-8">   <link rel="stylesheet" media="all" href="docco.css" /> </head> <body>   <div id="container">     <div id="background"></div>          <table cellpadding="0" cellspacing="0">       <thead>         <tr>           <th class="docs">             <h1>               underscore.coffee             </h1>           </th>           <th class="code">           </th>         </tr>       </thead>       <tbody>                               <tr id="section-1">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-1">&#182;</a>               </div>               <p><strong>Underscore.coffee
+<!DOCTYPE html>
+
+<html>
+<head>
+  <title>underscore.coffee</title>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <link rel="stylesheet" media="all" href="docco.css" />
+</head>
+<body>
+  <div id="container">
+    <div id="background"></div>
+    
+    <ul class="sections">
+        
+          <li id="title">
+              <div class="annotation">
+                  <h1>underscore.coffee</h1>
+              </div>
+          </li>
+        
+        
+        
+        <li id="section-1">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-1">&#182;</a>
+              </div>
+              <p><strong>Underscore.coffee
 (c) 2011 Jeremy Ashkenas, DocumentCloud Inc.</strong>
 Underscore is freely distributable under the terms of the
 <a href="http://en.wikipedia.org/wiki/MIT_License">MIT license</a>.
 Portions of Underscore are inspired by or borrowed from
-<a href="http://prototypejs.org/api">Prototype.js</a>, Oliver Steele's
-<a href="http://osteele.com">Functional</a>, and John Resig's
+<a href="http://prototypejs.org/api">Prototype.js</a>, Oliver Steele&#39;s
+<a href="http://osteele.com">Functional</a>, and John Resig&#39;s
 <a href="http://ejohn.org">Micro-Templating</a>.
 For all details and documentation:
-http://documentcloud.github.com/underscore/</p>             </td>             <td class="code">               <div class="highlight"><pre></pre></div>             </td>           </tr>                               <tr id="section-2">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-2">&#182;</a>               </div>               <h2>Baseline setup</h2>             </td>             <td class="code">               <div class="highlight"><pre></pre></div>             </td>           </tr>                               <tr id="section-3">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-3">&#182;</a>               </div>               <p>Establish the root object, <code>window</code> in the browser, or <code>global</code> on the server.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">root = </span><span class="k">this</span></pre></div>             </td>           </tr>                               <tr id="section-4">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-4">&#182;</a>               </div>               <p>Save the previous value of the <code>_</code> variable.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">previousUnderscore = </span><span class="nx">root</span><span class="p">.</span><span class="nx">_</span></pre></div>             </td>           </tr>                               <tr id="section-5">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-5">&#182;</a>               </div>               <p>Establish the object that gets thrown to break out of a loop iteration.
-<code>StopIteration</code> is SOP on Mozilla.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">breaker = </span><span class="k">if</span> <span class="k">typeof</span><span class="p">(</span><span class="nx">StopIteration</span><span class="p">)</span> <span class="o">is</span> <span class="s1">&#39;undefined&#39;</span> <span class="k">then</span> <span class="s1">&#39;__break__&#39;</span> <span class="k">else</span> <span class="nx">StopIteration</span></pre></div>             </td>           </tr>                               <tr id="section-6">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-6">&#182;</a>               </div>               <p>Helper function to escape <strong>RegExp</strong> contents, because JS doesn't have one.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">escapeRegExp = </span><span class="nf">(string) -&gt;</span> <span class="nx">string</span><span class="p">.</span><span class="nx">replace</span><span class="p">(</span><span class="sr">/([.*+?^${}()|[\]\/\\])/g</span><span class="p">,</span> <span class="s1">&#39;\\$1&#39;</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-7">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-7">&#182;</a>               </div>               <p>Save bytes in the minified (but not gzipped) version:</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">ArrayProto           = </span><span class="nb">Array</span><span class="p">.</span><span class="nx">prototype</span>
-<span class="nv">ObjProto             = </span><span class="nb">Object</span><span class="p">.</span><span class="nx">prototype</span></pre></div>             </td>           </tr>                               <tr id="section-8">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-8">&#182;</a>               </div>               <p>Create quick reference variables for speed access to core prototypes.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">slice                = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">slice</span>
-<span class="nv">unshift              = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">unshift</span>
-<span class="nv">toString             = </span><span class="nx">ObjProto</span><span class="p">.</span><span class="nx">toString</span>
-<span class="nv">hasOwnProperty       = </span><span class="nx">ObjProto</span><span class="p">.</span><span class="nx">hasOwnProperty</span>
-<span class="nv">propertyIsEnumerable = </span><span class="nx">ObjProto</span><span class="p">.</span><span class="nx">propertyIsEnumerable</span></pre></div>             </td>           </tr>                               <tr id="section-9">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-9">&#182;</a>               </div>               <p>All <strong>ECMA5</strong> native implementations we hope to use are declared here.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">nativeForEach        = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">forEach</span>
-<span class="nv">nativeMap            = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">map</span>
-<span class="nv">nativeReduce         = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">reduce</span>
-<span class="nv">nativeReduceRight    = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">reduceRight</span>
-<span class="nv">nativeFilter         = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">filter</span>
-<span class="nv">nativeEvery          = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">every</span>
-<span class="nv">nativeSome           = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">some</span>
-<span class="nv">nativeIndexOf        = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">indexOf</span>
-<span class="nv">nativeLastIndexOf    = </span><span class="nx">ArrayProto</span><span class="p">.</span><span class="nx">lastIndexOf</span>
-<span class="nv">nativeIsArray        = </span><span class="nb">Array</span><span class="p">.</span><span class="nx">isArray</span>
-<span class="nv">nativeKeys           = </span><span class="nb">Object</span><span class="p">.</span><span class="nx">keys</span></pre></div>             </td>           </tr>                               <tr id="section-10">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-10">&#182;</a>               </div>               <p>Create a safe reference to the Underscore object for use below.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_ = </span><span class="nf">(obj) -&gt;</span> <span class="k">new</span> <span class="nx">wrapper</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-11">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-11">&#182;</a>               </div>               <p>Export the Underscore object for <strong>CommonJS</strong>.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="k">if</span> <span class="k">typeof</span><span class="p">(</span><span class="nx">exports</span><span class="p">)</span> <span class="o">!=</span> <span class="s1">&#39;undefined&#39;</span> <span class="k">then</span> <span class="nv">exports._ = </span><span class="nx">_</span></pre></div>             </td>           </tr>                               <tr id="section-12">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-12">&#182;</a>               </div>               <p>Export Underscore to global scope.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">root._ = </span><span class="nx">_</span></pre></div>             </td>           </tr>                               <tr id="section-13">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-13">&#182;</a>               </div>               <p>Current version.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.VERSION = </span><span class="s1">&#39;1.1.0&#39;</span></pre></div>             </td>           </tr>                               <tr id="section-14">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-14">&#182;</a>               </div>               <h2>Collection Functions</h2>             </td>             <td class="code">               <div class="highlight"><pre></pre></div>             </td>           </tr>                               <tr id="section-15">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-15">&#182;</a>               </div>               <p>The cornerstone, an <strong>each</strong> implementation.
-Handles objects implementing <strong>forEach</strong>, arrays, and raw objects.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.each = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="k">try</span>
-    <span class="k">if</span> <span class="nx">nativeForEach</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">forEach</span> <span class="o">is</span> <span class="nx">nativeForEach</span>
-      <span class="nx">obj</span><span class="p">.</span><span class="nx">forEach</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">context</span>
-    <span class="k">else</span> <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isNumber</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">length</span>
-      <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span> <span class="nx">context</span><span class="p">,</span> <span class="nx">obj</span><span class="p">[</span><span class="nx">i</span><span class="p">],</span> <span class="nx">i</span><span class="p">,</span> <span class="nx">obj</span> <span class="k">for</span> <span class="nx">i</span> <span class="k">in</span> <span class="p">[</span><span class="mi">0</span><span class="p">...</span><span class="nx">obj</span><span class="p">.</span><span class="nx">length</span><span class="p">]</span>
-    <span class="k">else</span>
-      <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span> <span class="nx">context</span><span class="p">,</span> <span class="nx">val</span><span class="p">,</span> <span class="nx">key</span><span class="p">,</span> <span class="nx">obj</span>  <span class="k">for</span> <span class="nx">own</span> <span class="nx">key</span><span class="p">,</span> <span class="nx">val</span> <span class="k">of</span> <span class="nx">obj</span>
-  <span class="k">catch</span> <span class="nx">e</span>
-    <span class="k">throw</span> <span class="nx">e</span> <span class="k">if</span> <span class="nx">e</span> <span class="o">isnt</span> <span class="nx">breaker</span>
-  <span class="nx">obj</span></pre></div>             </td>           </tr>                               <tr id="section-16">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-16">&#182;</a>               </div>               <p>Return the results of applying the iterator to each element. Use JavaScript
-1.6's version of <strong>map</strong>, if possible.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.map = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="k">return</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">map</span><span class="p">(</span><span class="nx">iterator</span><span class="p">,</span> <span class="nx">context</span><span class="p">)</span> <span class="k">if</span> <span class="nx">nativeMap</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">map</span> <span class="o">is</span> <span class="nx">nativeMap</span>
-  <span class="nv">results = </span><span class="p">[]</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="nx">results</span><span class="p">.</span><span class="nx">push</span> <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span> <span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span>
-  <span class="nx">results</span></pre></div>             </td>           </tr>                               <tr id="section-17">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-17">&#182;</a>               </div>               <p><strong>Reduce</strong> builds up a single result from a list of values. Also known as
-<strong>inject</strong>, or <strong>foldl</strong>. Uses JavaScript 1.8's version of <strong>reduce</strong>, if possible.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.reduce = </span><span class="nf">(obj, iterator, memo, context) -&gt;</span>
-  <span class="k">if</span> <span class="nx">nativeReduce</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">reduce</span> <span class="o">is</span> <span class="nx">nativeReduce</span>
-    <span class="nv">iterator = </span><span class="nx">_</span><span class="p">.</span><span class="nx">bind</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">context</span> <span class="k">if</span> <span class="nx">context</span>
-    <span class="k">return</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">reduce</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">memo</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="nv">memo = </span><span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span> <span class="nx">context</span><span class="p">,</span> <span class="nx">memo</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span>
-  <span class="nx">memo</span></pre></div>             </td>           </tr>                               <tr id="section-18">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-18">&#182;</a>               </div>               <p>The right-associative version of <strong>reduce</strong>, also known as <strong>foldr</strong>. Uses
-JavaScript 1.8's version of <strong>reduceRight</strong>, if available.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.reduceRight = </span><span class="nf">(obj, iterator, memo, context) -&gt;</span>
-  <span class="k">if</span> <span class="nx">nativeReduceRight</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">reduceRight</span> <span class="o">is</span> <span class="nx">nativeReduceRight</span>
-    <span class="nv">iterator = </span><span class="nx">_</span><span class="p">.</span><span class="nx">bind</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">context</span> <span class="k">if</span> <span class="nx">context</span>
-    <span class="k">return</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">reduceRight</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">memo</span>
-  <span class="nv">reversed = </span><span class="nx">_</span><span class="p">.</span><span class="nx">clone</span><span class="p">(</span><span class="nx">_</span><span class="p">.</span><span class="nx">toArray</span><span class="p">(</span><span class="nx">obj</span><span class="p">)).</span><span class="nx">reverse</span><span class="p">()</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">reduce</span> <span class="nx">reversed</span><span class="p">,</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">memo</span><span class="p">,</span> <span class="nx">context</span></pre></div>             </td>           </tr>                               <tr id="section-19">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-19">&#182;</a>               </div>               <p>Return the first value which passes a truth test.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.detect = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="nv">result = </span><span class="kc">null</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="k">if</span> <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span> <span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span>
-      <span class="nv">result = </span><span class="nx">value</span>
-      <span class="nx">_</span><span class="p">.</span><span class="nx">breakLoop</span><span class="p">()</span>
-  <span class="nx">result</span></pre></div>             </td>           </tr>                               <tr id="section-20">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-20">&#182;</a>               </div>               <p>Return all the elements that pass a truth test. Use JavaScript 1.6's
-<strong>filter</strong>, if it exists.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.filter = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="k">return</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">filter</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">context</span> <span class="k">if</span> <span class="nx">nativeFilter</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">filter</span> <span class="o">is</span> <span class="nx">nativeFilter</span>
-  <span class="nv">results = </span><span class="p">[]</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="nx">results</span><span class="p">.</span><span class="nx">push</span> <span class="nx">value</span> <span class="k">if</span> <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span> <span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span>
-  <span class="nx">results</span></pre></div>             </td>           </tr>                               <tr id="section-21">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-21">&#182;</a>               </div>               <p>Return all the elements for which a truth test fails.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.reject = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="nv">results = </span><span class="p">[]</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="nx">results</span><span class="p">.</span><span class="nx">push</span> <span class="nx">value</span> <span class="k">if</span> <span class="o">not</span> <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span> <span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span>
-  <span class="nx">results</span></pre></div>             </td>           </tr>                               <tr id="section-22">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-22">&#182;</a>               </div>               <p>Determine whether all of the elements match a truth test. Delegate to
-JavaScript 1.6's <strong>every</strong>, if it is present.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.every = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="nx">iterator</span> <span class="o">||=</span> <span class="nx">_</span><span class="p">.</span><span class="nx">identity</span>
-  <span class="k">return</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">every</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">context</span> <span class="k">if</span> <span class="nx">nativeEvery</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">every</span> <span class="o">is</span> <span class="nx">nativeEvery</span>
-  <span class="nv">result = </span><span class="kc">true</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="nx">_</span><span class="p">.</span><span class="nx">breakLoop</span><span class="p">()</span> <span class="nx">unless</span> <span class="p">(</span><span class="nv">result = </span><span class="nx">result</span> <span class="o">and</span> <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span><span class="p">))</span>
-  <span class="nx">result</span></pre></div>             </td>           </tr>                               <tr id="section-23">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-23">&#182;</a>               </div>               <p>Determine if at least one element in the object matches a truth test. Use
-JavaScript 1.6's <strong>some</strong>, if it exists.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.some = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="nx">iterator</span> <span class="o">||=</span> <span class="nx">_</span><span class="p">.</span><span class="nx">identity</span>
-  <span class="k">return</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">some</span> <span class="nx">iterator</span><span class="p">,</span> <span class="nx">context</span> <span class="k">if</span> <span class="nx">nativeSome</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">some</span> <span class="o">is</span> <span class="nx">nativeSome</span>
-  <span class="nv">result = </span><span class="kc">false</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="nx">_</span><span class="p">.</span><span class="nx">breakLoop</span><span class="p">()</span> <span class="k">if</span> <span class="p">(</span><span class="nv">result = </span><span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span><span class="p">))</span>
-  <span class="nx">result</span></pre></div>             </td>           </tr>                               <tr id="section-24">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-24">&#182;</a>               </div>               <p>Determine if a given value is included in the array or object,
-based on <code>===</code>.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.include = </span><span class="nf">(obj, target) -&gt;</span>
-  <span class="k">return</span> <span class="nx">_</span><span class="p">.</span><span class="nx">indexOf</span><span class="p">(</span><span class="nx">obj</span><span class="p">,</span> <span class="nx">target</span><span class="p">)</span> <span class="o">isnt</span> <span class="o">-</span><span class="mi">1</span> <span class="k">if</span> <span class="nx">nativeIndexOf</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">indexOf</span> <span class="o">is</span> <span class="nx">nativeIndexOf</span>
-  <span class="k">return</span> <span class="kc">true</span> <span class="k">for</span> <span class="nx">own</span> <span class="nx">key</span><span class="p">,</span> <span class="nx">val</span> <span class="k">of</span> <span class="nx">obj</span> <span class="k">when</span> <span class="nx">val</span> <span class="o">is</span> <span class="nx">target</span>
-  <span class="kc">false</span></pre></div>             </td>           </tr>                               <tr id="section-25">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-25">&#182;</a>               </div>               <p>Invoke a method with arguments on every item in a collection.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.invoke = </span><span class="nf">(obj, method) -&gt;</span>
-  <span class="nv">args = </span><span class="nx">_</span><span class="p">.</span><span class="nx">rest</span> <span class="nx">arguments</span><span class="p">,</span> <span class="mi">2</span>
-  <span class="p">(</span><span class="k">if</span> <span class="nx">method</span> <span class="k">then</span> <span class="nx">val</span><span class="p">[</span><span class="nx">method</span><span class="p">]</span> <span class="k">else</span> <span class="nx">val</span><span class="p">).</span><span class="nx">apply</span><span class="p">(</span><span class="nx">val</span><span class="p">,</span> <span class="nx">args</span><span class="p">)</span> <span class="k">for</span> <span class="nx">val</span> <span class="k">in</span> <span class="nx">obj</span></pre></div>             </td>           </tr>                               <tr id="section-26">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-26">&#182;</a>               </div>               <p>Convenience version of a common use case of <strong>map</strong>: fetching a property.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.pluck = </span><span class="nf">(obj, key) -&gt;</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">map</span><span class="p">(</span><span class="nx">obj</span><span class="p">,</span> <span class="nf">(val) -&gt;</span> <span class="nx">val</span><span class="p">[</span><span class="nx">key</span><span class="p">])</span></pre></div>             </td>           </tr>                               <tr id="section-27">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-27">&#182;</a>               </div>               <p>Return the maximum item or (item-based computation).</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.max = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="k">return</span> <span class="nb">Math</span><span class="p">.</span><span class="nx">max</span><span class="p">.</span><span class="nx">apply</span><span class="p">(</span><span class="nb">Math</span><span class="p">,</span> <span class="nx">obj</span><span class="p">)</span> <span class="k">if</span> <span class="o">not</span> <span class="nx">iterator</span> <span class="o">and</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isArray</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span>
-  <span class="nv">result = computed: </span><span class="o">-</span><span class="kc">Infinity</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="nv">computed = </span><span class="k">if</span> <span class="nx">iterator</span> <span class="k">then</span> <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span><span class="p">)</span> <span class="k">else</span> <span class="nx">value</span>
-    <span class="nx">computed</span> <span class="o">&gt;=</span> <span class="nx">result</span><span class="p">.</span><span class="nx">computed</span> <span class="o">and</span> <span class="p">(</span><span class="nv">result = </span><span class="p">{</span><span class="nv">value: </span><span class="nx">value</span><span class="p">,</span> <span class="nv">computed: </span><span class="nx">computed</span><span class="p">})</span>
-  <span class="nx">result</span><span class="p">.</span><span class="nx">value</span></pre></div>             </td>           </tr>                               <tr id="section-28">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-28">&#182;</a>               </div>               <p>Return the minimum element (or element-based computation).</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.min = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="k">return</span> <span class="nb">Math</span><span class="p">.</span><span class="nx">min</span><span class="p">.</span><span class="nx">apply</span><span class="p">(</span><span class="nb">Math</span><span class="p">,</span> <span class="nx">obj</span><span class="p">)</span> <span class="k">if</span> <span class="o">not</span> <span class="nx">iterator</span> <span class="o">and</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isArray</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span>
-  <span class="nv">result = computed: </span><span class="kc">Infinity</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="nv">computed = </span><span class="k">if</span> <span class="nx">iterator</span> <span class="k">then</span> <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span><span class="p">)</span> <span class="k">else</span> <span class="nx">value</span>
-    <span class="nx">computed</span> <span class="o">&lt;</span> <span class="nx">result</span><span class="p">.</span><span class="nx">computed</span> <span class="o">and</span> <span class="p">(</span><span class="nv">result = </span><span class="p">{</span><span class="nv">value: </span><span class="nx">value</span><span class="p">,</span> <span class="nv">computed: </span><span class="nx">computed</span><span class="p">})</span>
-  <span class="nx">result</span><span class="p">.</span><span class="nx">value</span></pre></div>             </td>           </tr>                               <tr id="section-29">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-29">&#182;</a>               </div>               <p>Sort the object's values by a criterion produced by an iterator.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.sortBy = </span><span class="nf">(obj, iterator, context) -&gt;</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">pluck</span><span class="p">(((</span><span class="nx">_</span><span class="p">.</span><span class="nx">map</span> <span class="nx">obj</span><span class="p">,</span> <span class="nf">(value, index, list) -&gt;</span>
-    <span class="p">{</span><span class="nv">value: </span><span class="nx">value</span><span class="p">,</span> <span class="nv">criteria: </span><span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">context</span><span class="p">,</span> <span class="nx">value</span><span class="p">,</span> <span class="nx">index</span><span class="p">,</span> <span class="nx">list</span><span class="p">)}</span>
-  <span class="p">).</span><span class="nx">sort</span><span class="p">(</span><span class="nf">(left, right) -&gt;</span>
-    <span class="nv">a = </span><span class="nx">left</span><span class="p">.</span><span class="nx">criteria</span><span class="p">;</span> <span class="nv">b = </span><span class="nx">right</span><span class="p">.</span><span class="nx">criteria</span>
-    <span class="k">if</span> <span class="nx">a</span> <span class="o">&lt;</span> <span class="nx">b</span> <span class="k">then</span> <span class="o">-</span><span class="mi">1</span> <span class="k">else</span> <span class="k">if</span> <span class="nx">a</span> <span class="o">&gt;</span> <span class="nx">b</span> <span class="k">then</span> <span class="mi">1</span> <span class="k">else</span> <span class="mi">0</span>
-  <span class="p">)),</span> <span class="s1">&#39;value&#39;</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-30">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-30">&#182;</a>               </div>               <p>Use a comparator function to figure out at what index an object should
-be inserted so as to maintain order. Uses binary search.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.sortedIndex = </span><span class="nf">(array, obj, iterator) -&gt;</span>
-  <span class="nx">iterator</span> <span class="o">||=</span> <span class="nx">_</span><span class="p">.</span><span class="nx">identity</span>
-  <span class="nv">low = </span> <span class="mi">0</span>
-  <span class="nv">high = </span><span class="nx">array</span><span class="p">.</span><span class="nx">length</span>
-  <span class="k">while</span> <span class="nx">low</span> <span class="o">&lt;</span> <span class="nx">high</span>
-    <span class="nv">mid = </span><span class="p">(</span><span class="nx">low</span> <span class="o">+</span> <span class="nx">high</span><span class="p">)</span> <span class="o">&gt;&gt;</span> <span class="mi">1</span>
-    <span class="k">if</span> <span class="nx">iterator</span><span class="p">(</span><span class="nx">array</span><span class="p">[</span><span class="nx">mid</span><span class="p">])</span> <span class="o">&lt;</span> <span class="nx">iterator</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span> <span class="k">then</span> <span class="nv">low = </span><span class="nx">mid</span> <span class="o">+</span> <span class="mi">1</span> <span class="k">else</span> <span class="nv">high = </span><span class="nx">mid</span>
-  <span class="nx">low</span></pre></div>             </td>           </tr>                               <tr id="section-31">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-31">&#182;</a>               </div>               <p>Convert anything iterable into a real, live array.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.toArray = </span><span class="nf">(iterable) -&gt;</span>
-  <span class="k">return</span> <span class="p">[]</span>                   <span class="k">if</span> <span class="p">(</span><span class="o">!</span><span class="nx">iterable</span><span class="p">)</span>
-  <span class="k">return</span> <span class="nx">iterable</span><span class="p">.</span><span class="nx">toArray</span><span class="p">()</span>   <span class="k">if</span> <span class="p">(</span><span class="nx">iterable</span><span class="p">.</span><span class="nx">toArray</span><span class="p">)</span>
-  <span class="k">return</span> <span class="nx">iterable</span>             <span class="k">if</span> <span class="p">(</span><span class="nx">_</span><span class="p">.</span><span class="nx">isArray</span><span class="p">(</span><span class="nx">iterable</span><span class="p">))</span>
-  <span class="k">return</span> <span class="nx">slice</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">iterable</span><span class="p">)</span> <span class="k">if</span> <span class="p">(</span><span class="nx">_</span><span class="p">.</span><span class="nx">isArguments</span><span class="p">(</span><span class="nx">iterable</span><span class="p">))</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">values</span><span class="p">(</span><span class="nx">iterable</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-32">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-32">&#182;</a>               </div>               <p>Return the number of elements in an object.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.size = </span><span class="nf">(obj) -&gt;</span> <span class="nx">_</span><span class="p">.</span><span class="nx">toArray</span><span class="p">(</span><span class="nx">obj</span><span class="p">).</span><span class="nx">length</span></pre></div>             </td>           </tr>                               <tr id="section-33">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-33">&#182;</a>               </div>               <h2>Array Functions</h2>             </td>             <td class="code">               <div class="highlight"><pre></pre></div>             </td>           </tr>                               <tr id="section-34">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-34">&#182;</a>               </div>               <p>Get the first element of an array. Passing <code>n</code> will return the first N
+<a href="http://documentcloud.github.com/underscore/">http://documentcloud.github.com/underscore/</a></p>
+<h2>Baseline setup</h2>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-2">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-2">&#182;</a>
+              </div>
+              <p>Establish the root object, <code>window</code> in the browser, or <code>global</code> on the server.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>root = <span class="keyword">this</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-3">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-3">&#182;</a>
+              </div>
+              <p>Save the previous value of the <code>_</code> variable.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>previousUnderscore = root._</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-4">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-4">&#182;</a>
+              </div>
+              <p>Establish the object that gets thrown to break out of a loop iteration.
+<code>StopIteration</code> is SOP on Mozilla.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>breaker = <span class="keyword">if</span> <span class="keyword">typeof</span>(StopIteration) <span class="keyword">is</span> <span class="string">'undefined'</span> <span class="keyword">then</span> <span class="string">'__break__'</span> <span class="keyword">else</span> StopIteration</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-5">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-5">&#182;</a>
+              </div>
+              <p>Helper function to escape <strong>RegExp</strong> contents, because JS doesn&#39;t have one.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="function"><span class="title">escapeRegExp</span></span> = (string) -&gt; string.replace(<span class="regexp">/([.*+?^${}()|[\]\/\\])/g</span>, <span class="string">'\\$1'</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-6">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-6">&#182;</a>
+              </div>
+              <p>Save bytes in the minified (but not gzipped) version:</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>ArrayProto           = Array.prototype
+ObjProto             = Object.prototype</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-7">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-7">&#182;</a>
+              </div>
+              <p>Create quick reference variables for speed access to core prototypes.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>slice                = ArrayProto.slice
+unshift              = ArrayProto.unshift
+toString             = ObjProto.toString
+hasOwnProperty       = ObjProto.hasOwnProperty
+propertyIsEnumerable = ObjProto.propertyIsEnumerable</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-8">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-8">&#182;</a>
+              </div>
+              <p>All <strong>ECMA5</strong> native implementations we hope to use are declared here.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>nativeForEach        = ArrayProto.forEach
+nativeMap            = ArrayProto.map
+nativeReduce         = ArrayProto.reduce
+nativeReduceRight    = ArrayProto.reduceRight
+nativeFilter         = ArrayProto.filter
+nativeEvery          = ArrayProto.every
+nativeSome           = ArrayProto.some
+nativeIndexOf        = ArrayProto.indexOf
+nativeLastIndexOf    = ArrayProto.lastIndexOf
+nativeIsArray        = Array.isArray
+nativeKeys           = Object.keys</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-9">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-9">&#182;</a>
+              </div>
+              <p>Create a safe reference to the Underscore object for use below.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="function"><span class="title">_</span></span> = (obj) -&gt; <span class="keyword">new</span> wrapper(obj)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-10">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-10">&#182;</a>
+              </div>
+              <p>Export the Underscore object for <strong>CommonJS</strong>.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="keyword">if</span> <span class="keyword">typeof</span>(exports) != <span class="string">'undefined'</span> <span class="keyword">then</span> exports._ = _</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-11">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-11">&#182;</a>
+              </div>
+              <p>Export Underscore to global scope.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>root._ = _</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-12">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-12">&#182;</a>
+              </div>
+              <p>Current version.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.VERSION = <span class="string">'1.1.0'</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-13">
+            <div class="annotation">
+              
+              <div class="pilwrap for-h2">
+                <a class="pilcrow" href="#section-13">&#182;</a>
+              </div>
+              <h2>Collection Functions</h2>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-14">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-14">&#182;</a>
+              </div>
+              <p>The cornerstone, an <strong>each</strong> implementation.
+Handles objects implementing <strong>forEach</strong>, arrays, and raw objects.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">each</span></span> = (obj, iterator, context) -&gt;
+  <span class="keyword">try</span>
+    <span class="keyword">if</span> nativeForEach <span class="keyword">and</span> obj.forEach <span class="keyword">is</span> nativeForEach
+      obj.forEach iterator, context
+    <span class="keyword">else</span> <span class="keyword">if</span> _.isNumber obj.length
+      iterator.call context, obj[i], i, obj <span class="keyword">for</span> i <span class="keyword">in</span> [<span class="number">0.</span>..obj.length]
+    <span class="keyword">else</span>
+      iterator.call context, val, key, obj  <span class="keyword">for</span> own key, val <span class="keyword">of</span> obj
+  <span class="keyword">catch</span> e
+    <span class="keyword">throw</span> e <span class="keyword">if</span> e <span class="keyword">isnt</span> breaker
+  obj</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-15">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-15">&#182;</a>
+              </div>
+              <p>Return the results of applying the iterator to each element. Use JavaScript
+1.6&#39;s version of <strong>map</strong>, if possible.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">map</span></span> = (obj, iterator, context) -&gt;
+  <span class="keyword">return</span> obj.map(iterator, context) <span class="keyword">if</span> nativeMap <span class="keyword">and</span> obj.map <span class="keyword">is</span> nativeMap
+  results = []
+  _.each obj, (value, index, list) -&gt;
+    results.push iterator.call context, value, index, list
+  results</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-16">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-16">&#182;</a>
+              </div>
+              <p><strong>Reduce</strong> builds up a single result from a list of values. Also known as
+<strong>inject</strong>, or <strong>foldl</strong>. Uses JavaScript 1.8&#39;s version of <strong>reduce</strong>, if possible.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">reduce</span></span> = (obj, iterator, memo, context) -&gt;
+  <span class="keyword">if</span> nativeReduce <span class="keyword">and</span> obj.reduce <span class="keyword">is</span> nativeReduce
+    iterator = _.bind iterator, context <span class="keyword">if</span> context
+    <span class="keyword">return</span> obj.reduce iterator, memo
+  _.each obj, (value, index, list) -&gt;
+    memo = iterator.call context, memo, value, index, list
+  memo</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-17">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-17">&#182;</a>
+              </div>
+              <p>The right-associative version of <strong>reduce</strong>, also known as <strong>foldr</strong>. Uses
+JavaScript 1.8&#39;s version of <strong>reduceRight</strong>, if available.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">reduceRight</span></span> = (obj, iterator, memo, context) -&gt;
+  <span class="keyword">if</span> nativeReduceRight <span class="keyword">and</span> obj.reduceRight <span class="keyword">is</span> nativeReduceRight
+    iterator = _.bind iterator, context <span class="keyword">if</span> context
+    <span class="keyword">return</span> obj.reduceRight iterator, memo
+  reversed = _.clone(_.toArray(obj)).reverse()
+  _.reduce reversed, iterator, memo, context</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-18">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-18">&#182;</a>
+              </div>
+              <p>Return the first value which passes a truth test.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">detect</span></span> = (obj, iterator, context) -&gt;
+  result = <span class="literal">null</span>
+  _.each obj, (value, index, list) -&gt;
+    <span class="keyword">if</span> iterator.call context, value, index, list
+      result = value
+      _.breakLoop()
+  result</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-19">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-19">&#182;</a>
+              </div>
+              <p>Return all the elements that pass a truth test. Use JavaScript 1.6&#39;s
+<strong>filter</strong>, if it exists.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">filter</span></span> = (obj, iterator, context) -&gt;
+  <span class="keyword">return</span> obj.filter iterator, context <span class="keyword">if</span> nativeFilter <span class="keyword">and</span> obj.filter <span class="keyword">is</span> nativeFilter
+  results = []
+  _.each obj, (value, index, list) -&gt;
+    results.push value <span class="keyword">if</span> iterator.call context, value, index, list
+  results</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-20">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-20">&#182;</a>
+              </div>
+              <p>Return all the elements for which a truth test fails.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">reject</span></span> = (obj, iterator, context) -&gt;
+  results = []
+  _.each obj, (value, index, list) -&gt;
+    results.push value <span class="keyword">if</span> <span class="keyword">not</span> iterator.call context, value, index, list
+  results</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-21">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-21">&#182;</a>
+              </div>
+              <p>Determine whether all of the elements match a truth test. Delegate to
+JavaScript 1.6&#39;s <strong>every</strong>, if it is present.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">every</span></span> = (obj, iterator, context) -&gt;
+  iterator ||= _.identity
+  <span class="keyword">return</span> obj.every iterator, context <span class="keyword">if</span> nativeEvery <span class="keyword">and</span> obj.every <span class="keyword">is</span> nativeEvery
+  result = <span class="literal">true</span>
+  _.each obj, (value, index, list) -&gt;
+    _.breakLoop() <span class="keyword">unless</span> (result = result <span class="keyword">and</span> iterator.call(context, value, index, list))
+  result</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-22">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-22">&#182;</a>
+              </div>
+              <p>Determine if at least one element in the object matches a truth test. Use
+JavaScript 1.6&#39;s <strong>some</strong>, if it exists.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">some</span></span> = (obj, iterator, context) -&gt;
+  iterator ||= _.identity
+  <span class="keyword">return</span> obj.some iterator, context <span class="keyword">if</span> nativeSome <span class="keyword">and</span> obj.some <span class="keyword">is</span> nativeSome
+  result = <span class="literal">false</span>
+  _.each obj, (value, index, list) -&gt;
+    _.breakLoop() <span class="keyword">if</span> (result = iterator.call(context, value, index, list))
+  result</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-23">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-23">&#182;</a>
+              </div>
+              <p>Determine if a given value is included in the array or object,
+based on <code>===</code>.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">include</span></span> = (obj, target) -&gt;
+  <span class="keyword">return</span> _.indexOf(obj, target) <span class="keyword">isnt</span> -<span class="number">1</span> <span class="keyword">if</span> nativeIndexOf <span class="keyword">and</span> obj.indexOf <span class="keyword">is</span> nativeIndexOf
+  <span class="keyword">return</span> <span class="literal">true</span> <span class="keyword">for</span> own key, val <span class="keyword">of</span> obj <span class="keyword">when</span> val <span class="keyword">is</span> target
+  <span class="literal">false</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-24">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-24">&#182;</a>
+              </div>
+              <p>Invoke a method with arguments on every item in a collection.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">invoke</span></span> = (obj, method) -&gt;
+  args = _.rest arguments, <span class="number">2</span>
+  (<span class="keyword">if</span> method <span class="keyword">then</span> val[method] <span class="keyword">else</span> val).apply(val, args) <span class="keyword">for</span> val <span class="keyword">in</span> obj</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-25">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-25">&#182;</a>
+              </div>
+              <p>Convenience version of a common use case of <strong>map</strong>: fetching a property.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">pluck</span></span> = (obj, key) -&gt;
+  _.map(obj, (val) -&gt; val[key])</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-26">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-26">&#182;</a>
+              </div>
+              <p>Return the maximum item or (item-based computation).</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">max</span></span> = (obj, iterator, context) -&gt;
+  <span class="keyword">return</span> Math.max.apply(Math, obj) <span class="keyword">if</span> <span class="keyword">not</span> iterator <span class="keyword">and</span> _.isArray(obj)
+  result = computed: -Infinity
+  _.each obj, (value, index, list) -&gt;
+    computed = <span class="keyword">if</span> iterator <span class="keyword">then</span> iterator.call(context, value, index, list) <span class="keyword">else</span> value
+    computed &gt;= result.computed <span class="keyword">and</span> (result = {value: value, computed: computed})
+  result.value</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-27">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-27">&#182;</a>
+              </div>
+              <p>Return the minimum element (or element-based computation).</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">min</span></span> = (obj, iterator, context) -&gt;
+  <span class="keyword">return</span> Math.min.apply(Math, obj) <span class="keyword">if</span> <span class="keyword">not</span> iterator <span class="keyword">and</span> _.isArray(obj)
+  result = computed: Infinity
+  _.each obj, (value, index, list) -&gt;
+    computed = <span class="keyword">if</span> iterator <span class="keyword">then</span> iterator.call(context, value, index, list) <span class="keyword">else</span> value
+    computed &lt; result.computed <span class="keyword">and</span> (result = {value: value, computed: computed})
+  result.value</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-28">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-28">&#182;</a>
+              </div>
+              <p>Sort the object&#39;s values by a criterion produced by an iterator.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">sortBy</span></span> = (obj, iterator, context) -&gt;
+  _.pluck(((_.map obj, (value, index, list) -&gt;
+    {value: value, criteria: iterator.call(context, value, index, list)}
+  ).sort((left, right) -&gt;
+    a = left.criteria; b = right.criteria
+    <span class="keyword">if</span> a &lt; b <span class="keyword">then</span> -<span class="number">1</span> <span class="keyword">else</span> <span class="keyword">if</span> a &gt; b <span class="keyword">then</span> <span class="number">1</span> <span class="keyword">else</span> <span class="number">0</span>
+  )), <span class="string">'value'</span>)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-29">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-29">&#182;</a>
+              </div>
+              <p>Use a comparator function to figure out at what index an object should
+be inserted so as to maintain order. Uses binary search.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">sortedIndex</span></span> = (array, obj, iterator) -&gt;
+  iterator ||= _.identity
+  low =  <span class="number">0</span>
+  high = array.length
+  <span class="keyword">while</span> low &lt; high
+    mid = (low + high) &gt;&gt; <span class="number">1</span>
+    <span class="keyword">if</span> iterator(array[mid]) &lt; iterator(obj) <span class="keyword">then</span> low = mid + <span class="number">1</span> <span class="keyword">else</span> high = mid
+  low</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-30">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-30">&#182;</a>
+              </div>
+              <p>Convert anything iterable into a real, live array.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">toArray</span></span> = (iterable) -&gt;
+  <span class="keyword">return</span> []                   <span class="keyword">if</span> (!iterable)
+  <span class="keyword">return</span> iterable.toArray()   <span class="keyword">if</span> (iterable.toArray)
+  <span class="keyword">return</span> iterable             <span class="keyword">if</span> (_.isArray(iterable))
+  <span class="keyword">return</span> slice.call(iterable) <span class="keyword">if</span> (_.isArguments(iterable))
+  _.values(iterable)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-31">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-31">&#182;</a>
+              </div>
+              <p>Return the number of elements in an object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">size</span></span> = (obj) -&gt; _.toArray(obj).length</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-32">
+            <div class="annotation">
+              
+              <div class="pilwrap for-h2">
+                <a class="pilcrow" href="#section-32">&#182;</a>
+              </div>
+              <h2>Array Functions</h2>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-33">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-33">&#182;</a>
+              </div>
+              <p>Get the first element of an array. Passing <code>n</code> will return the first N
 values in the array. Aliased as <strong>head</strong>. The <code>guard</code> check allows it to work
-with <strong>map</strong>.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.first = </span><span class="nf">(array, n, guard) -&gt;</span>
-  <span class="k">if</span> <span class="nx">n</span> <span class="o">and</span> <span class="o">not</span> <span class="nx">guard</span> <span class="k">then</span> <span class="nx">slice</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">array</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="nx">n</span><span class="p">)</span> <span class="k">else</span> <span class="nx">array</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span></pre></div>             </td>           </tr>                               <tr id="section-35">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-35">&#182;</a>               </div>               <p>Returns everything but the first entry of the array. Aliased as <strong>tail</strong>.
+with <strong>map</strong>.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">first</span></span> = (array, n, guard) -&gt;
+  <span class="keyword">if</span> n <span class="keyword">and</span> <span class="keyword">not</span> guard <span class="keyword">then</span> slice.call(array, <span class="number">0</span>, n) <span class="keyword">else</span> array[<span class="number">0</span>]</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-34">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-34">&#182;</a>
+              </div>
+              <p>Returns everything but the first entry of the array. Aliased as <strong>tail</strong>.
 Especially useful on the arguments object. Passing an <code>index</code> will return
 the rest of the values in the array from that index onward. The <code>guard</code>
-check allows it to work with <strong>map</strong>.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.rest = </span><span class="nf">(array, index, guard) -&gt;</span>
-  <span class="nx">slice</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">array</span><span class="p">,</span> <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isUndefined</span><span class="p">(</span><span class="nx">index</span><span class="p">)</span> <span class="o">or</span> <span class="nx">guard</span> <span class="k">then</span> <span class="mi">1</span> <span class="k">else</span> <span class="nx">index</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-36">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-36">&#182;</a>               </div>               <p>Get the last element of an array.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.last = </span><span class="nf">(array) -&gt;</span> <span class="nx">array</span><span class="p">[</span><span class="nx">array</span><span class="p">.</span><span class="nx">length</span> <span class="o">-</span> <span class="mi">1</span><span class="p">]</span></pre></div>             </td>           </tr>                               <tr id="section-37">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-37">&#182;</a>               </div>               <p>Trim out all falsy values from an array.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.compact = </span><span class="nf">(array) -&gt;</span> <span class="nx">item</span> <span class="k">for</span> <span class="nx">item</span> <span class="k">in</span> <span class="nx">array</span> <span class="k">when</span> <span class="nx">item</span></pre></div>             </td>           </tr>                               <tr id="section-38">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-38">&#182;</a>               </div>               <p>Return a completely flattened version of an array.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.flatten = </span><span class="nf">(array) -&gt;</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">reduce</span> <span class="nx">array</span><span class="p">,</span> <span class="nf">(memo, value) -&gt;</span>
-    <span class="k">return</span> <span class="nx">memo</span><span class="p">.</span><span class="nx">concat</span><span class="p">(</span><span class="nx">_</span><span class="p">.</span><span class="nx">flatten</span><span class="p">(</span><span class="nx">value</span><span class="p">))</span> <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isArray</span> <span class="nx">value</span>
-    <span class="nx">memo</span><span class="p">.</span><span class="nx">push</span> <span class="nx">value</span>
-    <span class="nx">memo</span>
-  <span class="p">,</span> <span class="p">[]</span></pre></div>             </td>           </tr>                               <tr id="section-39">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-39">&#182;</a>               </div>               <p>Return a version of the array that does not contain the specified value(s).</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.without = </span><span class="nf">(array) -&gt;</span>
-  <span class="nv">values = </span><span class="nx">_</span><span class="p">.</span><span class="nx">rest</span> <span class="nx">arguments</span>
-  <span class="nx">val</span> <span class="k">for</span> <span class="nx">val</span> <span class="k">in</span> <span class="nx">_</span><span class="p">.</span><span class="nx">toArray</span><span class="p">(</span><span class="nx">array</span><span class="p">)</span> <span class="k">when</span> <span class="o">not</span> <span class="nx">_</span><span class="p">.</span><span class="nx">include</span> <span class="nx">values</span><span class="p">,</span> <span class="nx">val</span></pre></div>             </td>           </tr>                               <tr id="section-40">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-40">&#182;</a>               </div>               <p>Produce a duplicate-free version of the array. If the array has already
-been sorted, you have the option of using a faster algorithm.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.uniq = </span><span class="nf">(array, isSorted) -&gt;</span>
-  <span class="nv">memo = </span><span class="p">[]</span>
-  <span class="k">for</span> <span class="nx">el</span><span class="p">,</span> <span class="nx">i</span> <span class="k">in</span> <span class="nx">_</span><span class="p">.</span><span class="nx">toArray</span> <span class="nx">array</span>
-    <span class="nx">memo</span><span class="p">.</span><span class="nx">push</span> <span class="nx">el</span> <span class="k">if</span> <span class="nx">i</span> <span class="o">is</span> <span class="mi">0</span> <span class="o">||</span> <span class="p">(</span><span class="k">if</span> <span class="nx">isSorted</span> <span class="o">is</span> <span class="kc">true</span> <span class="k">then</span> <span class="nx">_</span><span class="p">.</span><span class="nx">last</span><span class="p">(</span><span class="nx">memo</span><span class="p">)</span> <span class="o">isnt</span> <span class="nx">el</span> <span class="k">else</span> <span class="o">not</span> <span class="nx">_</span><span class="p">.</span><span class="nx">include</span><span class="p">(</span><span class="nx">memo</span><span class="p">,</span> <span class="nx">el</span><span class="p">))</span>
-  <span class="nx">memo</span></pre></div>             </td>           </tr>                               <tr id="section-41">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-41">&#182;</a>               </div>               <p>Produce an array that contains every item shared between all the
-passed-in arrays.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.intersect = </span><span class="nf">(array) -&gt;</span>
-  <span class="nv">rest = </span><span class="nx">_</span><span class="p">.</span><span class="nx">rest</span> <span class="nx">arguments</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">select</span> <span class="nx">_</span><span class="p">.</span><span class="nx">uniq</span><span class="p">(</span><span class="nx">array</span><span class="p">),</span> <span class="nf">(item) -&gt;</span>
-    <span class="nx">_</span><span class="p">.</span><span class="nx">all</span> <span class="nx">rest</span><span class="p">,</span> <span class="nf">(other) -&gt;</span>
-      <span class="nx">_</span><span class="p">.</span><span class="nx">indexOf</span><span class="p">(</span><span class="nx">other</span><span class="p">,</span> <span class="nx">item</span><span class="p">)</span> <span class="o">&gt;=</span> <span class="mi">0</span></pre></div>             </td>           </tr>                               <tr id="section-42">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-42">&#182;</a>               </div>               <p>Zip together multiple lists into a single array -- elements that share
-an index go together.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.zip = </span><span class="o">-&gt;</span>
-  <span class="nv">length = </span> <span class="nx">_</span><span class="p">.</span><span class="nx">max</span> <span class="nx">_</span><span class="p">.</span><span class="nx">pluck</span> <span class="nx">arguments</span><span class="p">,</span> <span class="s1">&#39;length&#39;</span>
-  <span class="nv">results = </span><span class="k">new</span> <span class="nb">Array</span> <span class="nx">length</span>
-  <span class="k">for</span> <span class="nx">i</span> <span class="k">in</span> <span class="p">[</span><span class="mi">0</span><span class="p">...</span><span class="nx">length</span><span class="p">]</span>
-    <span class="nx">results</span><span class="p">[</span><span class="nx">i</span><span class="p">]</span> <span class="o">=</span> <span class="nx">_</span><span class="p">.</span><span class="nx">pluck</span> <span class="nx">arguments</span><span class="p">,</span> <span class="nb">String</span> <span class="nx">i</span>
-  <span class="nx">results</span></pre></div>             </td>           </tr>                               <tr id="section-43">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-43">&#182;</a>               </div>               <p>If the browser doesn't supply us with <strong>indexOf</strong> (I'm looking at you, MSIE),
+check allows it to work with <strong>map</strong>.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">rest</span></span> = (array, index, guard) -&gt;
+  slice.call(array, <span class="keyword">if</span> _.isUndefined(index) <span class="keyword">or</span> guard <span class="keyword">then</span> <span class="number">1</span> <span class="keyword">else</span> index)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-35">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-35">&#182;</a>
+              </div>
+              <p>Get the last element of an array.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">last</span></span> = (array) -&gt; array[array.length - <span class="number">1</span>]</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-36">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-36">&#182;</a>
+              </div>
+              <p>Trim out all falsy values from an array.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">compact</span></span> = (array) -&gt; item <span class="keyword">for</span> item <span class="keyword">in</span> array <span class="keyword">when</span> item</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-37">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-37">&#182;</a>
+              </div>
+              <p>Return a completely flattened version of an array.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">flatten</span></span> = (array) -&gt;
+  _.reduce array, (memo, value) -&gt;
+    <span class="keyword">return</span> memo.concat(_.flatten(value)) <span class="keyword">if</span> _.isArray value
+    memo.push value
+    memo
+  , []</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-38">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-38">&#182;</a>
+              </div>
+              <p>Return a version of the array that does not contain the specified value(s).</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">without</span></span> = (array) -&gt;
+  values = _.rest arguments
+  val <span class="keyword">for</span> val <span class="keyword">in</span> _.toArray(array) <span class="keyword">when</span> <span class="keyword">not</span> _.include values, val</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-39">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-39">&#182;</a>
+              </div>
+              <p>Produce a duplicate-free version of the array. If the array has already
+been sorted, you have the option of using a faster algorithm.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">uniq</span></span> = (array, isSorted) -&gt;
+  memo = []
+  <span class="keyword">for</span> el, i <span class="keyword">in</span> _.toArray array
+    memo.push el <span class="keyword">if</span> i <span class="keyword">is</span> <span class="number">0</span> || (<span class="keyword">if</span> isSorted <span class="keyword">is</span> <span class="literal">true</span> <span class="keyword">then</span> _.last(memo) <span class="keyword">isnt</span> el <span class="keyword">else</span> <span class="keyword">not</span> _.include(memo, el))
+  memo</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-40">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-40">&#182;</a>
+              </div>
+              <p>Produce an array that contains every item shared between all the
+passed-in arrays.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">intersect</span></span> = (array) -&gt;
+  rest = _.rest arguments
+  _.select _.uniq(array), (item) -&gt;
+    _.all rest, (other) -&gt;
+      _.indexOf(other, item) &gt;= <span class="number">0</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-41">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-41">&#182;</a>
+              </div>
+              <p>Zip together multiple lists into a single array -- elements that share
+an index go together.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">zip</span></span> = -&gt;
+  length =  _.max _.pluck arguments, <span class="string">'length'</span>
+  results = <span class="keyword">new</span> Array length
+  <span class="keyword">for</span> i <span class="keyword">in</span> [<span class="number">0.</span>..length]
+    results[i] = _.pluck arguments, String i
+  results</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-42">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-42">&#182;</a>
+              </div>
+              <p>If the browser doesn&#39;t supply us with <strong>indexOf</strong> (I&#39;m looking at you, MSIE),
 we need this function. Return the position of the first occurrence of an
-item in an array, or -1 if the item is not included in the array.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.indexOf = </span><span class="nf">(array, item) -&gt;</span>
-  <span class="k">return</span> <span class="nx">array</span><span class="p">.</span><span class="nx">indexOf</span> <span class="nx">item</span> <span class="k">if</span> <span class="nx">nativeIndexOf</span> <span class="o">and</span> <span class="nx">array</span><span class="p">.</span><span class="nx">indexOf</span> <span class="o">is</span> <span class="nx">nativeIndexOf</span>
-  <span class="nv">i = </span><span class="mi">0</span><span class="p">;</span> <span class="nv">l = </span><span class="nx">array</span><span class="p">.</span><span class="nx">length</span>
-  <span class="k">while</span> <span class="nx">l</span> <span class="o">-</span> <span class="nx">i</span>
-    <span class="k">if</span> <span class="nx">array</span><span class="p">[</span><span class="nx">i</span><span class="p">]</span> <span class="o">is</span> <span class="nx">item</span> <span class="k">then</span> <span class="k">return</span> <span class="nx">i</span> <span class="k">else</span> <span class="nx">i</span><span class="o">++</span>
-  <span class="o">-</span><span class="mi">1</span></pre></div>             </td>           </tr>                               <tr id="section-44">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-44">&#182;</a>               </div>               <p>Provide JavaScript 1.6's <strong>lastIndexOf</strong>, delegating to the native function,
-if possible.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.lastIndexOf = </span><span class="nf">(array, item) -&gt;</span>
-  <span class="k">return</span> <span class="nx">array</span><span class="p">.</span><span class="nx">lastIndexOf</span><span class="p">(</span><span class="nx">item</span><span class="p">)</span> <span class="k">if</span> <span class="nx">nativeLastIndexOf</span> <span class="o">and</span> <span class="nx">array</span><span class="p">.</span><span class="nx">lastIndexOf</span> <span class="o">is</span> <span class="nx">nativeLastIndexOf</span>
-  <span class="nv">i = </span><span class="nx">array</span><span class="p">.</span><span class="nx">length</span>
-  <span class="k">while</span> <span class="nx">i</span>
-    <span class="k">if</span> <span class="nx">array</span><span class="p">[</span><span class="nx">i</span><span class="p">]</span> <span class="o">is</span> <span class="nx">item</span> <span class="k">then</span> <span class="k">return</span> <span class="nx">i</span> <span class="k">else</span> <span class="nx">i</span><span class="o">--</span>
-  <span class="o">-</span><span class="mi">1</span></pre></div>             </td>           </tr>                               <tr id="section-45">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-45">&#182;</a>               </div>               <p>Generate an integer Array containing an arithmetic progression. A port of
-<a href="http://docs.python.org/library/functions.html#range">the native Python <strong>range</strong> function</a>.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.range = </span><span class="nf">(start, stop, step) -&gt;</span>
-  <span class="nv">a         = </span><span class="nx">arguments</span>
-  <span class="nv">solo      = </span><span class="nx">a</span><span class="p">.</span><span class="nx">length</span> <span class="o">&lt;=</span> <span class="mi">1</span>
-  <span class="nv">i = start = </span><span class="k">if</span> <span class="nx">solo</span> <span class="k">then</span> <span class="mi">0</span> <span class="k">else</span> <span class="nx">a</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span>
-  <span class="nv">stop      = </span><span class="k">if</span> <span class="nx">solo</span> <span class="k">then</span> <span class="nx">a</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span> <span class="k">else</span> <span class="nx">a</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span>
-  <span class="nv">step      = </span><span class="nx">a</span><span class="p">[</span><span class="mi">2</span><span class="p">]</span> <span class="o">or</span> <span class="mi">1</span>
-  <span class="nv">len       = </span><span class="nb">Math</span><span class="p">.</span><span class="nx">ceil</span><span class="p">((</span><span class="nx">stop</span> <span class="o">-</span> <span class="nx">start</span><span class="p">)</span> <span class="o">/</span> <span class="nx">step</span><span class="p">)</span>
-  <span class="k">return</span> <span class="p">[]</span>   <span class="k">if</span> <span class="nx">len</span> <span class="o">&lt;=</span> <span class="mi">0</span>
-  <span class="nv">range     = </span><span class="k">new</span> <span class="nb">Array</span> <span class="nx">len</span>
-  <span class="nv">idx       = </span><span class="mi">0</span>
-  <span class="nx">loop</span>
-    <span class="k">return</span> <span class="nx">range</span> <span class="k">if</span> <span class="p">(</span><span class="k">if</span> <span class="nx">step</span> <span class="o">&gt;</span> <span class="mi">0</span> <span class="k">then</span> <span class="nx">i</span> <span class="o">-</span> <span class="nx">stop</span> <span class="k">else</span> <span class="nx">stop</span> <span class="o">-</span> <span class="nx">i</span><span class="p">)</span> <span class="o">&gt;=</span> <span class="mi">0</span>
-    <span class="nx">range</span><span class="p">[</span><span class="nx">idx</span><span class="p">]</span> <span class="o">=</span> <span class="nx">i</span>
-    <span class="nx">idx</span><span class="o">++</span>
-    <span class="nx">i</span><span class="o">+=</span> <span class="nx">step</span></pre></div>             </td>           </tr>                               <tr id="section-46">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-46">&#182;</a>               </div>               <h2>Function Functions</h2>             </td>             <td class="code">               <div class="highlight"><pre></pre></div>             </td>           </tr>                               <tr id="section-47">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-47">&#182;</a>               </div>               <p>Create a function bound to a given object (assigning <code>this</code>, and arguments,
-optionally). Binding with arguments is also known as <strong>curry</strong>.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.bind = </span><span class="nf">(func, obj) -&gt;</span>
-  <span class="nv">args = </span><span class="nx">_</span><span class="p">.</span><span class="nx">rest</span> <span class="nx">arguments</span><span class="p">,</span> <span class="mi">2</span>
-  <span class="o">-&gt;</span> <span class="nx">func</span><span class="p">.</span><span class="nx">apply</span> <span class="nx">obj</span> <span class="o">or</span> <span class="nx">root</span><span class="p">,</span> <span class="nx">args</span><span class="p">.</span><span class="nx">concat</span> <span class="nx">arguments</span></pre></div>             </td>           </tr>                               <tr id="section-48">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-48">&#182;</a>               </div>               <p>Bind all of an object's methods to that object. Useful for ensuring that
-all callbacks defined on an object belong to it.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.bindAll = </span><span class="nf">(obj) -&gt;</span>
-  <span class="nv">funcs = </span><span class="k">if</span> <span class="nx">arguments</span><span class="p">.</span><span class="nx">length</span> <span class="o">&gt;</span> <span class="mi">1</span> <span class="k">then</span> <span class="nx">_</span><span class="p">.</span><span class="nx">rest</span><span class="p">(</span><span class="nx">arguments</span><span class="p">)</span> <span class="k">else</span> <span class="nx">_</span><span class="p">.</span><span class="nx">functions</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="nx">funcs</span><span class="p">,</span> <span class="nf">(f) -&gt;</span> <span class="nx">obj</span><span class="p">[</span><span class="nx">f</span><span class="p">]</span> <span class="o">=</span> <span class="nx">_</span><span class="p">.</span><span class="nx">bind</span> <span class="nx">obj</span><span class="p">[</span><span class="nx">f</span><span class="p">],</span> <span class="nx">obj</span>
-  <span class="nx">obj</span></pre></div>             </td>           </tr>                               <tr id="section-49">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-49">&#182;</a>               </div>               <p>Delays a function for the given number of milliseconds, and then calls
-it with the arguments supplied.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.delay = </span><span class="nf">(func, wait) -&gt;</span>
-  <span class="nv">args = </span><span class="nx">_</span><span class="p">.</span><span class="nx">rest</span> <span class="nx">arguments</span><span class="p">,</span> <span class="mi">2</span>
-  <span class="nx">setTimeout</span><span class="p">((</span><span class="o">-&gt;</span> <span class="nx">func</span><span class="p">.</span><span class="nx">apply</span><span class="p">(</span><span class="nx">func</span><span class="p">,</span> <span class="nx">args</span><span class="p">)),</span> <span class="nx">wait</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-50">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-50">&#182;</a>               </div>               <p>Memoize an expensive function by storing its results.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.memoize = </span><span class="nf">(func, hasher) -&gt;</span>
-  <span class="nv">memo = </span><span class="p">{}</span>
-  <span class="nx">hasher</span> <span class="o">or=</span> <span class="nx">_</span><span class="p">.</span><span class="nx">identity</span>
-  <span class="o">-&gt;</span>
-    <span class="nv">key = </span><span class="nx">hasher</span><span class="p">.</span><span class="nx">apply</span> <span class="k">this</span><span class="p">,</span> <span class="nx">arguments</span>
-    <span class="k">return</span> <span class="nx">memo</span><span class="p">[</span><span class="nx">key</span><span class="p">]</span> <span class="k">if</span> <span class="nx">key</span> <span class="k">of</span> <span class="nx">memo</span>
-    <span class="nx">memo</span><span class="p">[</span><span class="nx">key</span><span class="p">]</span> <span class="o">=</span> <span class="nx">func</span><span class="p">.</span><span class="nx">apply</span> <span class="k">this</span><span class="p">,</span> <span class="nx">arguments</span></pre></div>             </td>           </tr>                               <tr id="section-51">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-51">&#182;</a>               </div>               <p>Defers a function, scheduling it to run after the current call stack has
-cleared.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.defer = </span><span class="nf">(func) -&gt;</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">delay</span><span class="p">.</span><span class="nx">apply</span> <span class="nx">_</span><span class="p">,</span> <span class="p">[</span><span class="nx">func</span><span class="p">,</span> <span class="mi">1</span><span class="p">].</span><span class="nx">concat</span> <span class="nx">_</span><span class="p">.</span><span class="nx">rest</span> <span class="nx">arguments</span></pre></div>             </td>           </tr>                               <tr id="section-52">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-52">&#182;</a>               </div>               <p>Returns the first function passed as an argument to the second,
+item in an array, or -1 if the item is not included in the array.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">indexOf</span></span> = (array, item) -&gt;
+  <span class="keyword">return</span> array.indexOf item <span class="keyword">if</span> nativeIndexOf <span class="keyword">and</span> array.indexOf <span class="keyword">is</span> nativeIndexOf
+  i = <span class="number">0</span>; l = array.length
+  <span class="keyword">while</span> l - i
+    <span class="keyword">if</span> array[i] <span class="keyword">is</span> item <span class="keyword">then</span> <span class="keyword">return</span> i <span class="keyword">else</span> i++
+  -<span class="number">1</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-43">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-43">&#182;</a>
+              </div>
+              <p>Provide JavaScript 1.6&#39;s <strong>lastIndexOf</strong>, delegating to the native function,
+if possible.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">lastIndexOf</span></span> = (array, item) -&gt;
+  <span class="keyword">return</span> array.lastIndexOf(item) <span class="keyword">if</span> nativeLastIndexOf <span class="keyword">and</span> array.lastIndexOf <span class="keyword">is</span> nativeLastIndexOf
+  i = array.length
+  <span class="keyword">while</span> i
+    <span class="keyword">if</span> array[i] <span class="keyword">is</span> item <span class="keyword">then</span> <span class="keyword">return</span> i <span class="keyword">else</span> i--
+  -<span class="number">1</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-44">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-44">&#182;</a>
+              </div>
+              <p>Generate an integer Array containing an arithmetic progression. A port of
+<a href="http://docs.python.org/library/functions.html#range">the native Python <strong>range</strong> function</a>.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">range</span></span> = (start, stop, step) -&gt;
+  a         = arguments
+  solo      = a.length &lt;= <span class="number">1</span>
+  i = start = <span class="keyword">if</span> solo <span class="keyword">then</span> <span class="number">0</span> <span class="keyword">else</span> a[<span class="number">0</span>]
+  stop      = <span class="keyword">if</span> solo <span class="keyword">then</span> a[<span class="number">0</span>] <span class="keyword">else</span> a[<span class="number">1</span>]
+  step      = a[<span class="number">2</span>] <span class="keyword">or</span> <span class="number">1</span>
+  len       = Math.ceil((stop - start) / step)
+  <span class="keyword">return</span> []   <span class="keyword">if</span> len &lt;= <span class="number">0</span>
+  range     = <span class="keyword">new</span> Array len
+  idx       = <span class="number">0</span>
+  <span class="keyword">loop</span>
+    <span class="keyword">return</span> range <span class="keyword">if</span> (<span class="keyword">if</span> step &gt; <span class="number">0</span> <span class="keyword">then</span> i - stop <span class="keyword">else</span> stop - i) &gt;= <span class="number">0</span>
+    range[idx] = i
+    idx++
+    i+= step</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-45">
+            <div class="annotation">
+              
+              <div class="pilwrap for-h2">
+                <a class="pilcrow" href="#section-45">&#182;</a>
+              </div>
+              <h2>Function Functions</h2>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-46">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-46">&#182;</a>
+              </div>
+              <p>Create a function bound to a given object (assigning <code>this</code>, and arguments,
+optionally). Binding with arguments is also known as <strong>curry</strong>.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">bind</span></span> = (func, obj) -&gt;
+  args = _.rest arguments, <span class="number">2</span>
+  -&gt; func.apply obj <span class="keyword">or</span> root, args.concat arguments</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-47">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-47">&#182;</a>
+              </div>
+              <p>Bind all of an object&#39;s methods to that object. Useful for ensuring that
+all callbacks defined on an object belong to it.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">bindAll</span></span> = (obj) -&gt;
+  funcs = <span class="keyword">if</span> arguments.length &gt; <span class="number">1</span> <span class="keyword">then</span> _.rest(arguments) <span class="keyword">else</span> _.functions(obj)
+  _.each funcs, (f) -&gt; obj[f] = _.bind obj[f], obj
+  obj</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-48">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-48">&#182;</a>
+              </div>
+              <p>Delays a function for the given number of milliseconds, and then calls
+it with the arguments supplied.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">delay</span></span> = (func, wait) -&gt;
+  args = _.rest arguments, <span class="number">2</span>
+  setTimeout((-&gt; func.apply(func, args)), wait)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-49">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-49">&#182;</a>
+              </div>
+              <p>Memoize an expensive function by storing its results.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">memoize</span></span> = (func, hasher) -&gt;
+  memo = {}
+  hasher <span class="keyword">or</span>= _.identity
+  -&gt;
+    key = hasher.apply <span class="keyword">this</span>, arguments
+    <span class="keyword">return</span> memo[key] <span class="keyword">if</span> key <span class="keyword">of</span> memo
+    memo[key] = func.apply <span class="keyword">this</span>, arguments</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-50">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-50">&#182;</a>
+              </div>
+              <p>Defers a function, scheduling it to run after the current call stack has
+cleared.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">defer</span></span> = (func) -&gt;
+  _.delay.apply _, [func, <span class="number">1</span>].concat _.rest arguments</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-51">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-51">&#182;</a>
+              </div>
+              <p>Returns the first function passed as an argument to the second,
 allowing you to adjust arguments, run code before and after, and
-conditionally execute the original function.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.wrap = </span><span class="nf">(func, wrapper) -&gt;</span>
-  <span class="o">-&gt;</span> <span class="nx">wrapper</span><span class="p">.</span><span class="nx">apply</span> <span class="nx">wrapper</span><span class="p">,</span> <span class="p">[</span><span class="nx">func</span><span class="p">].</span><span class="nx">concat</span> <span class="nx">arguments</span></pre></div>             </td>           </tr>                               <tr id="section-53">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-53">&#182;</a>               </div>               <p>Returns a function that is the composition of a list of functions, each
-consuming the return value of the function that follows.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.compose = </span><span class="o">-&gt;</span>
-  <span class="nv">funcs = </span><span class="nx">arguments</span>
-  <span class="o">-&gt;</span>
-    <span class="nv">args = </span><span class="nx">arguments</span>
-    <span class="k">for</span> <span class="nx">i</span> <span class="k">in</span> <span class="p">[</span><span class="nx">funcs</span><span class="p">.</span><span class="nx">length</span> <span class="o">-</span> <span class="mi">1</span><span class="p">..</span><span class="mi">0</span><span class="p">]</span> <span class="k">by</span> <span class="o">-</span><span class="mi">1</span>
-      <span class="nv">args = </span><span class="p">[</span><span class="nx">funcs</span><span class="p">[</span><span class="nx">i</span><span class="p">].</span><span class="nx">apply</span><span class="p">(</span><span class="k">this</span><span class="p">,</span> <span class="nx">args</span><span class="p">)]</span>
-    <span class="nx">args</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span></pre></div>             </td>           </tr>                               <tr id="section-54">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-54">&#182;</a>               </div>               <h2>Object Functions</h2>             </td>             <td class="code">               <div class="highlight"><pre></pre></div>             </td>           </tr>                               <tr id="section-55">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-55">&#182;</a>               </div>               <p>Retrieve the names of an object's properties.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.keys = </span><span class="nx">nativeKeys</span> <span class="o">or</span> <span class="nf">(obj) -&gt;</span>
-  <span class="k">return</span> <span class="nx">_</span><span class="p">.</span><span class="nx">range</span> <span class="mi">0</span><span class="p">,</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">length</span> <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isArray</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span>
-  <span class="nx">key</span> <span class="k">for</span> <span class="nx">key</span><span class="p">,</span> <span class="nx">val</span> <span class="k">of</span> <span class="nx">obj</span></pre></div>             </td>           </tr>                               <tr id="section-56">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-56">&#182;</a>               </div>               <p>Retrieve the values of an object's properties.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.values = </span><span class="nf">(obj) -&gt;</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">map</span> <span class="nx">obj</span><span class="p">,</span> <span class="nx">_</span><span class="p">.</span><span class="nx">identity</span></pre></div>             </td>           </tr>                               <tr id="section-57">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-57">&#182;</a>               </div>               <p>Return a sorted list of the function names available in Underscore.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.functions = </span><span class="nf">(obj) -&gt;</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">filter</span><span class="p">(</span><span class="nx">_</span><span class="p">.</span><span class="nx">keys</span><span class="p">(</span><span class="nx">obj</span><span class="p">),</span> <span class="nf">(key) -&gt;</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isFunction</span><span class="p">(</span><span class="nx">obj</span><span class="p">[</span><span class="nx">key</span><span class="p">])).</span><span class="nx">sort</span><span class="p">()</span></pre></div>             </td>           </tr>                               <tr id="section-58">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-58">&#182;</a>               </div>               <p>Extend a given object with all of the properties in a source object.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.extend = </span><span class="nf">(obj) -&gt;</span>
-  <span class="k">for</span> <span class="nx">source</span> <span class="k">in</span> <span class="nx">_</span><span class="p">.</span><span class="nx">rest</span><span class="p">(</span><span class="nx">arguments</span><span class="p">)</span>
-    <span class="nx">obj</span><span class="p">[</span><span class="nx">key</span><span class="p">]</span> <span class="o">=</span> <span class="nx">val</span> <span class="k">for</span> <span class="nx">key</span><span class="p">,</span> <span class="nx">val</span> <span class="k">of</span> <span class="nx">source</span>
-  <span class="nx">obj</span></pre></div>             </td>           </tr>                               <tr id="section-59">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-59">&#182;</a>               </div>               <p>Create a (shallow-cloned) duplicate of an object.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.clone = </span><span class="nf">(obj) -&gt;</span>
-  <span class="k">return</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">slice</span> <span class="mi">0</span> <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isArray</span> <span class="nx">obj</span>
-  <span class="nx">_</span><span class="p">.</span><span class="nx">extend</span> <span class="p">{},</span> <span class="nx">obj</span></pre></div>             </td>           </tr>                               <tr id="section-60">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-60">&#182;</a>               </div>               <p>Invokes interceptor with the obj, and then returns obj.
-The primary purpose of this method is to "tap into" a method chain, in order to perform operations on intermediate results within the chain.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.tap = </span><span class="nf">(obj, interceptor) -&gt;</span>
-  <span class="nx">interceptor</span> <span class="nx">obj</span>
-  <span class="nx">obj</span></pre></div>             </td>           </tr>                               <tr id="section-61">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-61">&#182;</a>               </div>               <p>Perform a deep comparison to check if two objects are equal.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isEqual = </span><span class="nf">(a, b) -&gt;</span></pre></div>             </td>           </tr>                               <tr id="section-62">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-62">&#182;</a>               </div>               <p>Check object identity.</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="kc">true</span> <span class="k">if</span> <span class="nx">a</span> <span class="o">is</span> <span class="nx">b</span></pre></div>             </td>           </tr>                               <tr id="section-63">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-63">&#182;</a>               </div>               <p>Different types?</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="nv">atype = </span><span class="k">typeof</span><span class="p">(</span><span class="nx">a</span><span class="p">);</span> <span class="nv">btype = </span><span class="k">typeof</span><span class="p">(</span><span class="nx">b</span><span class="p">)</span>
-  <span class="k">return</span> <span class="kc">false</span> <span class="k">if</span> <span class="nx">atype</span> <span class="o">isnt</span> <span class="nx">btype</span></pre></div>             </td>           </tr>                               <tr id="section-64">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-64">&#182;</a>               </div>               <p>Basic equality test (watch out for coercions).</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="kc">true</span> <span class="k">if</span> <span class="o">`</span><span class="nx">a</span> <span class="o">==</span> <span class="nx">b</span><span class="o">`</span></pre></div>             </td>           </tr>                               <tr id="section-65">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-65">&#182;</a>               </div>               <p>One is falsy and the other truthy.</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="kc">false</span> <span class="k">if</span> <span class="p">(</span><span class="o">!</span><span class="nx">a</span> <span class="o">and</span> <span class="nx">b</span><span class="p">)</span> <span class="o">or</span> <span class="p">(</span><span class="nx">a</span> <span class="o">and</span> <span class="o">!</span><span class="nx">b</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-66">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-66">&#182;</a>               </div>               <p>One of them implements an <code>isEqual()</code>?</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="nx">a</span><span class="p">.</span><span class="nx">isEqual</span><span class="p">(</span><span class="nx">b</span><span class="p">)</span> <span class="k">if</span> <span class="nx">a</span><span class="p">.</span><span class="nx">isEqual</span></pre></div>             </td>           </tr>                               <tr id="section-67">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-67">&#182;</a>               </div>               <p>Check dates' integer values.</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="nx">a</span><span class="p">.</span><span class="nx">getTime</span><span class="p">()</span> <span class="o">is</span> <span class="nx">b</span><span class="p">.</span><span class="nx">getTime</span><span class="p">()</span> <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isDate</span><span class="p">(</span><span class="nx">a</span><span class="p">)</span> <span class="o">and</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isDate</span><span class="p">(</span><span class="nx">b</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-68">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-68">&#182;</a>               </div>               <p>Both are NaN?</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="kc">false</span> <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nb">isNaN</span><span class="p">(</span><span class="nx">a</span><span class="p">)</span> <span class="o">and</span> <span class="nx">_</span><span class="p">.</span><span class="nb">isNaN</span><span class="p">(</span><span class="nx">b</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-69">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-69">&#182;</a>               </div>               <p>Compare regular expressions.</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isRegExp</span><span class="p">(</span><span class="nx">a</span><span class="p">)</span> <span class="o">and</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isRegExp</span><span class="p">(</span><span class="nx">b</span><span class="p">)</span>
-    <span class="k">return</span> <span class="nx">a</span><span class="p">.</span><span class="nx">source</span>     <span class="o">is</span> <span class="nx">b</span><span class="p">.</span><span class="nx">source</span> <span class="o">and</span>
-           <span class="nx">a</span><span class="p">.</span><span class="nx">global</span>     <span class="o">is</span> <span class="nx">b</span><span class="p">.</span><span class="nx">global</span> <span class="o">and</span>
-           <span class="nx">a</span><span class="p">.</span><span class="nx">ignoreCase</span> <span class="o">is</span> <span class="nx">b</span><span class="p">.</span><span class="nx">ignoreCase</span> <span class="o">and</span>
-           <span class="nx">a</span><span class="p">.</span><span class="nx">multiline</span>  <span class="o">is</span> <span class="nx">b</span><span class="p">.</span><span class="nx">multiline</span></pre></div>             </td>           </tr>                               <tr id="section-70">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-70">&#182;</a>               </div>               <p>If a is not an object by this point, we can't handle it.</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="kc">false</span> <span class="k">if</span> <span class="nx">atype</span> <span class="o">isnt</span> <span class="s1">&#39;object&#39;</span></pre></div>             </td>           </tr>                               <tr id="section-71">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-71">&#182;</a>               </div>               <p>Check for different array lengths before comparing contents.</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="kc">false</span> <span class="k">if</span> <span class="nx">a</span><span class="p">.</span><span class="nx">length</span> <span class="o">and</span> <span class="p">(</span><span class="nx">a</span><span class="p">.</span><span class="nx">length</span> <span class="o">isnt</span> <span class="nx">b</span><span class="p">.</span><span class="nx">length</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-72">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-72">&#182;</a>               </div>               <p>Nothing else worked, deep compare the contents.</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="nv">aKeys = </span><span class="nx">_</span><span class="p">.</span><span class="nx">keys</span><span class="p">(</span><span class="nx">a</span><span class="p">);</span> <span class="nv">bKeys = </span><span class="nx">_</span><span class="p">.</span><span class="nx">keys</span><span class="p">(</span><span class="nx">b</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-73">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-73">&#182;</a>               </div>               <p>Different object sizes?</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="kc">false</span> <span class="k">if</span> <span class="nx">aKeys</span><span class="p">.</span><span class="nx">length</span> <span class="o">isnt</span> <span class="nx">bKeys</span><span class="p">.</span><span class="nx">length</span></pre></div>             </td>           </tr>                               <tr id="section-74">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-74">&#182;</a>               </div>               <p>Recursive comparison of contents.</p>             </td>             <td class="code">               <div class="highlight"><pre>  <span class="k">return</span> <span class="kc">false</span> <span class="k">for</span> <span class="nx">key</span><span class="p">,</span> <span class="nx">val</span> <span class="k">of</span> <span class="nx">a</span> <span class="k">when</span> <span class="o">!</span><span class="p">(</span><span class="nx">key</span> <span class="k">of</span> <span class="nx">b</span><span class="p">)</span> <span class="o">or</span> <span class="o">!</span><span class="nx">_</span><span class="p">.</span><span class="nx">isEqual</span><span class="p">(</span><span class="nx">val</span><span class="p">,</span> <span class="nx">b</span><span class="p">[</span><span class="nx">key</span><span class="p">])</span>
-  <span class="kc">true</span></pre></div>             </td>           </tr>                               <tr id="section-75">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-75">&#182;</a>               </div>               <p>Is a given array or object empty?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isEmpty = </span><span class="nf">(obj) -&gt;</span>
-  <span class="k">return</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">length</span> <span class="o">is</span> <span class="mi">0</span> <span class="k">if</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isArray</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span> <span class="o">or</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isString</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span>
-  <span class="k">return</span> <span class="kc">false</span> <span class="k">for</span> <span class="nx">own</span> <span class="nx">key</span> <span class="k">of</span> <span class="nx">obj</span>
-  <span class="kc">true</span></pre></div>             </td>           </tr>                               <tr id="section-76">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-76">&#182;</a>               </div>               <p>Is a given value a DOM element?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isElement   = </span><span class="nf">(obj) -&gt;</span> <span class="nx">obj</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">nodeType</span> <span class="o">is</span> <span class="mi">1</span></pre></div>             </td>           </tr>                               <tr id="section-77">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-77">&#182;</a>               </div>               <p>Is a given value an array?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isArray     = </span><span class="nx">nativeIsArray</span> <span class="o">or</span> <span class="nf">(obj) -&gt;</span> <span class="o">!!</span><span class="p">(</span><span class="nx">obj</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">concat</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">unshift</span> <span class="o">and</span> <span class="o">not</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">callee</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-78">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-78">&#182;</a>               </div>               <p>Is a given variable an arguments object?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isArguments = </span><span class="nf">(obj) -&gt;</span> <span class="nx">obj</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">callee</span></pre></div>             </td>           </tr>                               <tr id="section-79">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-79">&#182;</a>               </div>               <p>Is the given value a function?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isFunction  = </span><span class="nf">(obj) -&gt;</span> <span class="o">!!</span><span class="p">(</span><span class="nx">obj</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">constructor</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">call</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">apply</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-80">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-80">&#182;</a>               </div>               <p>Is the given value a string?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isString    = </span><span class="nf">(obj) -&gt;</span> <span class="o">!!</span><span class="p">(</span><span class="nx">obj</span> <span class="o">is</span> <span class="s1">&#39;&#39;</span> <span class="o">or</span> <span class="p">(</span><span class="nx">obj</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">charCodeAt</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">substr</span><span class="p">))</span></pre></div>             </td>           </tr>                               <tr id="section-81">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-81">&#182;</a>               </div>               <p>Is a given value a number?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isNumber    = </span><span class="nf">(obj) -&gt;</span> <span class="p">(</span><span class="nx">obj</span> <span class="o">is</span> <span class="o">+</span><span class="nx">obj</span><span class="p">)</span> <span class="o">or</span> <span class="nx">toString</span><span class="p">.</span><span class="nx">call</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span> <span class="o">is</span> <span class="s1">&#39;[object Number]&#39;</span></pre></div>             </td>           </tr>                               <tr id="section-82">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-82">&#182;</a>               </div>               <p>Is a given value a boolean?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isBoolean   = </span><span class="nf">(obj) -&gt;</span> <span class="nx">obj</span> <span class="o">is</span> <span class="kc">true</span> <span class="o">or</span> <span class="nx">obj</span> <span class="o">is</span> <span class="kc">false</span></pre></div>             </td>           </tr>                               <tr id="section-83">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-83">&#182;</a>               </div>               <p>Is a given value a Date?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isDate      = </span><span class="nf">(obj) -&gt;</span> <span class="o">!!</span><span class="p">(</span><span class="nx">obj</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">getTimezoneOffset</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">setUTCFullYear</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-84">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-84">&#182;</a>               </div>               <p>Is the given value a regular expression?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isRegExp    = </span><span class="nf">(obj) -&gt;</span> <span class="o">!!</span><span class="p">(</span><span class="nx">obj</span> <span class="o">and</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">exec</span> <span class="o">and</span> <span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">ignoreCase</span> <span class="o">or</span> <span class="nx">obj</span><span class="p">.</span><span class="nx">ignoreCase</span> <span class="o">is</span> <span class="kc">false</span><span class="p">))</span></pre></div>             </td>           </tr>                               <tr id="section-85">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-85">&#182;</a>               </div>               <p>Is the given value NaN -- this one is interesting. <code>NaN != NaN</code>, and
-<code>isNaN(undefined) == true</code>, so we make sure it's a number first.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isNaN       = </span><span class="nf">(obj) -&gt;</span> <span class="nx">_</span><span class="p">.</span><span class="nx">isNumber</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span> <span class="o">and</span> <span class="nb">window</span><span class="p">.</span><span class="nb">isNaN</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-86">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-86">&#182;</a>               </div>               <p>Is a given value equal to null?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isNull      = </span><span class="nf">(obj) -&gt;</span> <span class="nx">obj</span> <span class="o">is</span> <span class="kc">null</span></pre></div>             </td>           </tr>                               <tr id="section-87">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-87">&#182;</a>               </div>               <p>Is a given variable undefined?</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.isUndefined = </span><span class="nf">(obj) -&gt;</span> <span class="k">typeof</span> <span class="nx">obj</span> <span class="o">is</span> <span class="s1">&#39;undefined&#39;</span></pre></div>             </td>           </tr>                               <tr id="section-88">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-88">&#182;</a>               </div>               <h2>Utility Functions</h2>             </td>             <td class="code">               <div class="highlight"><pre></pre></div>             </td>           </tr>                               <tr id="section-89">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-89">&#182;</a>               </div>               <p>Run Underscore.js in noConflict mode, returning the <code>_</code> variable to its
-previous owner. Returns a reference to the Underscore object.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.noConflict = </span><span class="o">-&gt;</span>
-  <span class="nv">root._ = </span><span class="nx">previousUnderscore</span>
-  <span class="k">this</span></pre></div>             </td>           </tr>                               <tr id="section-90">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-90">&#182;</a>               </div>               <p>Keep the identity function around for default iterators.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.identity = </span><span class="nf">(value) -&gt;</span> <span class="nx">value</span></pre></div>             </td>           </tr>                               <tr id="section-91">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-91">&#182;</a>               </div>               <p>Run a function <code>n</code> times.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.times = </span><span class="nf">(n, iterator, context) -&gt;</span>
-  <span class="nx">iterator</span><span class="p">.</span><span class="nx">call</span> <span class="nx">context</span><span class="p">,</span> <span class="nx">i</span> <span class="k">for</span> <span class="nx">i</span> <span class="k">in</span> <span class="p">[</span><span class="mi">0</span><span class="p">...</span><span class="nx">n</span><span class="p">]</span></pre></div>             </td>           </tr>                               <tr id="section-92">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-92">&#182;</a>               </div>               <p>Break out of the middle of an iteration.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.breakLoop = </span><span class="o">-&gt;</span> <span class="k">throw</span> <span class="nx">breaker</span></pre></div>             </td>           </tr>                               <tr id="section-93">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-93">&#182;</a>               </div>               <p>Add your own custom functions to the Underscore object, ensuring that
-they're correctly added to the OOP wrapper as well.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.mixin = </span><span class="nf">(obj) -&gt;</span>
-  <span class="k">for</span> <span class="nx">name</span> <span class="k">in</span> <span class="nx">_</span><span class="p">.</span><span class="nx">functions</span><span class="p">(</span><span class="nx">obj</span><span class="p">)</span>
-    <span class="nx">addToWrapper</span> <span class="nx">name</span><span class="p">,</span> <span class="nx">_</span><span class="p">[</span><span class="nx">name</span><span class="p">]</span> <span class="o">=</span> <span class="nx">obj</span><span class="p">[</span><span class="nx">name</span><span class="p">]</span></pre></div>             </td>           </tr>                               <tr id="section-94">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-94">&#182;</a>               </div>               <p>Generate a unique integer id (unique within the entire client session).
-Useful for temporary DOM ids.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">idCounter = </span><span class="mi">0</span>
-<span class="nv">_.uniqueId = </span><span class="nf">(prefix) -&gt;</span>
-  <span class="p">(</span><span class="nx">prefix</span> <span class="o">or</span> <span class="s1">&#39;&#39;</span><span class="p">)</span> <span class="o">+</span> <span class="nx">idCounter</span><span class="o">++</span></pre></div>             </td>           </tr>                               <tr id="section-95">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-95">&#182;</a>               </div>               <p>By default, Underscore uses <strong>ERB</strong>-style template delimiters, change the
-following template settings to use alternative delimiters.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.templateSettings = </span><span class="p">{</span>
-  <span class="nv">start: </span>       <span class="s1">&#39;&lt;%&#39;</span>
-  <span class="nv">end: </span>         <span class="s1">&#39;%&gt;&#39;</span>
-  <span class="nv">interpolate: </span> <span class="sr">/&lt;%=(.+?)%&gt;/g</span>
-<span class="p">}</span></pre></div>             </td>           </tr>                               <tr id="section-96">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-96">&#182;</a>               </div>               <p>JavaScript templating a-la <strong>ERB</strong>, pilfered from John Resig's
+conditionally execute the original function.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">wrap</span></span> = (func, wrapper) -&gt;
+  -&gt; wrapper.apply wrapper, [func].concat arguments</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-52">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-52">&#182;</a>
+              </div>
+              <p>Returns a function that is the composition of a list of functions, each
+consuming the return value of the function that follows.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">compose</span></span> = -&gt;
+  funcs = arguments
+  -&gt;
+    args = arguments
+    <span class="keyword">for</span> i <span class="keyword">in</span> [funcs.length - <span class="number">1.</span><span class="number">.0</span>] <span class="keyword">by</span> -<span class="number">1</span>
+      args = [funcs[i].apply(<span class="keyword">this</span>, args)]
+    args[<span class="number">0</span>]</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-53">
+            <div class="annotation">
+              
+              <div class="pilwrap for-h2">
+                <a class="pilcrow" href="#section-53">&#182;</a>
+              </div>
+              <h2>Object Functions</h2>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-54">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-54">&#182;</a>
+              </div>
+              <p>Retrieve the names of an object&#39;s properties.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.keys = nativeKeys <span class="keyword">or</span> (obj) -&gt;
+  <span class="keyword">return</span> _.range <span class="number">0</span>, obj.length <span class="keyword">if</span> _.isArray(obj)
+  key <span class="keyword">for</span> key, val <span class="keyword">of</span> obj</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-55">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-55">&#182;</a>
+              </div>
+              <p>Retrieve the values of an object&#39;s properties.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">values</span></span> = (obj) -&gt;
+  _.map obj, _.identity</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-56">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-56">&#182;</a>
+              </div>
+              <p>Return a sorted list of the function names available in Underscore.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">functions</span></span> = (obj) -&gt;
+  _.filter(_.keys(obj), (key) -&gt; _.isFunction(obj[key])).sort()</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-57">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-57">&#182;</a>
+              </div>
+              <p>Extend a given object with all of the properties in a source object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">extend</span></span> = (obj) -&gt;
+  <span class="keyword">for</span> source <span class="keyword">in</span> _.rest(arguments)
+    obj[key] = val <span class="keyword">for</span> key, val <span class="keyword">of</span> source
+  obj</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-58">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-58">&#182;</a>
+              </div>
+              <p>Create a (shallow-cloned) duplicate of an object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">clone</span></span> = (obj) -&gt;
+  <span class="keyword">return</span> obj.slice <span class="number">0</span> <span class="keyword">if</span> _.isArray obj
+  _.extend {}, obj</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-59">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-59">&#182;</a>
+              </div>
+              <p>Invokes interceptor with the obj, and then returns obj.
+The primary purpose of this method is to &quot;tap into&quot; a method chain, in order to perform operations on intermediate results within the chain.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">tap</span></span> = (obj, interceptor) -&gt;
+  interceptor obj
+  obj</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-60">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-60">&#182;</a>
+              </div>
+              <p>Perform a deep comparison to check if two objects are equal.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isEqual</span></span> = (a, b) -&gt;</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-61">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-61">&#182;</a>
+              </div>
+              <p>Check object identity.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> <span class="literal">true</span> <span class="keyword">if</span> a <span class="keyword">is</span> b</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-62">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-62">&#182;</a>
+              </div>
+              <p>Different types?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  atype = <span class="keyword">typeof</span>(a); btype = <span class="keyword">typeof</span>(b)
+  <span class="keyword">return</span> <span class="literal">false</span> <span class="keyword">if</span> atype <span class="keyword">isnt</span> btype</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-63">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-63">&#182;</a>
+              </div>
+              <p>Basic equality test (watch out for coercions).</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> <span class="literal">true</span> <span class="keyword">if</span> `<span class="javascript">a == b</span>`</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-64">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-64">&#182;</a>
+              </div>
+              <p>One is falsy and the other truthy.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> <span class="literal">false</span> <span class="keyword">if</span> (!a <span class="keyword">and</span> b) <span class="keyword">or</span> (a <span class="keyword">and</span> !b)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-65">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-65">&#182;</a>
+              </div>
+              <p>One of them implements an <code>isEqual()</code>?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> a.isEqual(b) <span class="keyword">if</span> a.isEqual</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-66">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-66">&#182;</a>
+              </div>
+              <p>Check dates&#39; integer values.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> a.getTime() <span class="keyword">is</span> b.getTime() <span class="keyword">if</span> _.isDate(a) <span class="keyword">and</span> _.isDate(b)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-67">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-67">&#182;</a>
+              </div>
+              <p>Both are NaN?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> <span class="literal">false</span> <span class="keyword">if</span> _.isNaN(a) <span class="keyword">and</span> _.isNaN(b)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-68">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-68">&#182;</a>
+              </div>
+              <p>Compare regular expressions.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">if</span> _.isRegExp(a) <span class="keyword">and</span> _.isRegExp(b)
+    <span class="keyword">return</span> a.source     <span class="keyword">is</span> b.source <span class="keyword">and</span>
+           a.global     <span class="keyword">is</span> b.global <span class="keyword">and</span>
+           a.ignoreCase <span class="keyword">is</span> b.ignoreCase <span class="keyword">and</span>
+           a.multiline  <span class="keyword">is</span> b.multiline</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-69">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-69">&#182;</a>
+              </div>
+              <p>If a is not an object by this point, we can&#39;t handle it.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> <span class="literal">false</span> <span class="keyword">if</span> atype <span class="keyword">isnt</span> <span class="string">'object'</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-70">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-70">&#182;</a>
+              </div>
+              <p>Check for different array lengths before comparing contents.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> <span class="literal">false</span> <span class="keyword">if</span> a.length <span class="keyword">and</span> (a.length <span class="keyword">isnt</span> b.length)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-71">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-71">&#182;</a>
+              </div>
+              <p>Nothing else worked, deep compare the contents.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  aKeys = _.keys(a); bKeys = _.keys(b)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-72">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-72">&#182;</a>
+              </div>
+              <p>Different object sizes?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> <span class="literal">false</span> <span class="keyword">if</span> aKeys.length <span class="keyword">isnt</span> bKeys.length</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-73">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-73">&#182;</a>
+              </div>
+              <p>Recursive comparison of contents.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>  <span class="keyword">return</span> <span class="literal">false</span> <span class="keyword">for</span> key, val <span class="keyword">of</span> a <span class="keyword">when</span> !(key <span class="keyword">of</span> b) <span class="keyword">or</span> !_.isEqual(val, b[key])
+  <span class="literal">true</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-74">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-74">&#182;</a>
+              </div>
+              <p>Is a given array or object empty?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isEmpty</span></span> = (obj) -&gt;
+  <span class="keyword">return</span> obj.length <span class="keyword">is</span> <span class="number">0</span> <span class="keyword">if</span> _.isArray(obj) <span class="keyword">or</span> _.isString(obj)
+  <span class="keyword">return</span> <span class="literal">false</span> <span class="keyword">for</span> own key <span class="keyword">of</span> obj
+  <span class="literal">true</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-75">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-75">&#182;</a>
+              </div>
+              <p>Is a given value a DOM element?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isElement</span></span>   = (obj) -&gt; obj <span class="keyword">and</span> obj.nodeType <span class="keyword">is</span> <span class="number">1</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-76">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-76">&#182;</a>
+              </div>
+              <p>Is a given value an array?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.isArray     = nativeIsArray <span class="keyword">or</span> (obj) -&gt; !!(obj <span class="keyword">and</span> obj.concat <span class="keyword">and</span> obj.unshift <span class="keyword">and</span> <span class="keyword">not</span> obj.callee)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-77">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-77">&#182;</a>
+              </div>
+              <p>Is a given variable an arguments object?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isArguments</span></span> = (obj) -&gt; obj <span class="keyword">and</span> obj.callee</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-78">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-78">&#182;</a>
+              </div>
+              <p>Is the given value a function?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isFunction</span></span>  = (obj) -&gt; !!(obj <span class="keyword">and</span> obj.constructor <span class="keyword">and</span> obj.call <span class="keyword">and</span> obj.apply)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-79">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-79">&#182;</a>
+              </div>
+              <p>Is the given value a string?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isString</span></span>    = (obj) -&gt; !!(obj <span class="keyword">is</span> <span class="string">''</span> <span class="keyword">or</span> (obj <span class="keyword">and</span> obj.charCodeAt <span class="keyword">and</span> obj.substr))</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-80">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-80">&#182;</a>
+              </div>
+              <p>Is a given value a number?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isNumber</span></span>    = (obj) -&gt; (obj <span class="keyword">is</span> +obj) <span class="keyword">or</span> toString.call(obj) <span class="keyword">is</span> <span class="string">'[object Number]'</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-81">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-81">&#182;</a>
+              </div>
+              <p>Is a given value a boolean?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isBoolean</span></span>   = (obj) -&gt; obj <span class="keyword">is</span> <span class="literal">true</span> <span class="keyword">or</span> obj <span class="keyword">is</span> <span class="literal">false</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-82">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-82">&#182;</a>
+              </div>
+              <p>Is a given value a Date?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isDate</span></span>      = (obj) -&gt; !!(obj <span class="keyword">and</span> obj.getTimezoneOffset <span class="keyword">and</span> obj.setUTCFullYear)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-83">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-83">&#182;</a>
+              </div>
+              <p>Is the given value a regular expression?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isRegExp</span></span>    = (obj) -&gt; !!(obj <span class="keyword">and</span> obj.exec <span class="keyword">and</span> (obj.ignoreCase <span class="keyword">or</span> obj.ignoreCase <span class="keyword">is</span> <span class="literal">false</span>))</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-84">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-84">&#182;</a>
+              </div>
+              <p>Is the given value NaN -- this one is interesting. <code>NaN != NaN</code>, and
+<code>isNaN(undefined) == true</code>, so we make sure it&#39;s a number first.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isNaN</span></span>       = (obj) -&gt; _.isNumber(obj) <span class="keyword">and</span> window.isNaN(obj)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-85">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-85">&#182;</a>
+              </div>
+              <p>Is a given value equal to null?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isNull</span></span>      = (obj) -&gt; obj <span class="keyword">is</span> <span class="literal">null</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-86">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-86">&#182;</a>
+              </div>
+              <p>Is a given variable undefined?</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">isUndefined</span></span> = (obj) -&gt; <span class="keyword">typeof</span> obj <span class="keyword">is</span> <span class="string">'undefined'</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-87">
+            <div class="annotation">
+              
+              <div class="pilwrap for-h2">
+                <a class="pilcrow" href="#section-87">&#182;</a>
+              </div>
+              <h2>Utility Functions</h2>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-88">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-88">&#182;</a>
+              </div>
+              <p>Run Underscore.js in noConflict mode, returning the <code>_</code> variable to its
+previous owner. Returns a reference to the Underscore object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">noConflict</span></span> = -&gt;
+  root._ = previousUnderscore
+  <span class="keyword">this</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-89">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-89">&#182;</a>
+              </div>
+              <p>Keep the identity function around for default iterators.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">identity</span></span> = (value) -&gt; value</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-90">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-90">&#182;</a>
+              </div>
+              <p>Run a function <code>n</code> times.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">times</span></span> = (n, iterator, context) -&gt;
+  iterator.call context, i <span class="keyword">for</span> i <span class="keyword">in</span> [<span class="number">0.</span>..n]</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-91">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-91">&#182;</a>
+              </div>
+              <p>Break out of the middle of an iteration.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">breakLoop</span></span> = -&gt; <span class="keyword">throw</span> breaker</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-92">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-92">&#182;</a>
+              </div>
+              <p>Add your own custom functions to the Underscore object, ensuring that
+they&#39;re correctly added to the OOP wrapper as well.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">mixin</span></span> = (obj) -&gt;
+  <span class="keyword">for</span> name <span class="keyword">in</span> _.functions(obj)
+    addToWrapper name, _[name] = obj[name]</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-93">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-93">&#182;</a>
+              </div>
+              <p>Generate a unique integer id (unique within the entire client session).
+Useful for temporary DOM ids.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>idCounter = <span class="number">0</span>
+_.<span class="function"><span class="title">uniqueId</span></span> = (prefix) -&gt;
+  (prefix <span class="keyword">or</span> <span class="string">''</span>) + idCounter++</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-94">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-94">&#182;</a>
+              </div>
+              <p>By default, Underscore uses <strong>ERB</strong>-style template delimiters, change the
+following template settings to use alternative delimiters.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.templateSettings = {
+  start:        <span class="string">'&lt;%'</span>
+  end:          <span class="string">'%&gt;'</span>
+  interpolate:  <span class="regexp">/&lt;%=(.+?)%&gt;/g</span>
+}</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-95">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-95">&#182;</a>
+              </div>
+              <p>JavaScript templating a-la <strong>ERB</strong>, pilfered from John Resig&#39;s
 <em>Secrets of the JavaScript Ninja</em>, page 83.
 Single-quote fix from Rick Strahl.
-With alterations for arbitrary delimiters, and to preserve whitespace.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.template = </span><span class="nf">(str, data) -&gt;</span>
-  <span class="nv">c = </span><span class="nx">_</span><span class="p">.</span><span class="nx">templateSettings</span>
-  <span class="nv">endMatch = </span><span class="k">new</span> <span class="nb">RegExp</span><span class="p">(</span><span class="s2">&quot;&#39;(?=[^&quot;</span><span class="o">+</span><span class="nx">c</span><span class="p">.</span><span class="nx">end</span><span class="p">.</span><span class="nx">substr</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span><span class="o">+</span><span class="s2">&quot;]*&quot;</span><span class="o">+</span><span class="nx">escapeRegExp</span><span class="p">(</span><span class="nx">c</span><span class="p">.</span><span class="nx">end</span><span class="p">)</span><span class="o">+</span><span class="s2">&quot;)&quot;</span><span class="p">,</span><span class="s2">&quot;g&quot;</span><span class="p">)</span>
-  <span class="nv">fn = </span><span class="k">new</span> <span class="nb">Function</span> <span class="s1">&#39;obj&#39;</span><span class="p">,</span>
-    <span class="s1">&#39;var p=[],print=function(){p.push.apply(p,arguments);};&#39;</span> <span class="o">+</span>
-    <span class="s1">&#39;with(obj||{}){p.push(\&#39;&#39;</span> <span class="o">+</span>
-    <span class="nx">str</span><span class="p">.</span><span class="nx">replace</span><span class="p">(</span><span class="sr">/\r/g</span><span class="p">,</span> <span class="s1">&#39;\\r&#39;</span><span class="p">)</span>
-       <span class="p">.</span><span class="nx">replace</span><span class="p">(</span><span class="sr">/\n/g</span><span class="p">,</span> <span class="s1">&#39;\\n&#39;</span><span class="p">)</span>
-       <span class="p">.</span><span class="nx">replace</span><span class="p">(</span><span class="sr">/\t/g</span><span class="p">,</span> <span class="s1">&#39;\\t&#39;</span><span class="p">)</span>
-       <span class="p">.</span><span class="nx">replace</span><span class="p">(</span><span class="nx">endMatch</span><span class="p">,</span><span class="s2">&quot;✄&quot;</span><span class="p">)</span>
-       <span class="p">.</span><span class="nx">split</span><span class="p">(</span><span class="s2">&quot;&#39;&quot;</span><span class="p">).</span><span class="nx">join</span><span class="p">(</span><span class="s2">&quot;\\&#39;&quot;</span><span class="p">)</span>
-       <span class="p">.</span><span class="nx">split</span><span class="p">(</span><span class="s2">&quot;✄&quot;</span><span class="p">).</span><span class="nx">join</span><span class="p">(</span><span class="s2">&quot;&#39;&quot;</span><span class="p">)</span>
-       <span class="p">.</span><span class="nx">replace</span><span class="p">(</span><span class="nx">c</span><span class="p">.</span><span class="nx">interpolate</span><span class="p">,</span> <span class="s2">&quot;&#39;,$1,&#39;&quot;</span><span class="p">)</span>
-       <span class="p">.</span><span class="nx">split</span><span class="p">(</span><span class="nx">c</span><span class="p">.</span><span class="nx">start</span><span class="p">).</span><span class="nx">join</span><span class="p">(</span><span class="s2">&quot;&#39;);&quot;</span><span class="p">)</span>
-       <span class="p">.</span><span class="nx">split</span><span class="p">(</span><span class="nx">c</span><span class="p">.</span><span class="nx">end</span><span class="p">).</span><span class="nx">join</span><span class="p">(</span><span class="s2">&quot;p.push(&#39;&quot;</span><span class="p">)</span> <span class="o">+</span>
-       <span class="s2">&quot;&#39;);}return p.join(&#39;&#39;);&quot;</span>
-  <span class="k">if</span> <span class="nx">data</span> <span class="k">then</span> <span class="nx">fn</span><span class="p">(</span><span class="nx">data</span><span class="p">)</span> <span class="k">else</span> <span class="nx">fn</span></pre></div>             </td>           </tr>                               <tr id="section-97">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-97">&#182;</a>               </div>               <h2>Aliases</h2>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">_.forEach  = </span><span class="nx">_</span><span class="p">.</span><span class="nx">each</span>
-<span class="nv">_.foldl    = _.inject = </span><span class="nx">_</span><span class="p">.</span><span class="nx">reduce</span>
-<span class="nv">_.foldr    = </span><span class="nx">_</span><span class="p">.</span><span class="nx">reduceRight</span>
-<span class="nv">_.select   = </span><span class="nx">_</span><span class="p">.</span><span class="nx">filter</span>
-<span class="nv">_.all      = </span><span class="nx">_</span><span class="p">.</span><span class="nx">every</span>
-<span class="nv">_.any      = </span><span class="nx">_</span><span class="p">.</span><span class="nx">some</span>
-<span class="nv">_.contains = </span><span class="nx">_</span><span class="p">.</span><span class="nx">include</span>
-<span class="nv">_.head     = </span><span class="nx">_</span><span class="p">.</span><span class="nx">first</span>
-<span class="nv">_.tail     = </span><span class="nx">_</span><span class="p">.</span><span class="nx">rest</span>
-<span class="nv">_.methods  = </span><span class="nx">_</span><span class="p">.</span><span class="nx">functions</span></pre></div>             </td>           </tr>                               <tr id="section-98">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-98">&#182;</a>               </div>               <h2>Setup the OOP Wrapper</h2>             </td>             <td class="code">               <div class="highlight"><pre></pre></div>             </td>           </tr>                               <tr id="section-99">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-99">&#182;</a>               </div>               <p>If Underscore is called as a function, it returns a wrapped object that
-can be used OO-style. This wrapper holds altered versions of all the
-underscore functions. Wrapped objects may be chained.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">wrapper = </span><span class="nf">(obj) -&gt;</span>
-  <span class="k">this</span><span class="p">.</span><span class="nv">_wrapped = </span><span class="nx">obj</span>
-  <span class="k">this</span></pre></div>             </td>           </tr>                               <tr id="section-100">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-100">&#182;</a>               </div>               <p>Helper function to continue chaining intermediate results.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">result = </span><span class="nf">(obj, chain) -&gt;</span>
-  <span class="k">if</span> <span class="nx">chain</span> <span class="k">then</span> <span class="nx">_</span><span class="p">(</span><span class="nx">obj</span><span class="p">).</span><span class="nx">chain</span><span class="p">()</span> <span class="k">else</span> <span class="nx">obj</span></pre></div>             </td>           </tr>                               <tr id="section-101">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-101">&#182;</a>               </div>               <p>A method to easily add functions to the OOP wrapper.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">addToWrapper = </span><span class="nf">(name, func) -&gt;</span>
-  <span class="nx">wrapper</span><span class="p">.</span><span class="nx">prototype</span><span class="p">[</span><span class="nx">name</span><span class="p">]</span> <span class="o">=</span> <span class="o">-&gt;</span>
-    <span class="nv">args = </span><span class="nx">_</span><span class="p">.</span><span class="nx">toArray</span> <span class="nx">arguments</span>
-    <span class="nx">unshift</span><span class="p">.</span><span class="nx">call</span> <span class="nx">args</span><span class="p">,</span> <span class="k">this</span><span class="p">.</span><span class="nx">_wrapped</span>
-    <span class="nx">result</span> <span class="nx">func</span><span class="p">.</span><span class="nx">apply</span><span class="p">(</span><span class="nx">_</span><span class="p">,</span> <span class="nx">args</span><span class="p">),</span> <span class="k">this</span><span class="p">.</span><span class="nx">_chain</span></pre></div>             </td>           </tr>                               <tr id="section-102">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-102">&#182;</a>               </div>               <p>Add all ofthe Underscore functions to the wrapper object.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nx">_</span><span class="p">.</span><span class="nx">mixin</span> <span class="nx">_</span></pre></div>             </td>           </tr>                               <tr id="section-103">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-103">&#182;</a>               </div>               <p>Add all mutator Array functions to the wrapper.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="p">[</span><span class="s1">&#39;pop&#39;</span><span class="p">,</span> <span class="s1">&#39;push&#39;</span><span class="p">,</span> <span class="s1">&#39;reverse&#39;</span><span class="p">,</span> <span class="s1">&#39;shift&#39;</span><span class="p">,</span> <span class="s1">&#39;sort&#39;</span><span class="p">,</span> <span class="s1">&#39;splice&#39;</span><span class="p">,</span> <span class="s1">&#39;unshift&#39;</span><span class="p">],</span> <span class="nf">(name) -&gt;</span>
-  <span class="nv">method = </span><span class="nb">Array</span><span class="p">.</span><span class="nx">prototype</span><span class="p">[</span><span class="nx">name</span><span class="p">]</span>
-  <span class="nx">wrapper</span><span class="p">.</span><span class="nx">prototype</span><span class="p">[</span><span class="nx">name</span><span class="p">]</span> <span class="o">=</span> <span class="o">-&gt;</span>
-    <span class="nx">method</span><span class="p">.</span><span class="nx">apply</span><span class="p">(</span><span class="k">this</span><span class="p">.</span><span class="nx">_wrapped</span><span class="p">,</span> <span class="nx">arguments</span><span class="p">)</span>
-    <span class="nx">result</span><span class="p">(</span><span class="k">this</span><span class="p">.</span><span class="nx">_wrapped</span><span class="p">,</span> <span class="k">this</span><span class="p">.</span><span class="nx">_chain</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-104">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-104">&#182;</a>               </div>               <p>Add all accessor Array functions to the wrapper.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nx">_</span><span class="p">.</span><span class="nx">each</span> <span class="p">[</span><span class="s1">&#39;concat&#39;</span><span class="p">,</span> <span class="s1">&#39;join&#39;</span><span class="p">,</span> <span class="s1">&#39;slice&#39;</span><span class="p">],</span> <span class="nf">(name) -&gt;</span>
-  <span class="nv">method = </span><span class="nb">Array</span><span class="p">.</span><span class="nx">prototype</span><span class="p">[</span><span class="nx">name</span><span class="p">]</span>
-  <span class="nx">wrapper</span><span class="p">.</span><span class="nx">prototype</span><span class="p">[</span><span class="nx">name</span><span class="p">]</span> <span class="o">=</span> <span class="o">-&gt;</span>
-    <span class="nx">result</span><span class="p">(</span><span class="nx">method</span><span class="p">.</span><span class="nx">apply</span><span class="p">(</span><span class="k">this</span><span class="p">.</span><span class="nx">_wrapped</span><span class="p">,</span> <span class="nx">arguments</span><span class="p">),</span> <span class="k">this</span><span class="p">.</span><span class="nx">_chain</span><span class="p">)</span></pre></div>             </td>           </tr>                               <tr id="section-105">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-105">&#182;</a>               </div>               <p>Start chaining a wrapped Underscore object.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">wrapper::chain = </span><span class="o">-&gt;</span>
-  <span class="k">this</span><span class="p">.</span><span class="nv">_chain = </span><span class="kc">true</span>
-  <span class="k">this</span></pre></div>             </td>           </tr>                               <tr id="section-106">             <td class="docs">               <div class="pilwrap">                 <a class="pilcrow" href="#section-106">&#182;</a>               </div>               <p>Extracts the result from a wrapped and chained object.</p>             </td>             <td class="code">               <div class="highlight"><pre><span class="nv">wrapper::value = </span><span class="o">-&gt;</span> <span class="k">this</span><span class="p">.</span><span class="nx">_wrapped</span>
+With alterations for arbitrary delimiters, and to preserve whitespace.</p>
 
-</pre></div>             </td>           </tr>                </tbody>     </table>   </div> </body> </html> 
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.<span class="function"><span class="title">template</span></span> = (str, data) -&gt;
+  c = _.templateSettings
+  endMatch = <span class="keyword">new</span> RegExp(<span class="string">"'(?=[^"</span>+c.end.substr(<span class="number">0</span>, <span class="number">1</span>)+<span class="string">"]*"</span>+escapeRegExp(c.end)+<span class="string">")"</span>,<span class="string">"g"</span>)
+  fn = <span class="keyword">new</span> Function <span class="string">'obj'</span>,
+    <span class="string">'var p=[],print=function(){p.push.apply(p,arguments);};'</span> +
+    <span class="string">'with(obj||{}){p.push(\''</span> +
+    str.replace(<span class="regexp">/\r/g</span>, <span class="string">'\\r'</span>)
+       .replace(<span class="regexp">/\n/g</span>, <span class="string">'\\n'</span>)
+       .replace(<span class="regexp">/\t/g</span>, <span class="string">'\\t'</span>)
+       .replace(endMatch,<span class="string">"✄"</span>)
+       .split(<span class="string">"'"</span>).join(<span class="string">"\\'"</span>)
+       .split(<span class="string">"✄"</span>).join(<span class="string">"'"</span>)
+       .replace(c.interpolate, <span class="string">"',$1,'"</span>)
+       .split(c.start).join(<span class="string">"');"</span>)
+       .split(c.end).join(<span class="string">"p.push('"</span>) +
+       <span class="string">"');}return p.join('');"</span>
+  <span class="keyword">if</span> data <span class="keyword">then</span> fn(data) <span class="keyword">else</span> fn</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-96">
+            <div class="annotation">
+              
+              <div class="pilwrap for-h2">
+                <a class="pilcrow" href="#section-96">&#182;</a>
+              </div>
+              <h2>Aliases</h2>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-97">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-97">&#182;</a>
+              </div>
+              
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.forEach  = _.each
+_.foldl    = _.inject = _.reduce
+_.foldr    = _.reduceRight
+_.select   = _.filter
+_.all      = _.every
+_.any      = _.some
+_.contains = _.include
+_.head     = _.first
+_.tail     = _.rest
+_.methods  = _.functions</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-98">
+            <div class="annotation">
+              
+              <div class="pilwrap for-h2">
+                <a class="pilcrow" href="#section-98">&#182;</a>
+              </div>
+              <h2>Setup the OOP Wrapper</h2>
+
+            </div>
+            
+        </li>
+        
+        
+        <li id="section-99">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-99">&#182;</a>
+              </div>
+              <p>If Underscore is called as a function, it returns a wrapped object that
+can be used OO-style. This wrapper holds altered versions of all the
+underscore functions. Wrapped objects may be chained.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="function"><span class="title">wrapper</span></span> = (obj) -&gt;
+  <span class="keyword">this</span>._wrapped = obj
+  <span class="keyword">this</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-100">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-100">&#182;</a>
+              </div>
+              <p>Helper function to continue chaining intermediate results.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="function"><span class="title">result</span></span> = (obj, chain) -&gt;
+  <span class="keyword">if</span> chain <span class="keyword">then</span> _(obj).chain() <span class="keyword">else</span> obj</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-101">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-101">&#182;</a>
+              </div>
+              <p>A method to easily add functions to the OOP wrapper.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre><span class="function"><span class="title">addToWrapper</span></span> = (name, func) -&gt;
+  wrapper.prototype[name] = -&gt;
+    args = _.toArray arguments
+    unshift.call args, <span class="keyword">this</span>._wrapped
+    result func.apply(_, args), <span class="keyword">this</span>._chain</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-102">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-102">&#182;</a>
+              </div>
+              <p>Add all ofthe Underscore functions to the wrapper object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.mixin _</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-103">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-103">&#182;</a>
+              </div>
+              <p>Add all mutator Array functions to the wrapper.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.each [<span class="string">'pop'</span>, <span class="string">'push'</span>, <span class="string">'reverse'</span>, <span class="string">'shift'</span>, <span class="string">'sort'</span>, <span class="string">'splice'</span>, <span class="string">'unshift'</span>], (name) -&gt;
+  method = Array.prototype[name]
+  wrapper.prototype[name] = -&gt;
+    method.apply(<span class="keyword">this</span>._wrapped, arguments)
+    result(<span class="keyword">this</span>._wrapped, <span class="keyword">this</span>._chain)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-104">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-104">&#182;</a>
+              </div>
+              <p>Add all accessor Array functions to the wrapper.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>_.each [<span class="string">'concat'</span>, <span class="string">'join'</span>, <span class="string">'slice'</span>], (name) -&gt;
+  method = Array.prototype[name]
+  wrapper.prototype[name] = -&gt;
+    result(method.apply(<span class="keyword">this</span>._wrapped, arguments), <span class="keyword">this</span>._chain)</pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-105">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-105">&#182;</a>
+              </div>
+              <p>Start chaining a wrapped Underscore object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>wrapper::<span class="function"><span class="title">chain</span></span> = -&gt;
+  <span class="keyword">this</span>._chain = <span class="literal">true</span>
+  <span class="keyword">this</span></pre></div></div>
+            
+        </li>
+        
+        
+        <li id="section-106">
+            <div class="annotation">
+              
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-106">&#182;</a>
+              </div>
+              <p>Extracts the result from a wrapped and chained object.</p>
+
+            </div>
+            
+            <div class="content"><div class='highlight'><pre>wrapper::<span class="function"><span class="title">value</span></span> = -&gt; <span class="keyword">this</span>._wrapped</pre></div></div>
+            
+        </li>
+        
+    </ul>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Use docco to regenerate documentation for underscore.coffee. Per @ruanp suggestion, screenshots are attached. The syntax highlighting, alignment, and responsive formatting have been fixed.
## Before

![broken](https://f.cloud.github.com/assets/1577682/1051297/88363f9e-10c8-11e3-868f-5d2a28f0ad7d.jpg)
## After

![fixed](https://f.cloud.github.com/assets/1577682/1051299/927659bc-10c8-11e3-9415-bd4a9daf4392.jpg)
