### PR TITLE
Fixes #3216 for declarations in object literals

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2153,7 +2153,6 @@
     Expansion.prototype.isComplex = NO;
 
     Expansion.prototype.compileNode = function(o) {
-      throw new Error;
       return this.error('Expansion must be used inside a destructuring assignment or parameter list');
     };
 

--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -283,6 +283,7 @@
           while (this.tag(s - 2) === 'HERECOMMENT') {
             s -= 2;
           }
+          this.objectValueIsFor = nextTag === 'FOR';
           startsLine = s === 0 || (_ref2 = this.tag(s - 1), __indexOf.call(LINEBREAKS, _ref2) >= 0) || tokens[s - 1].newLine;
           if (stackTop()) {
             _ref3 = stackTop(), stackTag = _ref3[0], stackIdx = _ref3[1];
@@ -305,8 +306,8 @@
             _ref4 = stackTop(), stackTag = _ref4[0], stackIdx = _ref4[1], (_ref5 = _ref4[2], sameLine = _ref5.sameLine, startsLine = _ref5.startsLine);
             if (inImplicitCall() && prevTag !== ',') {
               endImplicitCall();
-            } else if (inImplicitObject() && sameLine && tag !== 'TERMINATOR' && prevTag !== ':') {
-              endImplicitObject();
+            } else if (inImplicitObject() && !this.objectValueIsFor && sameLine && tag !== 'TERMINATOR' && prevTag !== ':' && endImplicitObject()) {
+
             } else if (inImplicitObject() && tag === 'TERMINATOR' && prevTag !== ',' && !(startsLine && this.looksObjectish(i + 1))) {
               endImplicitObject();
             } else {
@@ -314,7 +315,7 @@
             }
           }
         }
-        if (tag === ',' && !this.looksObjectish(i + 1) && inImplicitObject() && (nextTag !== 'TERMINATOR' || !this.looksObjectish(i + 2))) {
+        if (tag === ',' && !this.looksObjectish(i + 1) && inImplicitObject() && !this.objectValueIsFor && (nextTag !== 'TERMINATOR' || !this.looksObjectish(i + 2))) {
           offset = nextTag === 'OUTDENT' ? 1 : 0;
           while (inImplicitObject()) {
             endImplicitObject(i + offset);

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -261,6 +261,9 @@ class exports.Rewriter
         if @tag(i - 2) is '@' then s = i - 2 else s = i - 1
         s -= 2 while @tag(s - 2) is 'HERECOMMENT'
 
+        # Mark if the value is a for loop
+        @insideForDeclaration = nextTag is 'FOR'
+
         startsLine = s is 0 or @tag(s - 1) in LINEBREAKS or tokens[s - 1].newLine
         # Are we just continuing an already declared object?
         if stackTop()
@@ -302,8 +305,8 @@ class exports.Rewriter
             endImplicitCall()
           # Close implicit objects such as:
           # return a: 1, b: 2 unless true
-          else if inImplicitObject() and sameLine and
-                  tag isnt 'TERMINATOR' and prevTag isnt ':'
+          else if inImplicitObject() and not @insideForDeclaration and sameLine and
+                  tag isnt 'TERMINATOR' and prevTag isnt ':' and
             endImplicitObject()
           # Close implicit objects when at end of line, line didn't end with a comma
           # and the implicit object didn't start the line or the next line doesn't look like
@@ -328,6 +331,7 @@ class exports.Rewriter
       #     f a, b: c, d: e, f, g: h: i, j
       #
       if tag is ',' and not @looksObjectish(i + 1) and inImplicitObject() and
+         not @insideForDeclaration and
          (nextTag isnt 'TERMINATOR' or not @looksObjectish(i + 2))
         # When nextTag is OUTDENT the comma is insignificant and
         # should just be ignored so embed it in the implicit object.

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -428,6 +428,18 @@ test "#2207: Immediate implicit closes don't close implicit objects", ->
 
   eq func().key.join(' '), '1 2 3'
 
+test "#3216: For loop declaration as a value of an implicit object", ->
+  test = [0..2]
+  ob =
+    a: for v, i in test then i
+    b: for v, i in test then i
+    c: for v in test by 1 then v
+    d: for v in test when true then v
+  arrayEq ob.a, test
+  arrayEq ob.b, test
+  arrayEq ob.c, test
+  arrayEq ob.d, test
+
 test 'inline implicit object literals within multiline implicit object literals', ->
   x =
     a: aa: 0


### PR DESCRIPTION
Fixes #3216, along with unreported cases (`when` and `by`).

Super ugly, if anyone has any better ideas...
