### PR TITLE
fixed being unable to use 'yield throw'

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2530,7 +2530,7 @@
       if (o.scope.parent == null) {
         this.error('yield statements must occur within a function generator.');
       }
-      if (indexOf.call(Object.keys(this.first), 'expression') >= 0) {
+      if (indexOf.call(Object.keys(this.first), 'expression') >= 0 && !(this.first instanceof Throw)) {
         if (this.first.expression != null) {
           parts.push(this.first.expression.compileToFragments(o, LEVEL_OP));
         }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1801,7 +1801,7 @@ exports.Op = class Op extends Base
     op = @operator
     if not o.scope.parent?
       @error 'yield statements must occur within a function generator.'
-    if 'expression' in Object.keys @first
+    if 'expression' in Object.keys(@first) and not (@first instanceof Throw)
       parts.push @first.expression.compileToFragments o, LEVEL_OP if @first.expression?
     else
       parts.push [@makeCode "(#{op} "]

--- a/test/generators.coffee
+++ b/test/generators.coffee
@@ -124,3 +124,14 @@ test "switch expressions", ->
   ok z.value is 1337 and z.done is false
   z = x.next 3
   ok z.value is 3 and z.done is true
+
+test "`yield` can be thrown", ->
+  x = do ->
+    throw yield null
+  x.next()
+  throws -> x.next new Error "boom"
+
+test "`throw` can be yielded", ->
+  x = do ->
+    yield throw new Error "boom"
+  throws -> x.next()


### PR DESCRIPTION
I don't think this will actually appear in any real code, but I found this issue when I was adding more tests (see https://github.com/jashkenas/coffeescript/pull/3852) and fixed it.