### PR TITLE
Convert README to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+            {
+         }   }   {
+        {   {  }  }
+         }   }{  {
+        {  }{  }  }                    _____       __  __
+       { }{ }{  { }                   / ____|     / _|/ _|
+     .- { { }  { }} -.               | |     ___ | |_| |_ ___  ___
+    (  { } { } { } }  )              | |    / _ \|  _|  _/ _ \/ _ \
+    |`-..________ ..-'|              | |___| (_) | | | ||  __/  __/
+    |                 |               \_____\___/|_| |_| \___|\___|
+    |                 ;--.
+    |                (__  \            _____           _       _
+    |                 | )  )          / ____|         (_)     | |
+    |                 |/  /          | (___   ___ _ __ _ _ __ | |_
+    |                 (  /            \___ \ / __| '__| | '_ \| __|
+    |                 |/              ____) | (__| |  | | |_) | |_
+    |                 |              |_____/ \___|_|  |_| .__/ \__|
+     `-.._________..-'                                  | |
+                                                        |_|
+
+CoffeeScript is a little language that compiles into JavaScript.
+
+## Installation
+
+If you have the Node Package Manager installed:
+
+```shell
+npm install -g coffee-script
+```
+
+Leave off the -g if you don't wish to install globally.
+
+---
+
+If you don't wish to use NPM:
+
+```shell
+git clone https://github.com/jashkenas/coffee-script.git
+sudo coffee-script/bin/cake install
+```
+
+## Getting Started
+
+Execute a script:
+
+```shell
+coffee /path/to/script.coffee
+```
+
+Compile a script:
+
+```shell
+coffee -c /path/to/script.coffee
+```
+
+For documentation, usage, and examples, see: http://coffeescript.org/
+
+To suggest a feature, report a bug, or general discussion: http://github.com/jashkenas/coffee-script/issues
+
+If you'd like to chat, drop by #coffeescript on Freenode IRC, or on http://webchat.freenode.net.
+
+The source repository: https://github.com/jashkenas/coffee-script.git
+
+Top 100 contributors are listed here: http://github.com/jashkenas/coffee-script/contributors


### PR DESCRIPTION
This pull request renames `README` to `README.md` as well as adding various Markdown goodies to make it look better on the web.
