### PR TITLE
Fix --watch handling of deleted sources

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -246,7 +246,7 @@
   };
 
   watch = function(source, base) {
-    var compile, compileTimeout, err, prevStats, rewatch, watchErr, watcher;
+    var compile, compileTimeout, err, prevStats, rewatch, startWatcher, watchErr, watcher;
     watcher = null;
     prevStats = null;
     compileTimeout = null;
@@ -286,14 +286,22 @@
         });
       });
     };
+    startWatcher = function() {
+      return watcher = fs.watch(source).on('change', compile).on('error', function(err) {
+        if (err.code !== 'EPERM') {
+          throw err;
+        }
+        return removeSource(source, base);
+      });
+    };
     rewatch = function() {
       if (watcher != null) {
         watcher.close();
       }
-      return watcher = fs.watch(source, compile);
+      return startWatcher();
     };
     try {
-      return watcher = fs.watch(source, compile);
+      return startWatcher();
     } catch (_error) {
       err = _error;
       return watchErr(err);
@@ -301,11 +309,16 @@
   };
 
   watchDir = function(source, base) {
-    var e, readdirTimeout, watcher;
+    var err, readdirTimeout, startWatcher, stopWatcher, watcher;
+    watcher = null;
     readdirTimeout = null;
-    try {
-      watchedDirs[source] = true;
-      return watcher = fs.watch(source, function() {
+    startWatcher = function() {
+      return watcher = fs.watch(source).on('error', function(err) {
+        if (err.code !== 'EPERM') {
+          throw err;
+        }
+        return stopWatcher();
+      }).on('change', function() {
         clearTimeout(readdirTimeout);
         return readdirTimeout = wait(25, function() {
           var err, file, files, _i, _len, _results;
@@ -316,8 +329,7 @@
             if (err.code !== 'ENOENT') {
               throw err;
             }
-            watcher.close();
-            return removeSourceDir(source, base);
+            return stopWatcher();
           }
           _results = [];
           for (_i = 0, _len = files.length; _i < _len; _i++) {
@@ -327,10 +339,18 @@
           return _results;
         });
       });
+    };
+    stopWatcher = function() {
+      watcher.close();
+      return removeSourceDir(source, base);
+    };
+    watchedDirs[source] = true;
+    try {
+      return startWatcher();
     } catch (_error) {
-      e = _error;
-      if (e.code !== 'ENOENT') {
-        throw e;
+      err = _error;
+      if (err.code !== 'ENOENT') {
+        throw err;
       }
     }
   };
@@ -365,12 +385,12 @@
   };
 
   silentUnlink = function(path) {
-    var err;
+    var err, _ref1;
     try {
       return fs.unlinkSync(path);
     } catch (_error) {
       err = _error;
-      if (err.code !== 'ENOENT') {
+      if ((_ref1 = err.code) !== 'ENOENT' && _ref1 !== 'EPERM') {
         throw err;
       }
     }


### PR DESCRIPTION
- Fixes #3267 (Source maps don't get deleted when using `--watch`)
- Suppress `EPERM` errors from watchers (see also below)
- Minor readability improvements
  - Remove unnecessary parameter of `removeSource`
  - Explicitly declare `watcher` at scope start
  - Consistent use of `err` for errors and exceptions
#### Suppressing `EPERM`

If a watched directory gets deleted its `fs.FSWatcher` throws `EPERM` (not to be confused with `EACCESS`). The same happens for the watchers of contained files and `fs.unlink`. We have to fix it on our end because it will not be fixed in node (see joyent/node#4337).

This PR simply suppresses the error. I also refrained from adding `if process.platform is 'win32'` tests. All other causes of `EPERM` should break the actual compilation, i.e. when reading and writing files.
