### PR TITLE
Fix: support for consumers of the REPL *module* being able to opt into using the global context ...

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -19,7 +19,7 @@
     historyFile: process.env.HOME ? path.join(process.env.HOME, '.coffee_history') : void 0,
     historyMaxInputSize: 10240,
     "eval": function(input, context, filename, cb) {
-      var Assign, Block, Literal, Value, ast, err, js, _ref1;
+      var Assign, Block, Literal, Value, ast, err, js, result, _ref1;
       input = input.replace(/\uFF00/g, '\n');
       input = input.replace(/^\(([\s\S]*)\n\)$/m, '$1');
       _ref1 = require('./nodes'), Block = _ref1.Block, Assign = _ref1.Assign, Value = _ref1.Value, Literal = _ref1.Literal;
@@ -30,7 +30,8 @@
           bare: true,
           locals: Object.keys(context)
         });
-        return cb(null, vm.runInContext(js, context, filename));
+        result = context === global ? vm.runInThisContext(js, filename) : vm.runInContext(js, context, filename);
+        return cb(null, result);
       } catch (_error) {
         err = _error;
         updateSyntaxError(err, input);

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -27,7 +27,11 @@ replDefaults =
         new Assign (new Value new Literal '_'), ast, '='
       ]
       js = ast.compile bare: yes, locals: Object.keys(context)
-      cb null, vm.runInContext(js, context, filename)
+      result = if context is global
+        vm.runInThisContext js, filename 
+      else
+        vm.runInContext js, context, filename
+      cb null, result
     catch err
       # AST's `compile` does not add source code information to syntax errors.
       updateSyntaxError err, input


### PR DESCRIPTION
... via option `.useGlobal`.

Note that, at least for now, CoffeeScript's own REPL _CLI_ still uses a
non-global context, rendering modules such as `color`, which attempt to
modify the prototypes of JavaScript primitives, ineffective. By
contrast, node's own CLI does use the global context.
