### PR TITLE
Fixes #3762

### DIFF
--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -192,6 +192,8 @@ grammar =
   # CoffeeScript has two different symbols for functions. `->` is for ordinary
   # functions, and `=>` is for functions bound to the current value of *this*.
   FuncGlyph: [
+    o '->>',                                    -> 'noretfunc'
+    o '=>>',                                    -> 'noretboundfunc'
     o '->',                                     -> 'func'
     o '=>',                                     -> 'boundfunc'
   ]

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -792,7 +792,7 @@ NUMBER     = ///
 HEREDOC    = /// ^ ("""|''') ((?: \\[\s\S] | [^\\] )*?) (?:\n[^\n\S]*)? \1 ///
 
 OPERATOR   = /// ^ (
-  ?: [-=]>             # function
+  ?: [-=]>>?           # function
    | [-+*/%<>&|^!?=]=  # compound assign / compare
    | >>>=?             # zero-fill right shift
    | ([-+:])\1         # doubles

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1320,7 +1320,8 @@ exports.Code = class Code extends Base
   constructor: (params, body, tag) ->
     @params      = params or []
     @body        = body or new Block
-    @bound       = tag is 'boundfunc'
+    @bound       = tag in ['boundfunc','noretboundfunc']
+    @noReturn    = tag in ['noretfunc','noretboundfunc']
     @isGenerator = !!@body.contains (node) ->
       node instanceof Op and node.operator in ['yield', 'yield*']
 
@@ -1346,6 +1347,7 @@ exports.Code = class Code extends Base
     if @bound and not @context
       @context = '_this'
       wrapper = new Code [new Param new Literal @context], new Block [this]
+      wrapper.noReturn = @noReturn
       boundfunc = new Call(wrapper, [new Literal 'this'])
       boundfunc.updateLocationDataIfMissing @locationData
       return boundfunc.compileNode(o)


### PR DESCRIPTION
I kept the changes at a minimum and simply introduced additional tags.
Still working on test cases for this.

Here is a sample coffee-script

``` coffeescript
a = ->>
    foo = 2
    bar = 3

b = =>>
    foo = 2
    bar = 3
```

which gets compiled to

``` javascript
// Generated by CoffeeScript 1.8.0
var a, b;

a = function() {
  var bar, foo;
  foo = 2;
  bar = 3;
};

b = (function(_this) {
  return function() {
    var bar, foo;
    foo = 2;
    bar = 3;
  };
})(this);
```
