### PR TITLE
Fix `child_process.fork` patch

### DIFF
--- a/lib/coffee-script/register.js
+++ b/lib/coffee-script/register.js
@@ -51,19 +51,14 @@
     fork = child_process.fork;
     binary = require.resolve('../../bin/coffee');
     child_process.fork = function(path, args, options) {
-      var execPath;
-      if (args == null) {
-        args = [];
+      if (helpers.isCoffee(path)) {
+        if (!Array.isArray(args)) {
+          options = args || {};
+          args = [];
+        }
+        args = [path].concat(args);
+        path = binary;
       }
-      if (options == null) {
-        options = {};
-      }
-      execPath = helpers.isCoffee(path) ? binary : null;
-      if (!Array.isArray(args)) {
-        args = [];
-        options = args || {};
-      }
-      options.execPath || (options.execPath = execPath);
       return fork(path, args, options);
     };
   }

--- a/src/register.coffee
+++ b/src/register.coffee
@@ -42,10 +42,11 @@ if require.extensions
 if child_process
   {fork} = child_process
   binary = require.resolve '../../bin/coffee'
-  child_process.fork = (path, args = [], options = {}) ->
-    execPath = if helpers.isCoffee(path) then binary else null
-    if not Array.isArray args
-      args = []
-      options = args or {}
-    options.execPath or= execPath
+  child_process.fork = (path, args, options) ->
+    if helpers.isCoffee path
+      unless Array.isArray args
+        options = args or {}
+        args = []
+      args = [path].concat args
+      path = binary
     fork path, args, options


### PR DESCRIPTION
Fixes #2919 by simply leaving `execPath` alone. (Currently `bin/coffee` is called with node's `execOptions`.)

The `coffee` "binary" is now used as the module with the actual `.coffee`-module as its first argument. This also makes the patch work on Windows (the friendly OS where executability is determined by file extension and shebangs don't exist).

Also fixes `.fork` calls without an arguments array. (Currently `options` is set to `[]`)
