### PR TITLE
Fix super-related tagging of `Code` nodes

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -759,6 +759,11 @@
       return last(this.properties) instanceof Slice;
     };
 
+    Value.prototype.looksStatic = function(className) {
+      var _ref2;
+      return this.base.value === className && this.properties.length && ((_ref2 = this.properties[0].name) != null ? _ref2.value : void 0) !== 'prototype';
+    };
+
     Value.prototype.unwrap = function() {
       if (this.properties.length) {
         return this;
@@ -1446,9 +1451,6 @@
             } else {
               if (assign.variable["this"]) {
                 func["static"] = true;
-                if (func.bound) {
-                  func.context = name;
-                }
               } else {
                 assign.variable = new Value(new Literal(name), [new Access(new Literal('prototype')), new Access(base)]);
                 if (func instanceof Code && func.bound) {
@@ -1477,7 +1479,9 @@
             _ref2 = exps = child.expressions;
             for (i = _i = 0, _len = _ref2.length; _i < _len; i = ++_i) {
               node = _ref2[i];
-              if (node instanceof Value && node.isObject(true)) {
+              if (node instanceof Assign && node.variable.looksStatic(name)) {
+                node.value["static"] = true;
+              } else if (node instanceof Value && node.isObject(true)) {
                 cont = false;
                 exps[i] = _this.addProperties(node, name, o);
               }

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -816,3 +816,15 @@ test "#2949: super in static method with reserved name", ->
     @static: -> super
 
   eq Bar.static(), 'baz'
+
+test "#3232: super in static methods (not object-assigned)", ->
+  class Foo
+    @baz = -> true
+    @qux = -> true
+
+  class Bar extends Foo
+    @baz = -> super
+    Bar.qux = -> super
+
+  ok Bar.baz()
+  ok Bar.qux()


### PR DESCRIPTION
- `super` compiles now in static methods with reserved names (#2949)
- `@fn: -> super` and `@fn = -> super` produce the same compilation (#3232)
- `super` will no longer compile for ambiguous / wrong super-targets (see Implications below)  
#### Theory of Operation / Changes

`super` compiles only within a `Code` node that either
- is marked as a constructor (by `Class`)
- has both `.name` and `.klass` set
- has no own `.name` but is contained by another `Code` with both properties

If the `Code` node also has a truthy `.static` the super call will be compiled accordingly.

`.static` is set by `Class` for object assigns with a `@`. **Changed**: 97d9a63 looks also at non-object assignments. This fixes #3232.

`.klass` is set by
- `Class` to all its functions (on the class-level, not nested functions)
- `Assign` to prototype functions, i.e. if the LHS begins with the form {CLASS_NAME}.prototype.{IDENTIFIER|INDEX}. This has been **changed** to match only this exact form. (see also below)

`.name` is set by `Assign` which inspects its LHS with the help of the `METHOD_DEF` regexp. (Except constructors, they get their name from `Class.ensureConstructor`.)             

**Changed**: 138c25f restricts `METHOD_DEF` to match only 
- assignments to a prototype property, e.g. `C::f = ->`
  But no longer to properties of objects on prototypes, e.g. `C::f.g = ->`
- assignments to a property of a possible class, e.g. `C.static = ->`
  But no longer to anything else that ends with an IDENTIFIER, e.g. `C.a.b = ->`

Both cases are now detected in the same way. This fixes #2949.
#### Implications

The following examples do not work anymore and will throw a 'cannot call super ...' error. None of those look correct or useful to me.  

``` coffee
    class Foo 
      bar = -> super
      # bar = function() {
      #   return Foo.__super__.bar.apply(this, arguments);
      # };

      bar.baz.qux = -> super
      # bar.baz.qux = function() {
      #   return Foo.__super__.qux.apply(this, arguments);
      # };

      # This (regrettably) still works
      bar.baz = -> super

    Foo::bar.baz = ->
    # Foo.prototype.bar.baz = function() {
    #   return Foo.__super__.bar.apply(this, arguments);
    # };  
```

The following examples will no longer throw 'cannot call super ...' but compile. (This is related to #1606 -- but by no means complete or usable).   

``` coffee
    class Foo
      @bar: ->
        baz = -> super
        # return baz = function() {
        #   return Foo.__super__.constructor.bar.apply(this, arguments);
        # };

    Foo::bar = ->
      baz = -> super
      # return baz = function() {
      #   return Foo.__super__.bar.apply(this, arguments);
      # };
```
