### PR TITLE
Make patched stack traces’ prelude consistent with V8

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -304,7 +304,7 @@
   };
 
   Error.prepareStackTrace = function(err, stack) {
-    var frame, frames, getSourceMapping, _ref;
+    var frame, frames, getSourceMapping;
     getSourceMapping = function(filename, line, column) {
       var answer, sourceMap;
       sourceMap = getSourceMap(filename);
@@ -329,7 +329,7 @@
       }
       return _results;
     })();
-    return "" + err.name + ": " + ((_ref = err.message) != null ? _ref : '') + "\n" + (frames.join('\n')) + "\n";
+    return "" + (err.toString()) + "\n" + (frames.join('\n')) + "\n";
   };
 
 }).call(this);

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -294,5 +294,5 @@ Error.prepareStackTrace = (err, stack) ->
     break if frame.getFunction() is exports.run
     "  at #{formatSourcePosition frame, getSourceMapping}"
 
-  "#{err.name}: #{err.message ? ''}\n#{frames.join '\n'}\n"
+  "#{err.toString()}\n#{frames.join '\n'}\n"
 

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -50,11 +50,18 @@ if require?
     err = new Error 'error'
     ok err.stack.match /test[\/\\]error_messages\.coffee:\d+:\d+\b/
 
+  test "patchStackTrace stack prelude consistent with V8", ->
+    err = new Error
+    ok err.stack.match /^Error\n/ # Notice no colon when no message.
+
+    err = new Error 'error'
+    ok err.stack.match /^Error: error\n/
+
   test "#2849: compilation error in a require()d file", ->
     # Create a temporary file to require().
     ok not fs.existsSync 'test/syntax-error.coffee'
     fs.writeFileSync 'test/syntax-error.coffee', 'foo in bar or in baz'
-  
+
     try
       assertErrorFormat '''
         require './test/syntax-error'
@@ -67,7 +74,7 @@ if require?
     finally
       fs.unlink 'test/syntax-error.coffee'
 
-  
+
 test "#1096: unexpected generated tokens", ->
   # Unexpected interpolation
   assertErrorFormat '{"#{key}": val}', '''


### PR DESCRIPTION
In V8, the `stack` property of errors contains a prelude and then the
stack trace. The contents of the prelude depends on whether the error
has a message or not.

If the error has _not_ got a message, the prelude contains the name of the
error and a newline.

If the error _has_ got a message, the prelude contains the name of the
error, a colon, a space, the message and a newline.

In other words, the prelude consists of `error.toString() + "\n"`

Before, coffee-script’s patched stack traces worked exactly like that,
except that it _always_ added a colon and a space after the name of the
error.

This fix is important because it allows for easy and consistent
consumption of the stack trace only:

`stack = error.stack[error.toString().length..]`
