### PR TITLE
Fix repl for Node 0.11.12.

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -41,14 +41,15 @@
   };
 
   addMultilineHandler = function(repl) {
-    var inputStream, multiline, nodeLineListener, outputStream, rli;
+    var inputStream, multiline, nodeLineListener, origPrompt, outputStream, rli, _ref1;
     rli = repl.rli, inputStream = repl.inputStream, outputStream = repl.outputStream;
+    origPrompt = (_ref1 = repl._prompt) != null ? _ref1 : repl.prompt;
     multiline = {
       enabled: false,
-      initialPrompt: repl.prompt.replace(/^[^> ]*/, function(x) {
+      initialPrompt: origPrompt.replace(/^[^> ]*/, function(x) {
         return x.replace(/./g, '-');
       }),
-      prompt: repl.prompt.replace(/^[^> ]*>?/, function(x) {
+      prompt: origPrompt.replace(/^[^> ]*>?/, function(x) {
         return x.replace(/./g, '.');
       }),
       buffer: ''
@@ -61,6 +62,7 @@
         rli.setPrompt(multiline.prompt);
         rli.prompt(true);
       } else {
+        rli.setPrompt(origPrompt);
         nodeLineListener(cmd);
       }
     });
@@ -71,7 +73,7 @@
       if (multiline.enabled) {
         if (!multiline.buffer.match(/\n/)) {
           multiline.enabled = !multiline.enabled;
-          rli.setPrompt(repl.prompt);
+          rli.setPrompt(origPrompt);
           rli.prompt(true);
           return;
         }

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -39,11 +39,13 @@ replDefaults =
 
 addMultilineHandler = (repl) ->
   {rli, inputStream, outputStream} = repl
+  # Node 0.11.12 changed API, prompt is now _prompt.
+  origPrompt = repl._prompt ? repl.prompt
 
   multiline =
     enabled: off
-    initialPrompt: repl.prompt.replace /^[^> ]*/, (x) -> x.replace /./g, '-'
-    prompt: repl.prompt.replace /^[^> ]*>?/, (x) -> x.replace /./g, '.'
+    initialPrompt: origPrompt.replace /^[^> ]*/, (x) -> x.replace /./g, '-'
+    prompt: origPrompt.replace /^[^> ]*>?/, (x) -> x.replace /./g, '.'
     buffer: ''
 
   # Proxy node's line listener
@@ -55,6 +57,7 @@ addMultilineHandler = (repl) ->
       rli.setPrompt multiline.prompt
       rli.prompt true
     else
+      rli.setPrompt origPrompt
       nodeLineListener cmd
     return
 
@@ -65,7 +68,7 @@ addMultilineHandler = (repl) ->
       # allow arbitrarily switching between modes any time before multiple lines are entered
       unless multiline.buffer.match /\n/
         multiline.enabled = not multiline.enabled
-        rli.setPrompt repl.prompt
+        rli.setPrompt origPrompt
         rli.prompt true
         return
       # no-op unless the current line is empty


### PR DESCRIPTION
Node changed their repl so that it inherits from readline.Interface.
This means that `prompt` is now the rli function and not the original
prompt string.  This may be a little hacky, but I figure it would give
someone a start if they want to do a better fix.

The commit that changed this in Node is joyent/node@3ae0b17c76f693dd2e68a46f78c7dc7f595b33c6

This bug was mentioned in Issue #3395.
