### PR TITLE
Export the CoffeeScript REPL.

### DIFF
--- a/examples/custom_repl.coffee
+++ b/examples/custom_repl.coffee
@@ -1,0 +1,20 @@
+###
+Example of embedding the CoffeeScript REPL, strikingly similar to the Node REPL.
+###
+
+# Require 'coffee-script/repl' to import the repl module
+repl = require '../repl'
+
+console.log 'Custom REPL! Type `sayHi()` to see what it does!'
+
+# Start the REPL with your configuration
+r = repl.start
+  prompt: 'my-repl> '
+
+# Fields added to the context object are exposed as variables in the REPL
+r.context.sayHi = -> console.log 'Hello'
+
+# An exit event is emitted when the user exits the REPL
+r.on 'exit', ->
+  console.log 'Bye!'
+  process.exit()

--- a/repl.js
+++ b/repl.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/coffee-script/repl');


### PR DESCRIPTION
This is done by adding a root level wrapper script for
lib/coffee-script/repl, similar to how the register script is wrapped.
This allows user programs to embed a CoffeeScript REPL without digging
into CoffeeScript's internals.
