### PR TITLE
Escaped whitespace and slashes in Heregexes

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -275,7 +275,7 @@
       var body, flags, flagsOffset, heregex, plusToken, prev, re, tag, token, tokens, value, _i, _len, _ref2, _ref3, _ref4;
       heregex = match[0], body = match[1], flags = match[2];
       if (0 > body.indexOf('#{')) {
-        re = body.replace(HEREGEX_OMIT, '').replace(/\//g, '\\/');
+        re = body.replace(HEREGEX_OMIT, '$1$2').replace(/\//g, '\\/');
         if (re.match(/^\*/)) {
           this.error('regular expressions cannot begin with `*`');
         }
@@ -294,7 +294,7 @@
         if (tag === 'TOKENS') {
           tokens.push.apply(tokens, value);
         } else if (tag === 'NEOSTRING') {
-          if (!(value = value.replace(HEREGEX_OMIT, ''))) {
+          if (!(value = value.replace(HEREGEX_OMIT, '$1$2'))) {
             continue;
           }
           value = value.replace(/\\/g, '\\\\');
@@ -858,9 +858,9 @@
 
   REGEX = /^(\/(?![\s=])[^[\/\n\\]*(?:(?:\\[\s\S]|\[[^\]\n\\]*(?:\\[\s\S][^\]\n\\]*)*])[^[\/\n\\]*)*\/)([imgy]{0,4})(?!\w)/;
 
-  HEREGEX = /^\/{3}([\s\S]+?)\/{3}([imgy]{0,4})(?!\w)/;
+  HEREGEX = /^\/{3}((?:\\?[\s\S])+?)\/{3}([imgy]{0,4})(?!\w)/;
 
-  HEREGEX_OMIT = /\s+(?:#.*)?/g;
+  HEREGEX_OMIT = /((?:\\\\)+)|\\([^\n\S]|\/)|\s+(?:#.*)?/g;
 
   MULTILINER = /\n/g;
 

--- a/test/regexps.coffee
+++ b/test/regexps.coffee
@@ -61,3 +61,14 @@ test "empty regular expressions with flags", ->
   a = "" + //i
   fn ""
   eq '/(?:)/i', a
+
+test "#3059: don't remove escaped whitespace", ->
+  eq  /// One\ cannot [\ ] escape \  \destiny. ///.source,
+      /One cannot[ ]escape \destiny./.source
+
+test "#2238: don't escape already escaped slashes", ->
+  eq /// \\\/ \/ ///.source, /\\\/\//.source
+
+test "escaped slashes don't close heregex", ->
+  eq /// \/// ///.source, /\/\/\//.source
+  eq /// \\\////.source, /\\\//.source


### PR DESCRIPTION
Escaped whitespace and slashes in Heregexes
- Resolves #3059: Don't remove escaped whitespace.
- Fixes #2238: Prevent escaping slashes that are already escaped.
- Fix detection of end of heregex with escaped slashes.

Escaped whitespaces and slashes in Heregexes

It's a bit ugly but it implements #3059 and fixes #2238.
(Google and MSDN say this should work with all relevant JS engines.)

This PR also fixes the `HEREGEX` regex, so this is a thing now:

```
threeSlashes = /// \/// ///
```
#### Notes
- Linebreaks are excluded from the escapable characters to avoid any confusion. (A backslash at the end of a line usually denotes a continuation on the next line but would mean the exact opposite here.)
- Whitespace escaping introduces a potential pitfall:
  
  ```
  /// this\ #is not a comment ///
  ```
  
  It would be possible to treat this as a comment but that would be somewhat inconsistent and break other constructs (e.g. `/// ^[\ #].* ///`).
