### PR TITLE
Fix getting of character at index

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -208,7 +208,7 @@
       heredoc = quote.length === 3;
       ref2 = this.matchWithInterpolations(regex, quote), tokens = ref2.tokens, end = ref2.index;
       $ = tokens.length - 1;
-      delimiter = quote[0];
+      delimiter = quote.charAt(0);
       if (heredoc) {
         indent = null;
         doc = ((function() {

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -204,7 +204,7 @@ exports.Lexer = class Lexer
     {tokens, index: end} = @matchWithInterpolations regex, quote
     $ = tokens.length - 1
 
-    delimiter = quote[0]
+    delimiter = quote.charAt(0)
     if heredoc
       # Find the smallest indentation. It will be removed from all lines later.
       indent = null


### PR DESCRIPTION
In Internet Explorer version 8 and below is not supported getting of character from a string by using indexer. Instead of indexer need to use the `charAt` method.