### PR TITLE
Update critic example to treat strings as strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@ _ref = text.split(<span class="string">" "</span>), first = _ref[<span class="nu
 text = "Every literary critic believes he will outwit history and have the last word";
 
 _ref = text.split(" "), first = _ref[0], last = _ref[_ref.length - 1];
-;alert("first + " " + last");'>run: "first + " " + last"</div><br class='clear' /></div>
+;alert(first + " " + last);'>run: first + " " + last</div><br class='clear' /></div>
     <p>
       Destructuring assignment is also useful when combined with class constructors
       to assign properties to your instance from an options object passed to the constructor.


### PR DESCRIPTION
One of the current examples for destructuring assignment, the literary critic, invokes an alert statement using `alert("first + " " + last");`. This causes the alert to not fire due to a SyntaxError.

Instead, the leading and trailing `"` should be removed, so that `+` concatenates the strings correctly.

This fixes that change, changing the code to `alert(first + " " + last);`. It also changes the text visible to the reader to match the amended code.
