### PR TITLE
Exit with an error code 1 if could not write a compiled JavaScript file ...

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -65,7 +65,7 @@ optionParser = null
 # `--` will be passed verbatim to your script as arguments in `process.argv`
 exports.run = ->
   parseOptions()
-  # Make the REPL *CLI* use the global context so as to (a) be consistent with the 
+  # Make the REPL *CLI* use the global context so as to (a) be consistent with the
   # `node` REPL CLI and, therefore, (b) make packages that modify native prototypes
   # (such as 'colors' and 'sugar') work as expected.
   replCliOpts = useGlobal: yes
@@ -346,12 +346,14 @@ writeJs = (base, sourcePath, js, jsPath, generatedSourceMap = null) ->
       fs.writeFile jsPath, js, (err) ->
         if err
           printLine err.message
+          process.exit 1
         else if opts.compile and opts.watch
           timeLog "compiled #{sourcePath}"
     if generatedSourceMap
       fs.writeFile sourceMapPath, generatedSourceMap, (err) ->
         if err
           printLine "Could not write source map: #{err.message}"
+          process.exit 1
   fs.exists jsDir, (itExists) ->
     if itExists then compile() else mkdirp jsDir, compile
 


### PR DESCRIPTION
...or a source map.

Currently CoffeeScript reports a success even if it failed to write a
compiled file to disk. This behavior confuses automated tools such as
test runners which may return false positives if a test failed to
compile because of a file lock.
