### PR TITLE
Fix markup in math operator documentation

### DIFF
--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -657,7 +657,7 @@ Expressions
       test for JavaScript object-key presence.
     </p>
     <p>
-      To simplify math expressions, `**` can be used for exponentiation, `//` performs integer division and `%%` provides true mathematical modulo.
+      To simplify math expressions, <tt>**</tt> can be used for exponentiation, <tt>//</tt> performs integer division and <tt>%%</tt> provides true mathematical modulo.
     </p>
     <p>
       All together now:


### PR DESCRIPTION
In the documentation, surround the new `**`, `//`, and `%%` operators with `<tt>` tags instead of Markdown-style backticks <code>``</code>, since this is HTML.

Changes the section [Operators and Aliases](http://coffeescript.org/#operators).

I used [`<tt>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt) tags instead of [`<code>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code) tags because that’s what all the other operators in that sections are wrapped in.
