### PR TITLE
bound functions do not perserve arities

### DIFF
--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -205,6 +205,21 @@ test "a bound function in a bound function", ->
   eq (func() for func in m.generate()).join(' '), '10 10 10'
 
 
+test "bound functions in a class do perserve arities", ->
+  class Mini
+    unary_func: (a0)=>
+    binary_func: (a0, a1)=>
+    tinary_func: (a0, a1, a2)=>
+  obj = new Mini
+  obj2 =
+    unary_func: obj.unary_func
+    binary_func: obj.binary_func
+    tinary_func: obj.tinary_func
+
+  eq obj2.unary_func.length, 1
+  eq obj2.binary_func.length, 2
+  eq obj2.tinary_func.length, 3
+
 test "contructor called with varargs", ->
 
   class Connection

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -87,6 +87,21 @@ test "self-referencing functions", ->
   eq changeMe, 2
 
 
+test "bound functions do perserve arities", ->
+  obj =
+    unary_func: (a0)=>
+    binary_func: (a0, a1)=>
+    tinary_func: (a0, a1, a2)=>
+  obj2 =
+    unary_func: obj.unary_func
+    binary_func: obj.binary_func
+    tinary_func: obj.tinary_func
+
+  eq obj2.unary_func.length, 1
+  eq obj2.binary_func.length, 2
+  eq obj2.tinary_func.length, 3
+
+
 # Parameter List Features
 
 test "splats", ->


### PR DESCRIPTION
I'm using `coffee-script` and `connect.js`. I came into a problem and digged into `connect`'s source code, and I find on  [this line](https://github.com/senchalabs/connect/blob/2c574468dacca18eb1a81053d9c48b9110357b29/lib/proto.js#L185), connect uses [Function.length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) to determine the type of a handler. And then I found `coffee-script` failed to **perserve arities in bound functions of a class**.

To indicate the issue, I added two test cases. The first one passed, but the second one failed. I'll try to submit a patch later.
