### PR TITLE
Fix bug Coffee PEPL environment syntax error.

### DIFF
--- a/lib/coffee-script/helpers.js
+++ b/lib/coffee-script/helpers.js
@@ -201,7 +201,7 @@
   };
 
   syntaxErrorToString = function() {
-    var codeLine, colorize, colorsEnabled, end, filename, first_column, first_line, last_column, last_line, marker, ref1, ref2, start;
+    var codeLine, colorize, colorsEnabled, end, filename, first_column, first_line, i, last_column, last_line, len1, marker, ref1, ref2, ref3, start, token;
     if (!(this.code && this.location)) {
       return Error.prototype.toString.call(this);
     }
@@ -213,14 +213,23 @@
       last_column = first_column;
     }
     filename = this.filename || '[stdin]';
-    codeLine = this.code.split('\n')[first_line];
+    if (typeof this.code === 'string') {
+      codeLine = this.code.split('\n')[first_line];
+    } else {
+      codeLine = "";
+      ref2 = this.code;
+      for (i = 0, len1 = ref2.length; i < len1; i++) {
+        token = ref2[i];
+        codeLine += token[1];
+      }
+    }
     start = first_column;
     end = first_line === last_line ? last_column + 1 : codeLine.length;
     marker = codeLine.slice(0, start).replace(/[^\s]/g, ' ') + repeat('^', end - start);
     if (typeof process !== "undefined" && process !== null) {
       colorsEnabled = process.stdout.isTTY && !process.env.NODE_DISABLE_COLORS;
     }
-    if ((ref2 = this.colorful) != null ? ref2 : colorsEnabled) {
+    if ((ref3 = this.colorful) != null ? ref3 : colorsEnabled) {
       colorize = function(str) {
         return "\x1B[1;31m" + str + "\x1B[0m";
       };

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -165,7 +165,7 @@ syntaxErrorToString = ->
   last_column ?= first_column
 
   filename = @filename or '[stdin]'
-  if typeof this.code == 'string'
+  if typeof @code == 'string'
     codeLine = @code.split('\n')[first_line]
   else
     codeLine = ""

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -165,7 +165,12 @@ syntaxErrorToString = ->
   last_column ?= first_column
 
   filename = @filename or '[stdin]'
-  codeLine = @code.split('\n')[first_line]
+  if typeof this.code == 'string'
+    codeLine = @code.split('\n')[first_line]
+  else
+    codeLine = ""
+    for token in @code
+      codeLine += token[1]
   start    = first_column
   # Show only the first line on multi-line errors.
   end      = if first_line is last_line then last_column + 1 else codeLine.length


### PR DESCRIPTION
coffee throw error when syntax error on coffee REPL environment.
This PR fix the following bug.

```coffee
coffee> {aaa:1,[1]}
TypeError: undefined is not a function
  at SyntaxError.syntaxErrorToString [as toString] (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/helpers.js:226:39)
  at Object.exports.updateSyntaxError (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/helpers.js:198:27)
  at Object.nodes (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/coffee-script.js:37:23)
  at REPLServer.replDefaults.eval (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/repl.js:39:28)
  at bound (domain.js:254:14)
  at REPLServer.runBound [as eval] (domain.js:267:12)
  at repl.js:279:12
  at REPLServer.<anonymous> (/usr/local/lib/node_modules/coffee-script/lib/coffee-script/repl.js:79:9)
  at REPLServer.emit (events.js:129:20)
  at REPLServer.Interface._onLine (readline.js:214:10)
  at REPLServer.Interface._line (readline.js:553:8)
  at REPLServer.Interface._ttyWrite (readline.js:830:14)
  at ReadStream.onkeypress (readline.js:109:10)
  at ReadStream.emit (events.js:129:20)
  at readline.js:1175:14
  at Array.forEach (native)
  at emitKeys (readline.js:993:10)
  at ReadStream.onData (readline.js:910:14)
  at ReadStream.emit (events.js:107:17)
  at readableAddChunk (_stream_readable.js:163:16)
  at ReadStream.Readable.push (_stream_readable.js:126:10)
  at TTY.onread (net.js:529:20)
```

fix
```coffee
coffee> {a:1,[1]}
[stdin]:1:7: error: unexpected [
({a:1,[1]})

      ^
coffee>
```