### PR TITLE
Fixes #3186

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -22,8 +22,6 @@
 
   exports.VERSION = '1.6.3';
 
-  binary = require.resolve('../../bin/coffee');
-
   fileExtensions = ['.coffee', '.litcoffee', '.coffee.md'];
 
   exports.helpers = helpers;
@@ -239,6 +237,7 @@
 
   if (child_process) {
     fork = child_process.fork;
+    binary = require.resolve('../../bin/coffee');
     child_process.fork = function(path, args, options) {
       var execPath;
       if (args == null) {

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -15,7 +15,6 @@ SourceMap     = require './sourcemap'
 # The current CoffeeScript version number.
 exports.VERSION = '1.6.3'
 
-binary = require.resolve '../../bin/coffee'
 fileExtensions = ['.coffee', '.litcoffee', '.coffee.md']
 
 # Expose helpers for testing.
@@ -205,6 +204,7 @@ if require.extensions
 # to fork both CoffeeScript files, and JavaScript files, directly.
 if child_process
   {fork} = child_process
+  binary = require.resolve '../../bin/coffee'
   child_process.fork = (path, args = [], options = {}) ->
     execPath = if helpers.isCoffee(path) then binary else null
     if not Array.isArray args


### PR DESCRIPTION
Moves call to `require.resolve` inside a conditional as suggested here (jashkenas/coffee-script#3107) in order to resolve #3186.
