### PR TITLE
Cakefile: register .coffee extension by default

### DIFF
--- a/lib/coffee-script/cake.js
+++ b/lib/coffee-script/cake.js
@@ -12,6 +12,8 @@
 
   CoffeeScript = require('./coffee-script');
 
+  CoffeeScript.register();
+
   tasks = {};
 
   options = {};

--- a/src/cake.coffee
+++ b/src/cake.coffee
@@ -13,6 +13,9 @@ helpers      = require './helpers'
 optparse     = require './optparse'
 CoffeeScript = require './coffee-script'
 
+# Register .coffee extension
+CoffeeScript.register()
+
 # Keep track of the list of defined tasks, the accepted options, and so on.
 tasks     = {}
 options   = {}


### PR DESCRIPTION
It seems reasonable to expect that requiring .coffee files from within a `Cakefile` works out-of-the-box.
