### PR TITLE
Fix #2489 once more -- preserve bound methods arity

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1414,14 +1414,36 @@
       });
     };
 
-    Class.prototype.addBoundFunctions = function(o) {
-      var bvar, lhs, _i, _len, _ref2;
+    Class.prototype.addBoundFunctions = function(name, o) {
+      var bindMethods, bindMethodsRef, bvar, context, func, instFunc, p, protoFunc, wrapper, _i, _len, _ref2, _ref3;
+      if (!this.boundFuncs.length) {
+        return;
+      }
+      context = new Literal('_this');
+      bindMethods = new Code([new Param(context)]);
+      bindMethods.noReturn = true;
       _ref2 = this.boundFuncs;
       for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-        bvar = _ref2[_i];
-        lhs = (new Value(new Literal("this"), [new Access(bvar)])).compile(o);
-        this.ctor.body.unshift(new Literal("" + lhs + " = " + (utility('bind')) + "(" + lhs + ", this)"));
+        _ref3 = _ref2[_i], bvar = _ref3[0], func = _ref3[1];
+        instFunc = new Value(context, [new Access(bvar)]);
+        protoFunc = new Value(new Literal("" + name + ".prototype"), [new Access(bvar)]);
+        wrapper = new Code((function() {
+          var _j, _len1, _ref4, _results;
+          _ref4 = func.params;
+          _results = [];
+          for (_j = 0, _len1 = _ref4.length; _j < _len1; _j++) {
+            p = _ref4[_j];
+            _results.push(new Param(p.name, null, p.splat));
+          }
+          return _results;
+        })());
+        wrapper.fakeSignature = true;
+        wrapper.body.push(new Call(new Value(protoFunc, [new Access(new Literal('apply'))]), [context, new Literal('arguments')]));
+        bindMethods.body.push(new If(new Op('==', protoFunc, instFunc), new Assign(instFunc, wrapper)));
       }
+      bindMethodsRef = new Literal(o.classScope.freeVariable('bindMethods'));
+      this.body.unshift(new Assign(bindMethodsRef, bindMethods));
+      return this.ctor.body.unshift(new Call(bindMethodsRef, [new Literal('this')]));
     };
 
     Class.prototype.addProperties = function(node, name, o) {
@@ -1454,7 +1476,7 @@
               } else {
                 assign.variable = new Value(new Literal(name), [new Access(new Literal('prototype')), new Access(base)]);
                 if (func instanceof Code && func.bound) {
-                  this.boundFuncs.push(base);
+                  this.boundFuncs.push([base, func]);
                   func.bound = false;
                 }
               }
@@ -1539,7 +1561,7 @@
       this.setContext(name);
       this.walkBody(name, o);
       this.ensureConstructor(name);
-      this.addBoundFunctions(o);
+      this.addBoundFunctions(name, o);
       this.body.spaced = true;
       this.body.expressions.push(lname);
       if (this.parent) {
@@ -1848,7 +1870,7 @@
           if (p["this"]) {
             p = p.properties[0].name;
           }
-          if (p.value) {
+          if (p.value && !this.fakeSignature) {
             o.scope.add(p.value, 'var', true);
           }
         }
@@ -1891,7 +1913,7 @@
       if (splats) {
         exprs.unshift(splats);
       }
-      if (exprs.length) {
+      if (exprs.length && !this.fakeSignature) {
         (_ref7 = this.body.expressions).unshift.apply(_ref7, exprs);
       }
       for (i = _m = 0, _len4 = params.length; _m < _len4; i = ++_m) {
@@ -2990,9 +3012,6 @@
   UTILITIES = {
     "extends": function() {
       return "function(child, parent) { for (var key in parent) { if (" + (utility('hasProp')) + ".call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }";
-    },
-    bind: function() {
-      return 'function(fn, me){ return function(){ return fn.apply(me, arguments); }; }';
     },
     indexOf: function() {
       return "[].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; }";

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -828,3 +828,15 @@ test "#3232: super in static methods (not object-assigned)", ->
 
   ok Bar.baz()
   ok Bar.qux()
+
+test "#2489: preserve bound methods arity", ->
+  class Foo
+    bar: (a, b) =>
+    baz: ([a, b], {c, d:e}) =>
+    qux: (a, d..., [b,c]) =>
+
+  foo = new Foo
+
+  eq foo.bar.length, Foo::bar.length
+  eq foo.baz.length, Foo::baz.length
+  eq foo.qux.length, Foo::qux.length


### PR DESCRIPTION
Since compiler hacking is way more fun than CLI fixing, here's my version of "Fix #2489 again"
- Adds a "private" `_bindMethods` function wherein all binding takes place.
  This preserves the readability of the compiled constructor and avoids any potential memory leaks (related: #3143).
- Wrappers clone the parameters of the wrapped method and therefore have the same number of parameters and, for the most part (see example below), the same parameter names.
- Superclass constructors do neither override previously bound methods (as in redux) nor mindlessly wrap already wrapped methods (as is currently happening)

This comes with a hefty dose of ugly. Though I doubt the compilation could get much nicer. Compare #3258 which fixes this issue in a different way (prettier classes but more helpers).

Based upon prior art by @epidemian and @michaelficarra. Feel free to bash...
#### Side effect

This PR unintentionally "fixes" #1819 (the same way redux does). This  breaks other fun stuff:

``` coffee
class Nobody then expect: => console.log 'fluffy bunny'
callback = (new Nobody).expect
# ...
setTimeout callback, 1000
# ...
Nobody::expect = -> console.log 'spanish inquisition'
```

I can't really assess the severity of this change since I can't imagine why anybody would ever do anything like that (or #1819 for that matter).
#### Example compilation

``` coffee
class Foo extends Bar
  baz: (@this=1, that, [which, what]) =>
  qux: (args...) =>
```

``` js
/* ... */

Foo = (function(_super) {
  var _bindMethods;

  __extends(Foo, _super);

  _bindMethods = function(_this) {
    if (Foo.prototype.baz === _this.baz) {
      _this.baz = function(_this1, that, _arg) {
        return Foo.prototype.baz.apply(_this, arguments);
      };
    }
    if (Foo.prototype.qux === _this.qux) {
      _this.qux = function() {
        var args;
        return Foo.prototype.qux.apply(_this, arguments);
      };
    }
  };

  function Foo() {
    _bindMethods(this);
    return Foo.__super__.constructor.apply(this, arguments);
  }

  Foo.prototype.baz = function(_this, that, _arg) {
    /* ... */
  };

  Foo.prototype.qux = function() {
    /* ... */
  };

  return Foo;

})(Bar);
```
