### PR TITLE
In docs, move commas out of code

### DIFF
--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -672,7 +672,7 @@ Expressions
       <tr><td><tt>or</tt></td><td><tt>||</tt></td></tr>
       <tr><td><tt>true</tt>, <tt>yes</tt>, <tt>on</tt></td><td><tt>true</tt></td></tr>
       <tr><td><tt>false</tt>, <tt>no</tt>, <tt>off</tt></td><td><tt>false</tt></td></tr>
-      <tr><td><tt>@, this</tt></td><td><tt>this</tt></td></tr>
+      <tr><td><tt>@</tt>, <tt>this</tt></td><td><tt>this</tt></td></tr>
       <tr><td><tt>of</tt></td><td><tt>in</tt></td></tr>
       <tr><td><tt>in</tt></td><td><i><small>no JS equivalent</small></i></td></tr>
       <tr><td><tt>a ** b</tt></td><td><tt>Math.pow(a, b)</tt></td></tr>


### PR DESCRIPTION
The commas separating these keywords are not code themselves – not what the user would write – so they should be outside of the `<tt>` tags.

Edits the table in the section [Operators and Aliases](http://coffeescript.org/#operators).

Before:

![portion of the operators table before my change](https://f.cloud.github.com/assets/79168/2026104/7bb34a3a-8889-11e3-8d2a-cda58a194f28.png)

After both commits:

![portion of the operators table after my change](https://f.cloud.github.com/assets/79168/2026156/c3d8215e-888a-11e3-9874-a45ada1ccd67.png)
