### PR TITLE
added descriptions to tests which only had Issue numbers

### DIFF
--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -162,7 +162,7 @@ test "variable swapping to verify caching of RHS values when appropriate", ->
   eq nonceB, b
   eq nonceC, c
 
-test "#713", ->
+test "#713: destructuring assignment should return right-hand-side value", ->
   nonces = [nonceA={},nonceB={}]
   eq nonces, [a, b] = [c, d] = nonces
   eq nonceA, a
@@ -247,7 +247,7 @@ test "destructuring assignment with context (@) properties", ->
   eq d, obj.d
   eq e, obj.e
 
-test "#1024", ->
+test "#1024: destructure empty assignments to produce javascript-like results", ->
   eq 2 * [] = 3 + 5, 16
 
 test "#1005: invalid identifiers allowed on LHS of destructuring assignment", ->

--- a/test/compilation.coffee
+++ b/test/compilation.coffee
@@ -81,7 +81,7 @@ test "#2516: Unicode spaces should not be part of identifiers", ->
 test "don't accidentally stringify keywords", ->
   ok (-> this == 'this')() is false
 
-test "#1026", ->
+test "#1026: no if/else/else allowed", ->
   cantCompile '''
     if a
       b
@@ -91,7 +91,7 @@ test "#1026", ->
       d
   '''
 
-test "#1050", ->
+test "#1050: no closing asterisk comments from within block comments", ->
   cantCompile "### */ ###"
 
 test "#1273: escaping quotes at the end of heredocs", ->

--- a/test/control_flow.coffee
+++ b/test/control_flow.coffee
@@ -186,7 +186,7 @@ test "tight formatting with leading `then`", ->
   then nonce
   else undefined
 
-test "#738", ->
+test "#738: inline function defintion", ->
   nonce = {}
   fn = if true then -> nonce
   eq nonce, fn()

--- a/test/soaks.coffee
+++ b/test/soaks.coffee
@@ -52,11 +52,10 @@ test "function invocation with soaked property access", ->
 test "if-to-ternary should safely parenthesize soaked property accesses", ->
   ok (if nonexistent?.property then false else true)
 
-test "#726", ->
-  # TODO: check this test, looks like it's not really testing anything
+test "#726: don't check for a property on a conditionally-referenced nonexistent thing", ->
   eq undefined, nonexistent?[Date()]
 
-test "#756", ->
+test "#756: conditional assignment edge cases", ->
   # TODO: improve this test
   a = null
   ok isNaN      a?.b.c +  1
@@ -88,7 +87,7 @@ test "soaked method invocation", ->
   eq obj      , obj.increment().increment().self?()
   eq 2        , counter
 
-test "#733", ->
+test "#733: conditional assignments", ->
   a = b: {c: null}
   eq a.b?.c?(), undefined
   a.b?.c or= (it) -> it


### PR DESCRIPTION
for example:

```diff
-test "#1024", ->
+test "#1024: destructure empty assignments to produce javascript-like results", ->
   eq 2 * [] = 3 + 5, 16
```

the tests mostly covered edge cases. one had a `#TODO` to verify that the test was doing anything useful; I did that, and hopefully my description will prevent similar confusion from arising in future.