### PR TITLE
Fix help for .load

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -156,6 +156,7 @@
       if (opts.historyFile) {
         addHistory(repl, opts.historyFile, opts.historyMaxInputSize);
       }
+      repl.commands['.load'].help = 'Load code from a file into this REPL session';
       return repl;
     }
   };

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -138,4 +138,6 @@ module.exports =
     repl.on 'exit', -> repl.outputStream.write '\n'
     addMultilineHandler repl
     addHistory repl, opts.historyFile, opts.historyMaxInputSize if opts.historyFile
+    # Correct the description inherited from the node REPL
+    repl.commands['.load'].help = 'Load code from a file into this REPL session'
     repl


### PR DESCRIPTION
The help for .load in the REPL is misleading because it was inherited from the node REPL. Currently it says

```
Load JS from a file into the REPL session
```

This patch changes the message to 

```
Load code from a file into this REPL session
```
