### PR TITLE
Fix #2489 again: preserve bound methods length property

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1415,12 +1415,12 @@
     };
 
     Class.prototype.addBoundFunctions = function(o) {
-      var bvar, lhs, _i, _len, _ref2;
+      var bvar, func, lhs, _i, _len, _ref2, _ref3;
       _ref2 = this.boundFuncs;
       for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-        bvar = _ref2[_i];
+        _ref3 = _ref2[_i], bvar = _ref3[0], func = _ref3[1];
         lhs = (new Value(new Literal("this"), [new Access(bvar)])).compile(o);
-        this.ctor.body.unshift(new Literal("" + lhs + " = " + (utility('bind')) + "(" + lhs + ", this)"));
+        this.ctor.body.unshift(new Literal("" + lhs + " = " + (utility('bind', func.params.length)) + "(" + lhs + ", this)"));
       }
     };
 
@@ -1454,7 +1454,7 @@
               } else {
                 assign.variable = new Value(new Literal(name), [new Access(new Literal('prototype')), new Access(base)]);
                 if (func instanceof Code && func.bound) {
-                  this.boundFuncs.push(base);
+                  this.boundFuncs.push([base, func]);
                   func.bound = false;
                 }
               }
@@ -2991,8 +2991,15 @@
     "extends": function() {
       return "function(child, parent) { for (var key in parent) { if (" + (utility('hasProp')) + ".call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }";
     },
-    bind: function() {
-      return 'function(fn, me){ return function(){ return fn.apply(me, arguments); }; }';
+    bind: function(length) {
+      var _i, _results;
+      return "function(fn, me){ return function(" + ((function() {
+        _results = [];
+        for (var _i = 0; 0 <= length ? _i <= length : _i >= length; 0 <= length ? _i++ : _i--){ _results.push(_i); }
+        return _results;
+      }).apply(this).slice(1).map(function(i) {
+        return '__bind_arg_' + i;
+      }).join(' ,')) + "){ return fn.apply(me, arguments); }; }";
     },
     indexOf: function() {
       return "[].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; }";
@@ -3035,10 +3042,13 @@
 
   IS_REGEX = /^\//;
 
-  utility = function(name) {
-    var ref;
-    ref = "__" + name;
-    Scope.root.assign(ref, UTILITIES[name]());
+  utility = function() {
+    var args, name, ref;
+    name = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
+    ref = "__" + name + (args.map(function(arg) {
+      return "_" + arg;
+    }).join(''));
+    Scope.root.assign(ref, UTILITIES[name].apply(UTILITIES, args));
     return ref;
   };
 

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -205,6 +205,21 @@ test "a bound function in a bound function", ->
   eq (func() for func in m.generate()).join(' '), '10 10 10'
 
 
+test "bound functions in a class do perserve arities", ->
+  class Mini
+    unary_func: (a0)=>
+    binary_func: (a0, a1)=>
+    tinary_func: (a0, a1, a2)=>
+  obj = new Mini
+  obj2 =
+    unary_func: obj.unary_func
+    binary_func: obj.binary_func
+    tinary_func: obj.tinary_func
+
+  eq obj2.unary_func.length, 1
+  eq obj2.binary_func.length, 2
+  eq obj2.tinary_func.length, 3
+
 test "contructor called with varargs", ->
 
   class Connection

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -87,6 +87,21 @@ test "self-referencing functions", ->
   eq changeMe, 2
 
 
+test "bound functions do perserve arities", ->
+  obj =
+    unary_func: (a0)=>
+    binary_func: (a0, a1)=>
+    tinary_func: (a0, a1, a2)=>
+  obj2 =
+    unary_func: obj.unary_func
+    binary_func: obj.binary_func
+    tinary_func: obj.tinary_func
+
+  eq obj2.unary_func.length, 1
+  eq obj2.binary_func.length, 2
+  eq obj2.tinary_func.length, 3
+
+
 # Parameter List Features
 
 test "splats", ->


### PR DESCRIPTION
Hi, this is yet another approach trying to fix #2489 .

I read through the discussion of #2489 #2872 , and I came up with this lighter solution. Since `__bind` is not a public part, patching it will not break anything.
