### PR TITLE
Handle dotless commands in the REPL.

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -125,7 +125,7 @@
     repl.rli.on('exit', function() {
       return fs.close(fd);
     });
-    return repl.commands[getCommandId(repl, '.history')] = {
+    return repl.commands[getCommandId(repl, 'history')] = {
       help: 'Show command history',
       action: function() {
         repl.outputStream.write("" + (repl.rli.history.slice(0).reverse().join('\n')) + "\n");
@@ -136,11 +136,11 @@
 
   getCommandId = function(repl, commandName) {
     var commandsHaveLeadingDot;
-    commandsHaveLeadingDot = !repl.commands['help'];
+    commandsHaveLeadingDot = repl.commands['.help'] != null;
     if (commandsHaveLeadingDot) {
-      return commandName;
+      return "." + commandName;
     } else {
-      return commandName.slice(1);
+      return commandName;
     }
   };
 
@@ -168,7 +168,7 @@
       if (opts.historyFile) {
         addHistory(repl, opts.historyFile, opts.historyMaxInputSize);
       }
-      repl.commands[getCommandId(repl, '.load')].help = 'Load code from a file into this REPL session';
+      repl.commands[getCommandId(repl, 'load')].help = 'Load code from a file into this REPL session';
       return repl;
     }
   };

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -120,7 +120,7 @@ addHistory = (repl, filename, maxSize) ->
   repl.rli.on 'exit', -> fs.close fd
 
   # Add a command to show the history stack
-  repl.commands[getCommandId(repl, '.history')] =
+  repl.commands[getCommandId(repl, 'history')] =
     help: 'Show command history'
     action: ->
       repl.outputStream.write "#{repl.rli.history[..].reverse().join '\n'}\n"
@@ -128,8 +128,8 @@ addHistory = (repl, filename, maxSize) ->
 
 getCommandId = (repl, commandName) ->
   # Node 0.11 changed API, a command such as '.help' is now stored as 'help'
-  commandsHaveLeadingDot = ! repl.commands['help']
-  if commandsHaveLeadingDot then commandName else commandName[1..]
+  commandsHaveLeadingDot = repl.commands['.help']?
+  if commandsHaveLeadingDot then ".#{commandName}" else commandName
 
 module.exports =
   start: (opts = {}) ->
@@ -147,5 +147,5 @@ module.exports =
     addMultilineHandler repl
     addHistory repl, opts.historyFile, opts.historyMaxInputSize if opts.historyFile
     # Adapt help inherited from the node REPL
-    repl.commands[getCommandId(repl, '.load')].help = 'Load code from a file into this REPL session'
+    repl.commands[getCommandId(repl, 'load')].help = 'Load code from a file into this REPL session'
     repl


### PR DESCRIPTION
Node 0.11 switched to storing the REPL commands dotless internally.

This PR fixes two problems, when using coffee with node 0.11:
- coffee doesn't choke on the adapted help for .load (problem brought up in #3450)
- .history works again (previously you had to enter ..history)
