### PR TITLE
Literate ".coffee.md" files incorrect line numbers

### DIFF
--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -300,7 +300,7 @@ sourceMaps = {}
 # Generates the source map for a coffee file and stores it in the local cache variable.
 getSourceMap = (filename) ->
   return sourceMaps[filename] if sourceMaps[filename]
-  return unless path?.extname(filename) in exports.FILE_EXTENSIONS
+  return unless exports.FILE_EXTENSIONS.some (extname) -> filename.indexOf(extname, filename.length - extname.length) isnt -1
   answer = exports._compileFile filename, true
   sourceMaps[filename] = answer.sourceMap
 


### PR DESCRIPTION
Filenames made of two extensions are not handled inside the "getSourceMap" function. The previous implementation using "path.extname" only return the first extension.
I check and couldn't find any test checking filenumber while importing ".litcoffee" or ".coffee.md" so I'm not including any test either. Let me know if you wish to add one and i'll send you a complete push request.