### PR TITLE
Fix a typo causing module.paths to be always set as the cwd.

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -110,7 +110,7 @@
     mainModule = require.main;
     mainModule.filename = process.argv[1] = options.filename ? fs.realpathSync(options.filename) : '.';
     mainModule.moduleCache && (mainModule.moduleCache = {});
-    dir = options.fileName ? path.dirname(fs.realpathSync(options.filename)) : fs.realpathSync('.');
+    dir = options.filename ? path.dirname(fs.realpathSync(options.filename)) : fs.realpathSync('.');
     mainModule.paths = require('module')._nodeModulePaths(dir);
     if (!helpers.isCoffee(mainModule.filename) || require.extensions) {
       answer = compile(code, options);

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -107,7 +107,7 @@ exports.run = (code, options = {}) ->
   mainModule.moduleCache and= {}
 
   # Assign paths for node_modules loading
-  dir = if options.fileName
+  dir = if options.filename
     path.dirname fs.realpathSync options.filename
   else
     fs.realpathSync '.'


### PR DESCRIPTION
`options.fileName` was used instead of `options.filename`.
