### PR TITLE
Use stdio option instead of customFds

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -554,7 +554,7 @@
     p = spawn(process.execPath, nodeArgs.concat(args), {
       cwd: process.cwd(),
       env: process.env,
-      customFds: [0, 1, 2]
+      stdio: [0, 1, 2]
     });
     return p.on('exit', function(code) {
       return process.exit(code);

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -417,7 +417,7 @@ forkNode = ->
   p = spawn process.execPath, nodeArgs.concat(args),
     cwd:        process.cwd()
     env:        process.env
-    customFds:  [0, 1, 2]
+    stdio:      [0, 1, 2]
   p.on 'exit', (code) -> process.exit code
 
 # Print the `--help` usage message and exit. Deprecated switches are not


### PR DESCRIPTION
The customFds option in spawn is deprecated.
http://nodejs.org/docs/latest/api/child_process.html#child_process_child_process_spawn_command_args_options

Although it's actually converted for now, I don't want to see the annoying deprecated message.
https://github.com/joyent/node/blob/master/lib/child_process.js#L808

Could you consider to merge this?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jashkenas/coffeescript/3661)
<!-- Reviewable:end -->
