### PR TITLE
Fix #3846: Fix odd start token of implicit objects

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -216,7 +216,7 @@
           return i += 1;
         };
         startImplicitObject = function(j, startsLine) {
-          var idx;
+          var idx, val;
           if (startsLine == null) {
             startsLine = true;
           }
@@ -228,7 +228,9 @@
               ours: true
             }
           ]);
-          tokens.splice(idx, 0, generate('{', generate(new String('{')), token));
+          val = new String('{');
+          val.generated = true;
+          tokens.splice(idx, 0, generate('{', val, token));
           if (j == null) {
             return i += 1;
           }

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -171,7 +171,9 @@ class exports.Rewriter
       startImplicitObject = (j, startsLine = yes) ->
         idx = j ? i
         stack.push ['{', idx, sameLine: yes, startsLine: startsLine, ours: yes]
-        tokens.splice idx, 0, generate '{', generate(new String('{')), token
+        val = new String '{'
+        val.generated = yes
+        tokens.splice idx, 0, generate '{', val, token
         i += 1 if not j?
 
       endImplicitObject = (j) ->


### PR DESCRIPTION
Now the same hack as for reserved identifier tokens in the lexer is used
instead.

@swang Does this solve your problem?