### PR TITLE
Fix wrong location issue in heregex interpolation

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -290,7 +290,8 @@
       this.token('CALL_START', '(', 0, 0);
       tokens = [];
       _ref2 = this.interpolateString(body, {
-        regex: true
+        regex: true,
+        strOffset: 3
       });
       for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
         token = _ref2[_i];

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -263,7 +263,7 @@ exports.Lexer = class Lexer
     @token 'IDENTIFIER', 'RegExp', 0, 0
     @token 'CALL_START', '(', 0, 0
     tokens = []
-    for token in @interpolateString(body, regex: yes)
+    for token in @interpolateString(body, regex: yes, strOffset: 3)
       [tag, value] = token
       if tag is 'TOKENS'
         tokens.push value...

--- a/test/location.coffee
+++ b/test/location.coffee
@@ -128,10 +128,6 @@ test 'Verify locations in string interpolation (in "string", multiple interpolat
   eq tokens.length, 10
   [{}, {}, {}, a, {}, b, {}, c] = tokens
 
-  console.log a
-  console.log b
-  console.log c
-
   eq a[2].first_line, 1
   eq a[2].first_column, 2
   eq a[2].last_line, 1
@@ -314,6 +310,174 @@ test 'Verify locations in string interpolation (in """string""", multiple interp
   eq c[2].first_column, 2
   eq c[2].last_line, 9
   eq c[2].last_column, 2
+
+test 'Verify locations in heregex interpolation (in ///regex///, multiple interpolation)', ->
+  tokens = CoffeeScript.tokens '///#{a}b#{c}///'
+
+  eq tokens.length, 11
+  [{}, {}, {}, {}, a, {}, b, {}, c] = tokens
+
+  eq a[2].first_line, 0
+  eq a[2].first_column, 5
+  eq a[2].last_line, 0
+  eq a[2].last_column, 5
+
+  eq b[2].first_line, 0
+  eq b[2].first_column, 7
+  eq b[2].last_line, 0
+  eq b[2].last_column, 7
+
+  eq c[2].first_line, 0
+  eq c[2].first_column, 10
+  eq c[2].last_line, 0
+  eq c[2].last_column, 10
+
+test 'Verify locations in heregex interpolation (in ///regex///, multiple interpolation)', ->
+  tokens = CoffeeScript.tokens '///a#{b}c///'
+
+  eq tokens.length, 9
+  [{}, {}, a, {}, b, {}, c] = tokens
+
+  eq a[2].first_line, 0
+  eq a[2].first_column, 3
+  eq a[2].last_line, 0
+  eq a[2].last_column, 3
+
+  eq b[2].first_line, 0
+  eq b[2].first_column, 6
+  eq b[2].last_line, 0
+  eq b[2].last_column, 6
+
+  eq c[2].first_line, 0
+  eq c[2].first_column, 8
+  eq c[2].last_line, 0
+  eq c[2].last_column, 8
+
+test 'Verify locations in heregex interpolation (in ///regex///, multiple interpolation and line breaks)', ->
+  tokens = CoffeeScript.tokens '///#{a}\nb\n#{c}///'
+
+  eq tokens.length, 11
+  [{}, {}, {}, {}, a, {}, b, {}, c] = tokens
+
+  eq a[2].first_line, 0
+  eq a[2].first_column, 5
+  eq a[2].last_line, 0
+  eq a[2].last_column, 5
+
+  eq b[2].first_line, 0
+  eq b[2].first_column, 7
+  eq b[2].last_line, 1
+  eq b[2].last_column, 1
+
+  eq c[2].first_line, 2
+  eq c[2].first_column, 2
+  eq c[2].last_line, 2
+  eq c[2].last_column, 2
+
+test 'Verify locations in heregex interpolation (in ///regex///, multiple interpolation and line breaks)', ->
+  tokens = CoffeeScript.tokens '///#{a}\n\n\nb\n\n\n#{c}///'
+
+  eq tokens.length, 11
+  [{}, {}, {}, {}, a, {}, b, {}, c] = tokens
+
+  eq a[2].first_line, 0
+  eq a[2].first_column, 5
+  eq a[2].last_line, 0
+  eq a[2].last_column, 5
+
+  eq b[2].first_line, 0
+  eq b[2].first_column, 7
+  eq b[2].last_line, 5
+  eq b[2].last_column, 0
+
+  eq c[2].first_line, 6
+  eq c[2].first_column, 2
+  eq c[2].last_line, 6
+  eq c[2].last_column, 2
+
+test 'Verify locations in heregex interpolation (in ///regex///, multiple interpolation and line breaks)', ->
+  tokens = CoffeeScript.tokens '///a\n\n\n#{b}\n\n\nc///'
+
+  eq tokens.length, 9
+  [{}, {}, a, {}, b, {}, c] = tokens
+
+  eq a[2].first_line, 0
+  eq a[2].first_column, 3
+  eq a[2].last_line, 2
+  eq a[2].last_column, 0
+
+  eq b[2].first_line, 3
+  eq b[2].first_column, 2
+  eq b[2].last_line, 3
+  eq b[2].last_column, 2
+
+  eq c[2].first_line, 3
+  eq c[2].first_column, 4
+  eq c[2].last_line, 6
+  eq c[2].last_column, 0
+
+test 'Verify locations in heregex interpolation (in ///regex///, multiple interpolation and line breaks and stating with linebreak)', ->
+  tokens = CoffeeScript.tokens '///\n#{a}\nb\n#{c}///'
+
+  eq tokens.length, 11
+  [{}, {}, {}, {}, a, {}, b, {}, c] = tokens
+
+  eq a[2].first_line, 1
+  eq a[2].first_column, 2
+  eq a[2].last_line, 1
+  eq a[2].last_column, 2
+
+  eq b[2].first_line, 1
+  eq b[2].first_column, 4
+  eq b[2].last_line, 2
+  eq b[2].last_column, 1
+
+  eq c[2].first_line, 3
+  eq c[2].first_column, 2
+  eq c[2].last_line, 3
+  eq c[2].last_column, 2
+
+test 'Verify locations in heregex interpolation (in ///regex///, multiple interpolation and line breaks and stating with linebreak)', ->
+  tokens = CoffeeScript.tokens '///\n\n\n#{a}\n\n\nb\n\n\n#{c}///'
+
+  eq tokens.length, 11
+  [{}, {}, {}, {}, a, {}, b, {}, c] = tokens
+
+  eq a[2].first_line, 3
+  eq a[2].first_column, 2
+  eq a[2].last_line, 3
+  eq a[2].last_column, 2
+
+  eq b[2].first_line, 3
+  eq b[2].first_column, 4
+  eq b[2].last_line, 8
+  eq b[2].last_column, 0
+
+  eq c[2].first_line, 9
+  eq c[2].first_column, 2
+  eq c[2].last_line, 9
+  eq c[2].last_column, 2
+
+test 'Verify locations in heregex interpolation (in ///regex///, multiple interpolation and line breaks and stating with linebreak)', ->
+  tokens = CoffeeScript.tokens '///\n\n\na\n\n\n#{b}\n\n\nc///'
+
+  eq tokens.length, 9
+  [{}, {}, a, {}, b, {}, c] = tokens
+
+  eq a[2].first_line, 0
+  eq a[2].first_column, 3
+  eq a[2].last_line, 5
+  eq a[2].last_column, 0
+
+  eq b[2].first_line, 6
+  eq b[2].first_column, 2
+  eq b[2].last_line, 6
+  eq b[2].last_column, 2
+
+  eq c[2].first_line, 6
+  eq c[2].first_column, 4
+  eq c[2].last_line, 9
+  eq c[2].last_column, 0
 
 test "Verify all tokens get a location", ->
   doesNotThrow ->


### PR DESCRIPTION
The location of heregex interpolation is broken.
I added 8 test cases for this problem and fixed.

Heregex code:

```
///
#{a}
b
#{c}
///
```

Tokenize without this patch:

```
[ 'IDENTIFIER',
  'a',
  { first_line: 0, first_column: 3, last_line: 0, last_column: 3 } ] [ 'STRING',
  '"b"',
  { first_line: 1, first_column: 1, last_line: 1, last_column: 3 } ] [ 'IDENTIFIER',
  'c',
  { first_line: 2, first_column: 1, last_line: 2, last_column: 1 } ]
```

Tokenize with this patch:

```
[ 'IDENTIFIER',
  'a',
  { first_line: 1, first_column: 2, last_line: 1, last_column: 2 } ] [ 'STRING',
  '"b"',
  { first_line: 1, first_column: 4, last_line: 2, last_column: 1 } ] [ 'IDENTIFIER',
  'c',
  { first_line: 3, first_column: 2, last_line: 3, last_column: 2 } ]
```
