### PR TITLE
Avoid error when --nodejs --use_strict

### DIFF
--- a/lib/coffee-script/parser.js
+++ b/lib/coffee-script/parser.js
@@ -586,15 +586,18 @@ parse: function parse(input) {
         vstack.length = vstack.length - n;
         lstack.length = lstack.length - n;
     }
-    _token_stack:
-        function lex() {
-            var token;
-            token = lexer.lex() || EOF;
-            if (typeof token !== 'number') {
-                token = self.symbols_[token] || token;
-            }
-            return token;
+
+    function lex() {
+        var token;
+        token = lexer.lex() || EOF;
+        if (typeof token !== 'number') {
+            token = self.symbols_[token] || token;
         }
+        return token;
+    }
+
+    _token_stack:lex;
+
     var symbol, preErrorSymbol, state, action, a, r, yyval = {}, p, len, newState, expected;
     while (true) {
         state = stack[stack.length - 1];


### PR DESCRIPTION
Avoid Error on https://github.com/jashkenas/coffeescript/issues/3874 . But doesn't work `repl` mode.