### PR TITLE
Fix incorrect token representation

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -662,14 +662,12 @@
       if (interpolated) {
         ref3 = this.tokens, lastToken = ref3[ref3.length - 1];
         rparen = this.token(')', ')');
-        rparen[2] = [
-          ')', ')', {
-            first_line: lastToken[2].last_line,
-            first_column: lastToken[2].last_column + 1,
-            last_line: lastToken[2].last_line,
-            last_column: lastToken[2].last_column + 1
-          }
-        ];
+        rparen[2] = {
+          first_line: lastToken[2].last_line,
+          first_column: lastToken[2].last_column + 1,
+          last_line: lastToken[2].last_line,
+          last_column: lastToken[2].last_column + 1
+        };
         return rparen.stringEnd = true;
       }
     };

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -582,12 +582,12 @@ exports.Lexer = class Lexer
     if interpolated
       [..., lastToken] = @tokens
       rparen = @token ')', ')'
-      rparen[2] = [')', ')',
+      rparen[2] = {
         first_line:   lastToken[2].last_line
         first_column: lastToken[2].last_column + 1
         last_line:    lastToken[2].last_line
         last_column:  lastToken[2].last_column + 1
-      ]
+      }
       rparen.stringEnd = true
 
   # Pairs up a closing token, ensuring that all listed pairs of tokens are


### PR DESCRIPTION
The third element in a token should just be an object containing line number and column info. This PR fixes the problem with one of the tokens being set incorrectly.