### PR TITLE
Fixed example29

### DIFF
--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@ _ref = text.split(<span class="string">" "</span>), first = _ref[<span class="nu
 text = "Every literary critic believes he will outwit history and have the last word";
 
 _ref = text.split(" "), first = _ref[0], last = _ref[_ref.length - 1];
-;alert("first + " " + last");'>run: "first + " " + last"</div><br class='clear' /></div>
+;alert(first + " " + last);'>run: first + " " + last</div><br class='clear' /></div>
     <p>
       Destructuring assignment is also useful when combined with class constructors
       to assign properties to your instance from an options object passed to the constructor.


### PR DESCRIPTION
two extra quotes were present, causing "Uncaught SyntaxError: Unexpected string" error in console rather than the expected alert.
