### PR TITLE
Fixes #1871, close implicit objects in implicit returns

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -386,7 +386,6 @@
           moveOut -= dent;
         }
       }
-      this.indent = decreasedIndent;
       if (dent) {
         this.outdebt -= moveOut;
       }
@@ -396,6 +395,7 @@
       if (!(this.tag() === 'TERMINATOR' || noNewlines)) {
         this.token('TERMINATOR', '\n', outdentLength, 0);
       }
+      this.indent = decreasedIndent;
       return this;
     };
 

--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -305,7 +305,7 @@
             _ref4 = stackTop(), stackTag = _ref4[0], stackIdx = _ref4[1], (_ref5 = _ref4[2], sameLine = _ref5.sameLine, startsLine = _ref5.startsLine);
             if (inImplicitCall() && prevTag !== ',') {
               endImplicitCall();
-            } else if (inImplicitObject() && sameLine && !startsLine) {
+            } else if (inImplicitObject() && sameLine && tag !== 'TERMINATOR' && prevTag !== ':') {
               endImplicitObject();
             } else if (inImplicitObject() && tag === 'TERMINATOR' && prevTag !== ',' && !(startsLine && this.looksObjectish(i + 1))) {
               endImplicitObject();

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -302,7 +302,8 @@ class exports.Rewriter
             endImplicitCall()
           # Close implicit objects such as:
           # return a: 1, b: 2 unless true
-          else if inImplicitObject() and sameLine and not startsLine
+          else if inImplicitObject() and sameLine and
+                  tag isnt 'TERMINATOR' and prevTag isnt ':'
             endImplicitObject()
           # Close implicit objects when at end of line, line didn't end with a comma
           # and the implicit object didn't start the line or the next line doesn't look like

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -387,6 +387,23 @@ test "#1871: Special case for IMPLICIT_END in the middle of an implicit object",
 
   eq result.two.join(' '), '2 2 2'
 
+test "#1871: implicit object closed by IMPLICIT_END in implicit returns", ->
+  ob = do ->
+    a: 1 if no
+  eq ob, undefined
+
+  # instead these return an object
+  func = ->
+    key:
+      i for i in [1, 2, 3]
+
+  eq func().key.join(' '), '1 2 3'
+
+  func = ->
+    key: (i for i in [1, 2, 3])
+
+  eq func().key.join(' '), '1 2 3'
+
 test "#1961, #1974, regression with compound assigning to an implicit object", ->
 
   obj = null


### PR DESCRIPTION
Fixes namely https://github.com/jashkenas/coffee-script/issues/1871#issuecomment-32242892.

``` coffee
# coffee -bpe 'a: b if c'
if (c) {
  ({
    a: b
  });
}
```
