### PR TITLE
Provide tests for keeping shebang lines in compiled CS files

### DIFF
--- a/test/compilation.coffee
+++ b/test/compilation.coffee
@@ -97,3 +97,11 @@ test "#3001: `own` shouldn't be allowed in a `for`-`in` loop", ->
 
 test "#2994: single-line `if` requires `then`", ->
   cantCompile "if b else x"
+
+test "Shebang lines should be preserved after compilation", ->
+  js = CoffeeScript.compile "#!/usr/bin/env node\n\nconsole.log 'test'", header: on
+  ok js.split( "\n" )[0] is "#!/usr/bin/env node"
+
+  # Shebang lines not present on first line should be treated as normal comments
+  js = CoffeeScript.compile "console.log 'test'\n\n#!/usr/bin/env node"
+  ok js.split( "\n" ).indexOf( "#!/usr/bin/env node" ) is -1


### PR DESCRIPTION
Shebang lines are currently ignored when CoffeeScript files are compiled to JavaScript. This makes it quite hard ( although not impossible ) to create executable scripts on Unix-based systems.

The resulting JavaScript file should preserve the shebang line from original CoffeeScript file if present and if it is on the first line of the document.

Since I am not that skilled to implement this functionality in the compiler myself I am at least sending the tests describing the expected functionality.

PS. This has been already discussed in #2216 although a conclusion has not been reached there.
Thank you!
