### PR TITLE
add: Stat polling support while `fs.watch` doesn't work.

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -283,9 +283,9 @@
       });
     };
     try {
-      if (opts.polling) {
+      if (opts['watch-polling']) {
         fs.watchFile(source, {
-          interval: parseInt(opts.polling)
+          interval: parseInt(opts['watch-polling'])
         }, compile);
       } else {
         watcher = fs.watch(source, compile);
@@ -295,10 +295,10 @@
       watchErr(e);
     }
     return rewatch = function() {
-      if (opts.polling) {
+      if (opts['watch-polling']) {
         fs.unwatchFile(source);
         return fs.watchFile(source, {
-          interval: parseInt(opts.polling)
+          interval: parseInt(opts['watch-polling'])
         }, compile);
       } else {
         if (watcher != null) {
@@ -322,7 +322,7 @@
               if (err.code !== 'ENOENT') {
                 throw err;
               }
-              if (opts.polling) {
+              if (opts['watch-polling']) {
                 fs.unwatchFile(source);
               } else {
                 watcher.close();
@@ -349,9 +349,9 @@
           });
         });
       };
-      if (opts.polling) {
+      if (opts['watch-polling']) {
         return fs.watchFile(source, {
-          interval: parseInt(opts.polling)
+          interval: parseInt(opts['watch-polling'])
         }, compile);
       } else {
         return watcher = fs.watch(source, compile);

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -213,17 +213,17 @@ watch = (source, base) ->
     #
     # This is useful while watching remote directory.
     # Such as the `fs.watch` won't catch the SMB server's file change event.
-    if opts.polling
-      fs.watchFile source, { interval: parseInt(opts.polling) }, compile
+    if opts['watch-polling']
+      fs.watchFile source, { interval: parseInt(opts['watch-polling']) }, compile
     else
       watcher = fs.watch source, compile
   catch e
     watchErr e
 
   rewatch = ->
-    if opts.polling
+    if opts['watch-polling']
       fs.unwatchFile source
-      fs.watchFile source, { interval: parseInt(opts.polling) }, compile
+      fs.watchFile source, { interval: parseInt(opts['watch-polling']) }, compile
     else
       watcher?.close()
       watcher = fs.watch source, compile
@@ -240,7 +240,7 @@ watchDir = (source, base) ->
           if err
             throw err unless err.code is 'ENOENT'
 
-            if opts.polling
+            if opts['watch-polling']
               fs.unwatchFile source
             else
               watcher.close()
@@ -253,8 +253,8 @@ watchDir = (source, base) ->
             sourceCode.push null
             compilePath file, no, base
 
-    if opts.polling
-      fs.watchFile source, { interval: parseInt(opts.polling) }, compile
+    if opts['watch-polling']
+      fs.watchFile source, { interval: parseInt(opts['watch-polling']) }, compile
     else
       watcher = fs.watch source, compile
 


### PR DESCRIPTION
See issue: https://github.com/jashkenas/coffee-script/issues/3210

Add a new cli option: `-g --polling [SPAN]`

```
If state polling mode is enabled, use it.
Else use the native api.

This is useful while watching remote directory.
Such as the `fs.watch` won't catch the SMB server's file change event.
```
