### PR TITLE
Optionally to read data-src out from <script>

### DIFF
--- a/lib/coffee-script/browser.js
+++ b/lib/coffee-script/browser.js
@@ -104,12 +104,13 @@
       }
     };
     fn = function(script, i) {
-      var options;
+      var options, source;
       options = {
         literate: script.type === coffeetypes[1]
       };
-      if (script.src) {
-        return CoffeeScript.load(script.src, function(param) {
+      source = script.src || script.getAttribute('data-src');
+      if (source) {
+        return CoffeeScript.load(source, function(param) {
           coffees[i] = param;
           return execute();
         }, options, true);

--- a/src/browser.coffee
+++ b/src/browser.coffee
@@ -69,8 +69,9 @@ runScripts = ->
   for script, i in coffees
     do (script, i) ->
       options = literate: script.type is coffeetypes[1]
-      if script.src
-        CoffeeScript.load script.src,
+      source = script.src or script.getAttribute('data-src')
+      if source
+        CoffeeScript.load source,
           (param) ->
             coffees[i] = param
             execute()


### PR DESCRIPTION
By using `data-src` instead, this would avoid double script loading.