### PR TITLE
Fix “list of open-source CoffeeScript on GitHub”

### DIFF
--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -1084,7 +1084,7 @@ Expressions
     </h2>
 
     <p>
-      The <a href="https://github.com/languages/coffeescript">best list of
+      The <a href="https://github.com/trending?l=coffeescript">best list of
       open-source CoffeeScript examples</a> can be found on GitHub. But just
       to throw out few more:
     </p>


### PR DESCRIPTION
Link's been broken with the recent GitHub re-arrangement. This is the closest thing I could find to what that link used to lead to.
