### PR TITLE
function invocation failing test

### DIFF
--- a/test/control_flow.coffee
+++ b/test/control_flow.coffee
@@ -295,6 +295,14 @@ test "break at the top level", ->
       break
   eq 2, result
 
+
+test "function invokation", ->
+
+  items = [1,2,3]
+  items..toFixed(1)
+
+  eq items.join(', '), '2.0, 3.0, 4.0'
+
 test "break *not* at the top level", ->
   someFunc = ->
     i = 0


### PR DESCRIPTION
Is there any interest in supporting a shorthand for invoking methods on an entire array/object?

Something like:

``` coffeescript
items..foo()
```

Which would translate to something like:

``` coffeescript
item.foo() for item in items
```

Or perhaps something that worked within array comprehentions, except lacking an iterator:

``` coffeescript
..foo() for items
..foo() for items by 2
for items ..foo()
for items by 2 ..foo()
```

I feel like it's one of the most common patterns in programming, an a prime candidate for some sugar. I haven't implemented it but I would like to hear some feedback about whether it would be worth the effort.
