### PR TITLE
Remove sudo from install command in introduction

### DIFF
--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -11,7 +11,7 @@
 <body>
 
   <div id="fadeout"></div>
-p
+
   <div id="flybar">
     <a id="logo" href="#top"><img src="documentation/images/logo.png" width="225" height="39" alt="CoffeeScript" /></a>
     <div class="navigation toc">


### PR DESCRIPTION
1. It just seems like a bad practice to encourage people to run npm with `sudo`
2. The doc wasn’t consistent with itself — down below in the full “Installation” section the same command did _not_ include `sudo`
