### PR TITLE
fix exit code when using --nodejs option

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -346,10 +346,11 @@ forkNode = ->
   nodeArgs = opts.nodejs.split /\s+/
   args     = process.argv[1..]
   args.splice args.indexOf('--nodejs'), 2
-  spawn process.execPath, nodeArgs.concat(args),
+  p = spawn process.execPath, nodeArgs.concat(args),
     cwd:        process.cwd()
     env:        process.env
     customFds:  [0, 1, 2]
+  p.on 'exit', (code) -> process.exit code
 
 # Print the `--help` usage message and exit. Deprecated switches are not
 # shown.


### PR DESCRIPTION
```
$ echo 'process.exit 1' > foo.coffee
$ coffee foo.coffee ; echo $?
1
$ coffee --nodejs --no-deprecation foo.coffee ; echo $?
0
```
