### PR TITLE
Let the REPL be rlwrap-friendly by passing NODE_NO_READLINE=1

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -57,6 +57,9 @@
     replCliOpts = {
       useGlobal: true
     };
+    if (parseInt(process.env.NODE_NO_READLINE, 10)) {
+      replCliOpts.terminal = false;
+    }
     if (opts.nodejs) {
       return forkNode();
     }

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -69,6 +69,9 @@ exports.run = ->
   # `node` REPL CLI and, therefore, (b) make packages that modify native prototypes
   # (such as 'colors' and 'sugar') work as expected.
   replCliOpts = useGlobal: yes
+  # As `node`, let the REPL be rlwrap-friendly.
+  replCliOpts.terminal = no if parseInt process.env.NODE_NO_READLINE, 10
+
   return forkNode()                             if opts.nodejs
   return usage()                                if opts.help
   return version()                              if opts.version


### PR DESCRIPTION
This is a quick fix for #3399.

Basically, it copies the `node` command and [passes `terminal: false` to the REPL](https://github.com/joyent/node/blob/6cbfcdad46d733bb04332063727e304e449dc86b/src/node.js#L137) if `NODE_NO_READLINE` env var is set.

Now users that prefer to have the nice readline features like <kbd>ctrl</kbd>+<kbd>R</kbd> (history search) can do:

``` bash
alias coffee="env NODE_NO_READLINE=1 rlwrap coffee"
```

Side note: may i add a comment with that Bash alias to the changelog so more users can see it? Is there some problem with doing that alias?

Should we also copy the NODE_DISABLE_COLORS (what's up with Node and negated boolean names?) [configuration](https://github.com/joyent/node/blob/6cbfcdad46d733bb04332063727e304e449dc86b/src/node.js#L140)?
