### PR TITLE
changelog: use time elements for release dates

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -88,7 +88,7 @@ releaseHeader = (date, version, prevVersion) -> """
   <div class="anchor" id="#{version}"></div>
   <b class="header">
     #{prevVersion and "<a href=\"https://github.com/jashkenas/coffee-script/compare/#{prevVersion}...#{version}\">#{version}</a>" or version}
-    <span class="timestamp"> &ndash; <small>#{formatDate date}</small></span>
+    <span class="timestamp"> &mdash; <time datetime="#{date}">#{formatDate date}</time></span>
   </b>
 """
 

--- a/documentation/css/docs.css
+++ b/documentation/css/docs.css
@@ -81,14 +81,10 @@ code, pre, tt, textarea {
       padding-left: 0;
     }
 .timestamp {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: normal;
-  color: black;
+  text-transform: uppercase;
 }
-  .timestamp small {
-    font-size: 11px;
-    text-transform: uppercase;
-  }
 div.anchor {
   position: relative;
   top: -90px;


### PR DESCRIPTION
This changes the visual presentation ever so slightly:

![Before](https://f.cloud.github.com/assets/210406/2197655/a8a77f8a-98be-11e3-889d-1e93667cd4ba.png)

![After](https://f.cloud.github.com/assets/210406/2197656/adccb142-98be-11e3-9117-f172634e3d62.png)

I was able to avoid the need for the `document.createElement('time')` trick (for old IEs) by having the time element inherit all its styles from its parent element. This involved reducing the font-size of the parent element from 12px to 11px. To offset this change, I bumped up the en dash to an em dash. The result is satisfactory visually, and the markup is significantly more meaningful as a result.

It's safe to change the styling of `.timestamp` elements as they're used exclusively for marking up release dates in the change log.
