### PR TITLE
Fix #3361, make %% coerce right operand only once

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -3075,7 +3075,7 @@
       return "[].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; }";
     },
     modulo: function() {
-      return "function(a, b) { return (a % b + +b) % b; }";
+      return "function(a, b) { b = +b; return (a % b + b) % b; }";
     },
     hasProp: function() {
       return '{}.hasOwnProperty';

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2194,7 +2194,7 @@ UTILITIES =
   "
 
   modulo: -> """
-    function(a, b) { return (a % b + +b) % b; }
+    function(a, b) { b = +b; return (a % b + b) % b; }
   """
 
   # Shortcuts to speed up the lookup time for native functions.

--- a/test/operators.coffee
+++ b/test/operators.coffee
@@ -357,3 +357,9 @@ test "modulo operator converts arguments to numbers", ->
   eq 1, 1 %% '42'
   eq 1, '1' %% 42
   eq 1, '1' %% '42'
+
+test "#3361: Modulo operator coerces right operand once", ->
+  count = 0
+  res = 42 %% valueOf: -> count += 1
+  eq 1, count
+  eq 0, res


### PR DESCRIPTION
A very straightforward solution to #3361.

Other solutions could have been:

Forcing the coercion at the `__modulo` call site. Compiling `0 %% valueOf: -> console.log "!"` to:

``` javascript
var __modulo = function(a, b) { return (a % b + b) % b; };

__modulo(0, +{
  valueOf: function() {
    return console.log("!");
  }
});
```

(notice the `+` sign added to the call and removed from the `__modulo` definition)

Or inlining the whole thing:

``` javascript
var __ref;

(__ref = +{
  valueOf: function() {
    return console.log("!");
  }
}, (0 % __ref + __ref) % __ref);
```

But i prefer the solution in this PR because it results in the cleanest code on the call site (it also was the easiest to implement :stuck_out_tongue: ):

``` javascript
var __modulo = function(a, b) { b = +b; return (a % b + b) % b; };

__modulo(0, {
  valueOf: function() {
    return console.log("!");
  }
});
```
