### PR TITLE
Fix build, which is broken by jison 0.4.14+.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "uglify-js": "~2.2",
-    "jison": ">=0.2.0",
+    "jison": "0.4.13",
     "highlight.js": "~8.0.0",
     "underscore": "~1.5.2",
     "docco": "~0.6.2"


### PR DESCRIPTION
build:parser followed by build:full is broken by the latest jison
releases.  I haven't tracked down the problem, but to make the
build work, we should set this to 0.4.13.