### PR TITLE
Package with preferGlobal as appropriate for command-line application

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "coffee": "./bin/coffee",
     "cake": "./bin/cake"
   },
+  "preferGlobal": true,
   "scripts": {
     "test": "node ./bin/cake test"
   },


### PR DESCRIPTION
Per https://www.npmjs.org/doc/json.html#preferGlobal

> If your package is primarily a command-line application that should be installed globally, then set this value to true to provide a warning if it is installed locally.
> 
> It doesn't actually prevent users from installing it locally, but it does help prevent some confusion if it doesn't work as expected.
