### PR TITLE
Avoid unnecessary wrapping of some bound functions

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1794,9 +1794,6 @@
       this.params = params || [];
       this.body = body || new Block;
       this.bound = tag === 'boundfunc';
-      if (this.bound) {
-        this.context = '_this';
-      }
     }
 
     Code.prototype.children = ['params', 'body'];
@@ -1812,10 +1809,13 @@
     };
 
     Code.prototype.compileNode = function(o) {
-      var answer, boundfunc, code, exprs, i, idt, lit, p, param, params, ref, splats, uniqs, val, wasEmpty, wrapper, _i, _j, _k, _l, _len, _len1, _len2, _len3, _len4, _m, _ref2, _ref3, _ref4, _ref5, _ref6;
-      if (this.bound && !this.wrapped && !this["static"]) {
-        this.wrapped = true;
-        wrapper = new Code([new Param(new Literal('_this'))], new Block([this]));
+      var answer, boundfunc, code, exprs, i, lit, p, param, params, ref, splats, uniqs, val, wasEmpty, wrapper, _i, _j, _k, _l, _len, _len1, _len2, _len3, _len4, _m, _ref2, _ref3, _ref4, _ref5, _ref6;
+      if (this.bound && ((_ref2 = o.scope.method) != null ? _ref2.bound : void 0)) {
+        this.context = o.scope.method.context;
+      }
+      if (this.bound && !this.context) {
+        this.context = '_this';
+        wrapper = new Code([new Param(new Literal(this.context))], new Block([this]));
         boundfunc = new Call(wrapper, [new Literal('this')]);
         boundfunc.updateLocationDataIfMissing(this.locationData);
         return boundfunc.compileNode(o);
@@ -1832,15 +1832,15 @@
           return o.scope.parameter(name);
         }
       });
-      _ref2 = this.params;
-      for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-        param = _ref2[_i];
+      _ref3 = this.params;
+      for (_i = 0, _len = _ref3.length; _i < _len; _i++) {
+        param = _ref3[_i];
         if (!param.splat) {
           continue;
         }
-        _ref3 = this.params;
-        for (_j = 0, _len1 = _ref3.length; _j < _len1; _j++) {
-          p = _ref3[_j].name;
+        _ref4 = this.params;
+        for (_j = 0, _len1 = _ref4.length; _j < _len1; _j++) {
+          p = _ref4[_j].name;
           if (p["this"]) {
             p = p.properties[0].name;
           }
@@ -1849,20 +1849,20 @@
           }
         }
         splats = new Assign(new Value(new Arr((function() {
-          var _k, _len2, _ref4, _results;
-          _ref4 = this.params;
+          var _k, _len2, _ref5, _results;
+          _ref5 = this.params;
           _results = [];
-          for (_k = 0, _len2 = _ref4.length; _k < _len2; _k++) {
-            p = _ref4[_k];
+          for (_k = 0, _len2 = _ref5.length; _k < _len2; _k++) {
+            p = _ref5[_k];
             _results.push(p.asReference(o));
           }
           return _results;
         }).call(this))), new Value(new Literal('arguments')));
         break;
       }
-      _ref4 = this.params;
-      for (_k = 0, _len2 = _ref4.length; _k < _len2; _k++) {
-        param = _ref4[_k];
+      _ref5 = this.params;
+      for (_k = 0, _len2 = _ref5.length; _k < _len2; _k++) {
+        param = _ref5[_k];
         if (param.isComplex()) {
           val = ref = param.asReference(o);
           if (param.value) {
@@ -1888,7 +1888,7 @@
         exprs.unshift(splats);
       }
       if (exprs.length) {
-        (_ref5 = this.body.expressions).unshift.apply(_ref5, exprs);
+        (_ref6 = this.body.expressions).unshift.apply(_ref6, exprs);
       }
       for (i = _l = 0, _len3 = params.length; _l < _len3; i = ++_l) {
         p = params[i];
@@ -1905,10 +1905,6 @@
       if (!(wasEmpty || this.noReturn)) {
         this.body.makeReturn();
       }
-      if (this.bound && ((_ref6 = o.scope.parent.method) != null ? _ref6.bound : void 0)) {
-        this.bound = this.context = o.scope.parent.method.context;
-      }
-      idt = o.indent;
       code = 'function';
       if (this.ctor) {
         code += ' ' + this.name;


### PR DESCRIPTION
This fixes a side effect of 392767a0. Unnecessary wrappers are created for:
- bound functions in class bodies, that are not methods (This is related to #1947, which can be closed.)
- bound function within bound functions

Compilation examples at https://gist.github.com/marchaefner/7284379

(PR also removes an assignment to an unused variable.)
#### Theory of Operation
- The context (i.e. `this`) within bound functions will be replaced with the `.context` of the function / `Code` node. (in `Literal::compileNode`)
- `Class` sets `.context` on contained bound functions (but not instance methods) to its name.
- A bound function within a bound function will inherit its context. (This is currently done too late, after deciding whether to wrap.)
- If the context has not been set, and only then, we need to set it to `_this` and wrap the function. (Currently the context is set unconditionally and possibly overridden afterward.)
