### PR TITLE
Fix parenthesized conditions in if-else assignment

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1925,7 +1925,8 @@ exports.Parens = class Parens extends Base
       return expr.compileToFragments o
     fragments = expr.compileToFragments o, LEVEL_PAREN
     bare = o.level < LEVEL_OP and (expr instanceof Op or expr instanceof Call or
-      (expr instanceof For and expr.returns))
+      (expr instanceof For and expr.returns)) and (o.level < LEVEL_COND or
+        fragments.length <= 3)
     if bare then fragments else @wrapInBraces fragments
 
 #### For

--- a/test/control_flow.coffee
+++ b/test/control_flow.coffee
@@ -198,6 +198,17 @@ test "#748: trailing reserved identifiers", ->
     nonce
   eq nonce, result
 
+test 'if-else within an assignment, condition parenthesized', ->
+  result = if (1 == 1) then 'right'
+  eq result, 'right'
+
+  result = if ('whatever' ? no) then 'right'
+  eq result, 'right'
+
+  f = -> 'wrong'
+  result = if (f?()) then 'right' else 'wrong'
+  eq result, 'right'
+
 # Postfix
 
 test "#3056: multiple postfix conditionals", ->


### PR DESCRIPTION
This addresses at least #3309 and #3738 and has to do with parenthesized existential operator. After turning it back and forth several times, I couldn't find anything more elegant than this. I'm not sure if it requires something more fundamental to make the check with some more beauty. Additionally, in what case it could possibly generate extra parentheses now?
