### PR TITLE
Chaining semantics after arguments with outdent

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -290,15 +290,9 @@
           startImplicitObject(s, !!startsLine);
           return forward(2);
         }
-        if (inImplicitCall() && __indexOf.call(CALL_CLOSERS, tag) >= 0) {
-          if (prevTag === 'OUTDENT') {
-            endImplicitCall();
-            return forward(1);
-          }
-          if (prevToken.newLine) {
-            endAllImplicitCalls();
-            return forward(1);
-          }
+        if (inImplicitCall() && __indexOf.call(CALL_CLOSERS, tag) >= 0 && (prevTag === 'OUTDENT' || prevToken.newLine)) {
+          endAllImplicitCalls();
+          return forward(1);
         }
         if (inImplicitObject() && __indexOf.call(LINEBREAKS, tag) >= 0) {
           stackTop()[2].sameLine = false;

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -286,13 +286,10 @@ class exports.Rewriter
       #     .g b
       #     .h a
       #
-      if inImplicitCall() and tag in CALL_CLOSERS
-        if prevTag is 'OUTDENT'
-          endImplicitCall()
-          return forward(1)
-        if prevToken.newLine
-          endAllImplicitCalls()
-          return forward(1)
+      if inImplicitCall() and tag in CALL_CLOSERS and
+         (prevTag is 'OUTDENT' or prevToken.newLine)
+        endAllImplicitCalls()
+        return forward(1)
 
       stackTop()[2].sameLine = no if inImplicitObject() and tag in LINEBREAKS
 

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -98,6 +98,13 @@ test "#1495, method call chaining", ->
   ).join ', '
   eq 'a, b, c', result
 
+test "chaining after outdent", ->
+  str = 'abc'
+  zero = parseInt str.replace /\w/, (letter) ->
+    0
+  .toString()
+  eq '0', zero
+
 # Operators
 
 test "newline suppression for operators", ->


### PR DESCRIPTION
After adding chaining syntax in #3263 there has been a problem that kept bugging me:

``` coffee
callA callB ->
  body
.method()
# and
callA callB -> body
.method()
# Compiles to:    callA(callB(function() { return body; }).method());
```

but

``` coffee
callA callB expression
.method()
# Compiles to:    callA(callB(expression)).method();
```

This fixes the issue and makes functions and objects behave as any other argument.
