### PR TITLE
Issue spawning child process of `coffee` with `--nodejs` argument

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -545,15 +545,24 @@
   };
 
   forkNode = function() {
-    var args, nodeArgs, p;
+    var args, customFds, nodeArgs, p;
     nodeArgs = opts.nodejs.split(/\s+/);
     args = process.argv.slice(1);
     args.splice(args.indexOf('--nodejs'), 2);
+    customFds = [0, 1, 2];
+    if (process.send) {
+      customFds = customFds.concat('ipc');
+    }
     p = spawn(process.execPath, nodeArgs.concat(args), {
       cwd: process.cwd(),
       env: process.env,
-      customFds: [0, 1, 2]
+      customFds: customFds
     });
+    if (process.send) {
+      p.on('message', function(code) {
+        return process.send(code);
+      });
+    }
     return p.on('exit', function(code) {
       return process.exit(code);
     });

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -65,7 +65,7 @@ optionParser = null
 # `--` will be passed verbatim to your script as arguments in `process.argv`
 exports.run = ->
   parseOptions()
-  # Make the REPL *CLI* use the global context so as to (a) be consistent with the 
+  # Make the REPL *CLI* use the global context so as to (a) be consistent with the
   # `node` REPL CLI and, therefore, (b) make packages that modify native prototypes
   # (such as 'colors' and 'sugar') work as expected.
   replCliOpts = useGlobal: yes
@@ -412,10 +412,13 @@ forkNode = ->
   nodeArgs = opts.nodejs.split /\s+/
   args     = process.argv[1..]
   args.splice args.indexOf('--nodejs'), 2
+  customFds = [0, 1, 2]
+  customFds = customFds.concat('ipc') if process.send
   p = spawn process.execPath, nodeArgs.concat(args),
     cwd:        process.cwd()
     env:        process.env
-    customFds:  [0, 1, 2]
+    customFds:  customFds
+  p.on('message', (code) -> process.send code) if process.send
   p.on 'exit', (code) -> process.exit code
 
 # Print the `--help` usage message and exit. Deprecated switches are not


### PR DESCRIPTION
I ran into a strange issue with coffee script executable. Enabling `--harmony` seems to mess up IPC with node's `child_process.fork`

``` coffee

# parent.coffee

spawn = require('child_process').spawn

child = spawn('/usr/local/bin/coffee', [ '--nodejs', '--harmony-generators', './child.coffee' ], {
    stdio: [0, 1, 2, 'ipc']
})

child.on('message', console.log.bind(console, 'from child'))
child.send({ hello: 'child' })
```

``` coffee

# child.coffee

# comment
process.on('message', console.log.bind(console, 'from parent'))
process.send({ hello: 'parent' })

gen = `function *() {
}`

gen()
```

In the above code, if you remove `'--nodejs', '--harmony-generators'`, IPC works correctly but generators won't be enabled. Once you add the params in, IPC breaks (process.send is  undefined), but generators are enabled.
#3450 May be related to this.

node@0.11.12
coffee-script@1.7.1
