### PR TITLE
dont use `this` inside the global scope

### DIFF
--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -160,7 +160,7 @@ exports.register = -> require './register'
 
 # Throw error with deprecation warning when depending upon implicit `require.extensions` registration
 if require.extensions
-  for ext in @FILE_EXTENSIONS
+  for ext in exports.FILE_EXTENSIONS
     require.extensions[ext] ?= ->
       throw new Error """
       Use CoffeeScript.register() or require the coffee-script/register module to require #{ext} files.


### PR DESCRIPTION
This is causing bugs in a project I'm working on that emulates Node's require functionality. 

I would be very appreciative of anyone who is able to provide me some documentation on the value/meaning/... of 'this' inside normal Node modules. Then I might be able to implement a similar reference in my own project.
