### PR TITLE
Replace references to jQuery's 'bind' with 'on'

### DIFF
--- a/documentation/coffee/fat_arrow.coffee
+++ b/documentation/coffee/fat_arrow.coffee
@@ -2,5 +2,5 @@ Account = (customer, cart) ->
   @customer = customer
   @cart = cart
 
-  $('.shopping_cart').bind 'click', (event) =>
+  $('.shopping_cart').on 'click', (event) =>
     @customer.purchase @cart

--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -806,7 +806,7 @@ Expressions
       it to the current value of <tt>this</tt>, right on the spot. This is helpful
       when using callback-based libraries like Prototype or jQuery, for creating
       iterator functions to pass to <tt>each</tt>, or event-handler functions
-      to use with <tt>bind</tt>. Functions created with the fat arrow are able to access
+      to use with <tt>on</tt>. Functions created with the fat arrow are able to access
       properties of the <tt>this</tt> where they're defined.
     </p>
     <%= codeFor('fat_arrow') %>

--- a/documentation/js/fat_arrow.js
+++ b/documentation/js/fat_arrow.js
@@ -4,7 +4,7 @@ var Account;
 Account = function(customer, cart) {
   this.customer = customer;
   this.cart = cart;
-  return $('.shopping_cart').bind('click', (function(_this) {
+  return $('.shopping_cart').on('click', (function(_this) {
     return function(event) {
       return _this.customer.purchase(_this.cart);
     };


### PR DESCRIPTION
"As of jQuery 1.7, the .on() method provides all functionality required for attaching event handlers" per http://api.jquery.com/on/ and I expect .bind will be deprecated at some point. Plus, the multiple meanings of "bind" in this section could be a bit confusing for newcomers.