### PR TITLE
Update example to treat strings as strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1742,7 +1742,7 @@ futurists = {
 };
 
 _ref = futurists.poet, name = _ref.name, (_ref1 = _ref.address, street = _ref1[0], city = _ref1[1]);
-;alert("name + "-" + street");'>run: "name + "-" + street"</div><br class='clear' /></div>
+;alert(name + "-" + street);'>run: name + "-" + street</div><br class='clear' /></div>
     <p>
       Destructuring assignment can even be combined with splats.
     </p>


### PR DESCRIPTION
One of the current examples for destructuring assignment, the futurist poet, invokes an alert statement using `alert("name + "-" + street");`. This causes **name** and **street** to be incorrectly cast to Number, resulting in a reader seeing "NaN".

Instead, the leading and trailing `"` should be removed, so that the `-` operator is not used, and instead `+` concatenates the strings correctly.

This fixes that change, changing the code to `alert(name + "-" + street);`.
