### PR TITLE
Fix compilation for conditional assignment

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1712,15 +1712,24 @@
     };
 
     Assign.prototype.compileConditional = function(o) {
-      var left, right, _ref4;
+      var fragments, left, right, _ref4;
       _ref4 = this.variable.cacheReference(o), left = _ref4[0], right = _ref4[1];
       if (!left.properties.length && left.base instanceof Literal && left.base.value !== "this" && !o.scope.check(left.base.value)) {
         this.variable.error("the variable \"" + left.base.value + "\" can't be assigned with " + this.context + " because it has not been declared before");
       }
       if (__indexOf.call(this.context, "?") >= 0) {
         o.isExistentialEquals = true;
+        return new If(new Existence(left), right, {
+          type: 'if'
+        }).addElse(new Assign(right, this.value, '=')).compileToFragments(o);
+      } else {
+        fragments = new Op(this.context.slice(0, -1), left, new Assign(right, this.value, '=')).compileToFragments(o);
+        if (o.level <= LEVEL_LIST) {
+          return fragments;
+        } else {
+          return this.wrapInBraces(fragments);
+        }
       }
-      return new Op(this.context.slice(0, -1), left, new Assign(right, this.value, '=')).compileToFragments(o);
     };
 
     Assign.prototype.compileSplice = function(o) {
@@ -2318,7 +2327,7 @@
 
     Op.prototype.compileExistence = function(o) {
       var fst, ref;
-      if (!o.isExistentialEquals && this.first.isComplex()) {
+      if (this.first.isComplex()) {
         ref = new Literal(o.scope.freeVariable('ref'));
         fst = new Parens(new Assign(ref, this.first));
       } else {

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -81,6 +81,9 @@ test "compound assignment should be careful about caching variables", ->
   eq 5, base.five
   eq 5, count
 
+  eq 5, base().five ?= 6
+  eq 6, count
+
 test "compound assignment with implicit objects", ->
   obj = undefined
   obj ?=
@@ -380,3 +383,9 @@ test "#2613: parens on LHS of destructuring", ->
   a = {}
   [(a).b] = [1, 2, 3]
   eq a.b, 1
+
+test "#2181: conditional assignment as a subexpression", ->
+  a = false
+  false && a or= true
+  eq false, a
+  eq false, not a or= true


### PR DESCRIPTION
Fixes two errors with conditional assignments as subexpressions:
1.  #2181: `||=` and `&&=` are not properly parenthesized.
   
   Straightforward fix, analogous to the other assignment variants.
2.  Variable caching for `?=` is broken. (Could not find a related issue.)
   
   ``` coffee
   x = foo().bar ?= baz
   ```
   
   compiles to
   
   ``` javascript
   x = (_base = foo()).bar != null ? (_base = foo()).bar : _base.bar = baz;
   ```
   
   Fixed by constructing the `If` directly in `Assign.compileConditional` instead of delegating to `Op` and losing the reference (`_base.bar`) in the process.
   
   Compilation is now (as it should be):
   
   ``` javascript
   x = (_base = foo()).bar != null ? _base.bar : _base.bar = baz;
   ```
