### PR TITLE
Allow multiline comment at end of an object definition [Fixes #3761]

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -301,6 +301,9 @@
             } else if (inImplicitObject() && !this.insideForDeclaration && sameLine && tag !== 'TERMINATOR' && prevTag !== ':' && endImplicitObject()) {
 
             } else if (inImplicitObject() && tag === 'TERMINATOR' && prevTag !== ',' && !(startsLine && this.looksObjectish(i + 1))) {
+              if (nextTag === 'HERECOMMENT') {
+                return forward(1);
+              }
               endImplicitObject();
             } else {
               break;

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -305,6 +305,7 @@ class exports.Rewriter
           # the continuation of an object.
           else if inImplicitObject() and tag is 'TERMINATOR' and prevTag isnt ',' and
                   not (startsLine and @looksObjectish(i + 1))
+            return forward 1 if nextTag is 'HERECOMMENT'
             endImplicitObject()
           else
             break

--- a/test/comments.coffee
+++ b/test/comments.coffee
@@ -418,3 +418,12 @@ test "#3638: Demand a whitespace after # symbol", ->
   """
 
   eq CoffeeScript.compile(input, bare: on), result
+
+test "#3761: Multiline comment at end of an object", ->
+  anObject =
+    x: 3
+    ###
+    #Comment
+    ###
+
+  ok anObject.x is 3


### PR DESCRIPTION
#3761 appears to only be an issue when the multiline comment is indented, and it appears at the end of an object definition

includes test

Issue #3735 appears to be unaffected by this patch - that may not be caused by rewriter.coffee at all.