### PR TITLE
Fix broken CoffeeScript APIs

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -413,24 +413,24 @@
     };
 
     Block.prototype.compileRoot = function(o) {
-      var exp, fragments, i, name, prelude, preludeExps, rest, _i, _len, _ref2;
+      var exp, fragments, i, name, prelude, preludeExps, rest, _i, _len, _ref2, _ref3;
       o.indent = o.bare ? '' : TAB;
       o.level = LEVEL_TOP;
       this.spaced = true;
-      o.scope = new Scope(null, this, null, o.referencedVars);
-      _ref2 = o.locals || [];
-      for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
-        name = _ref2[_i];
+      o.scope = new Scope(null, this, null, (_ref2 = o.referencedVars) != null ? _ref2 : []);
+      _ref3 = o.locals || [];
+      for (_i = 0, _len = _ref3.length; _i < _len; _i++) {
+        name = _ref3[_i];
         o.scope.parameter(name);
       }
       prelude = [];
       if (!o.bare) {
         preludeExps = (function() {
-          var _j, _len1, _ref3, _results;
-          _ref3 = this.expressions;
+          var _j, _len1, _ref4, _results;
+          _ref4 = this.expressions;
           _results = [];
-          for (i = _j = 0, _len1 = _ref3.length; _j < _len1; i = ++_j) {
-            exp = _ref3[i];
+          for (i = _j = 0, _len1 = _ref4.length; _j < _len1; i = ++_j) {
+            exp = _ref4[i];
             if (!(exp.unwrap() instanceof Comment)) {
               break;
             }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -320,7 +320,7 @@ exports.Block = class Block extends Base
     o.indent  = if o.bare then '' else TAB
     o.level   = LEVEL_TOP
     @spaced   = yes
-    o.scope   = new Scope null, this, null, o.referencedVars
+    o.scope   = new Scope null, this, null, o.referencedVars ? []
     # Mark given local variables in the root scope as parameters so they don't
     # end up being declared on this block.
     o.scope.parameter name for name in o.locals or []


### PR DESCRIPTION
As evidenced in #3804, commit 8ab15d7 broke the CoffeeScript API. The REPL uses
those APIs, but wasn't updated in that commit. Still, that shouldn't have
_broken_ the REPL. The reason it broke is because the added _option_
'referencedVars' wasn't actually _optional;_ if it was omitted code that relies
on it being set broke. This commit defaults that option to an empty array, which
makes things behave exactly like before when the 'referencedVars' option is
omitted.