### PR TITLE
Declare FOROF temporary variable in the closure

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2723,7 +2723,7 @@
         scope.find(name);
       }
       if (index) {
-        scope.find(index);
+        scope.find(index, true);
       }
       if (this.returns) {
         rvar = scope.freeVariable('results');

--- a/lib/coffee-script/scope.js
+++ b/lib/coffee-script/scope.js
@@ -45,11 +45,11 @@
       return this.parent.namedMethod();
     };
 
-    Scope.prototype.find = function(name) {
+    Scope.prototype.find = function(name, immediate) {
       if (this.check(name)) {
         return true;
       }
-      this.add(name, 'var');
+      this.add(name, 'var', immediate);
       return false;
     };
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1943,7 +1943,7 @@ exports.For = class For extends While
     name      = @name  and (@name.compile o, LEVEL_LIST) if not @pattern
     index     = @index and (@index.compile o, LEVEL_LIST)
     scope.find(name)  if name and not @pattern
-    scope.find(index) if index
+    scope.find(index, true) if index
     rvar      = scope.freeVariable 'results' if @returns
     ivar      = (@object and index) or scope.freeVariable 'i'
     kvar      = (@range and name) or index or ivar

--- a/src/scope.litcoffee
+++ b/src/scope.litcoffee
@@ -47,9 +47,9 @@ function object that has a name filled in, or bottoms out.
 Look up a variable name in lexical scope, and declare it if it does not
 already exist.
 
-      find: (name) ->
+      find: (name, immediate) ->
         return yes if @check name
-        @add name, 'var'
+        @add name, 'var', immediate
         no
 
 Reserve a variable name as originating from a function parameter for this


### PR DESCRIPTION
I don't see any reason why it would need to be declared in the outer scope (and I have a stupid reason for preferring it in the inner scope: a my jshint version has a bug that makes it think the variable is global when it's not in the inner scope)

Example before:

```
$ bin/coffee -ce 'd = (v for v of {})'
// Generated by CoffeeScript 1.7.1
(function() {
  var d, v;

  d = (function() {
    var _results;
    _results = [];
    for (v in {}) {
      _results.push(v);
    }
    return _results;
  })();

}).call(this);
```

Example after:

```
$bin/coffee -ce 'd = (v for v of {})'
// Generated by CoffeeScript 1.7.1
(function() {
  var d;

  d = (function() {
    var v, _results;
    _results = [];
    for (v in {}) {
      _results.push(v);
    }
    return _results;
  })();
}).call(this);
```

I have not looked at the test system yet, but I can try to make some tests if you think it is useful
