### PR TITLE
Added failing test case for the `yield` precedence

### DIFF
--- a/test/generators.coffee
+++ b/test/generators.coffee
@@ -82,22 +82,24 @@ test "yield in if statements", ->
 
 test "symbolic operators has precedence over the `yield`", ->
 
-  symbolic   = '+ - * / << >> & | || && ** ^ \\ or and'.split ' '
+  symbolic   = '+ - * / << >> & | || && ** ^ // or and'.split ' '
   compound   = ("#{op}=" for op in symbolic)
   relations  = '< > == != <= >= is isnt'.split ' '
 
-  operators  = []
-  operators.push symbolic...
-  operators.push compound...
-  operators.push relations...
+  operators  = [symbolic..., '=', compound..., relations...]
 
-  allOf = (gen) -> ref.value until (ref = gen.next()).done
+  collect = (gen) -> ref.value until (ref = gen.next()).done
 
   values = [0, 1, 2, 3]
 
   for op in operators
-    generator = CoffeeScript.eval "(arr) -> yield i #{op} 2 for i in arr"
-    transform = CoffeeScript.eval "(i) -> i #{op} 2"
-    expected = values.map transform
-    actual = allOf generator values
+
+    expression = "i #{op} 2"
+
+    yielded    = CoffeeScript.eval "(arr) ->  yield #{expression} for i in arr"
+    mapped     = CoffeeScript.eval "(arr) ->       (#{expression} for i in arr)"
+
+    expected   = mapped values
+    actual     = collect yielded values
+
     arrayEq actual, expected


### PR DESCRIPTION
I've added a test case for the `yield` precedence. Discussed in https://github.com/jashkenas/coffeescript/issues/3674

``` coffeescript
 test "symbolic operators has precedence over the `yield`", ->

  symbolic   = '+ - * / << >> & | || && ** ^ // or and'.split ' '
  compound   = ("#{op}=" for op in symbolic)
  relations  = '< > == != <= >= is isnt'.split ' '

  operators  = [symbolic..., '=', compound..., relations...]

  collect = (gen) -> ref.value until (ref = gen.next()).done

  values = [0, 1, 2, 3]

  for op in operators

    expression = "i #{op} 2"

    yielded    = CoffeeScript.eval "(arr) ->  yield #{expression} for i in arr"
    mapped     = CoffeeScript.eval "(arr) ->       (#{expression} for i in arr)"

    expected   = mapped values
    actual     = collect yielded values

    arrayEq actual, expected
```
