### PR TITLE
Reserved keywords as parameters maybe clobbered

### DIFF
--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -201,6 +201,18 @@ test "arguments vs parameters", ->
   f = (g) -> g()
   eq 5, f (x) -> 5
 
+test "reserved keyword as parameters", ->
+  f = (_case, @case) -> [_case, @case]
+  [a, b] = f(1, 2)
+  eq 1, a
+  eq 2, b
+
+  f = (@case, _case...) -> [@case, _case...]
+  [a, b, c] = f(1, 2, 3)
+  eq 1, a
+  eq 2, b
+  eq 3, c
+
 test "#1844: bound functions in nested comprehensions causing empty var statements", ->
   a = ((=>) for a in [0] for b in [0])
   eq 1, a.length


### PR DESCRIPTION
I was looking at some of the strict tests added in 66eb186a74376acded0f637dd504cfc98fc6d44b (by @geraldalewis) and noticed some are generating invalid output. The test only checks if the code can be generated but not evaluated.

There was two different types of errors.

``` coffee
(@case, _case) ->
```

generates

``` js
(function(_case, _case) {
  this["case"] = _case;
});
```

So theres a bug in the variable renaming here.

The second is a little worse.

``` coffee
(@case, _case...) ->
```

generates

``` js
var __slice = [].slice;

(function() {
  var case, _case;
  _case = arguments[0], _case = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
  this["case"] = _case;
});
```

An unused and reversed local is created for `case`.

I haven't looked into a fix yet, but I figured I'd open an patch with tests and maybe someone much more familiar will know what to do.