### PR TITLE
command: deprecate --join

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -86,6 +86,7 @@
     }
     if (opts.join) {
       opts.join = path.resolve(opts.join);
+      console.error('\nThe --join option is deprecated and will be removed in a future version.\n\nIf for some reason it\'s necessary to share local variables between files,\nreplace...\n\n    $ coffee --compile --join bundle.js -- a.coffee b.coffee c.coffee\n\nwith...\n\n    $ cat a.coffee b.coffee c.coffee | coffee --compile --stdio > bundle.js\n');
     }
     _ref1 = opts["arguments"];
     _results = [];

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -81,7 +81,22 @@ exports.run = ->
   process.argv[0] = 'coffee'
 
   opts.output = path.resolve opts.output  if opts.output
-  opts.join   = path.resolve opts.join    if opts.join
+  if opts.join
+    opts.join = path.resolve opts.join
+    console.error '''
+
+    The --join option is deprecated and will be removed in a future version.
+
+    If for some reason it's necessary to share local variables between files,
+    replace...
+
+        $ coffee --compile --join bundle.js -- a.coffee b.coffee c.coffee
+
+    with...
+
+        $ cat a.coffee b.coffee c.coffee | coffee --compile --stdio > bundle.js
+
+    '''
   for source in opts.arguments
     source = path.resolve source
     compilePath source, yes, source


### PR DESCRIPTION
As discussed in #3472.

The deprecation warning should convey three points:
- the deprecation of `--join`;
- the reason for the deprecation; and
- a straightforward migration.

The reason for the deprecation is that having different files share scope is surprising. Initially the message said so explicitly, but the current wording is much shorter and still suggests that the practice is distasteful.

To simulate `--join`, first concatenate the files, then pipe the output to `coffee`. To avoid clouding this message, I think it best to ignore the possible complications: files without a trailing newline, and completely indented files. (`cat` is really just a placeholder for _an external tool which concatenates files_.)
