### PR TITLE
Add tab key usage to try-it editor

### DIFF
--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -2048,6 +2048,16 @@ Expressions
     # Listen for keypresses and recompile.
     $('#repl_source').keyup -> compileSource()
 
+    # Use tab key to insert tabs
+    $('#repl_source').keydown (e) ->
+      if e.keyCode is 9
+        e.preventDefault()
+        textbox = e.target
+        # Insert tab character at caret or in selection
+        textbox.value = textbox.value[0...textbox.selectionStart] + "\t" + textbox.value[textbox.selectionEnd...]
+        # Put caret in correct position
+        textbox.selectionEnd = ++textbox.selectionStart
+
     # Eval the compiled js.
     evalJS = ->
       try

--- a/index.html
+++ b/index.html
@@ -3316,6 +3316,16 @@ task(<span class="string">'build:parser'</span>, <span class="string">'rebuild t
     # Listen for keypresses and recompile.
     $('#repl_source').keyup -> compileSource()
 
+    # Use tab key to insert tabs
+    $('#repl_source').keydown (e) ->
+      if e.keyCode is 9
+        e.preventDefault()
+        textbox = e.target
+        # Insert tab character at caret or in selection
+        textbox.value = textbox.value[0...textbox.selectionStart] + "\t" + textbox.value[textbox.selectionEnd...]
+        # Put caret in correct position
+        textbox.selectionEnd = ++textbox.selectionStart
+
     # Eval the compiled js.
     evalJS = ->
       try


### PR DESCRIPTION
Use the tab character in the try-it editor's textbox
