### PR TITLE
remove docco as dependency (still a devDependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,9 @@
     "jison": ">=0.2.0",
     "highlight.js": "~8.0.0",
     "underscore": "~1.5.2",
-    "docco": "0.6.x"
+    "docco": "~0.6.2"
   },
   "dependencies": {
-    "mkdirp": "~0.3.5",
-    "docco": "~0.6.2"
+    "mkdirp": "~0.3.5"
   }
 }


### PR DESCRIPTION
Please correct me if I'm wrong, but as far as I can tell we don't need docco as a dependency.
It's definitely needed as a devDependency, but I only see docco being used in the cakefile.
Should be safe to remove? Or is there a reason it's there?
