### PR TITLE
Added checking on process.stdout to be compatible with browserify

### DIFF
--- a/lib/coffee-script/helpers.js
+++ b/lib/coffee-script/helpers.js
@@ -201,7 +201,7 @@
   };
 
   syntaxErrorToString = function() {
-    var codeLine, colorize, colorsEnabled, end, filename, first_column, first_line, last_column, last_line, marker, ref1, ref2, start;
+    var codeLine, colorize, colorsEnabled, end, filename, first_column, first_line, last_column, last_line, marker, ref1, ref2, ref3, ref4, start;
     if (!(this.code && this.location)) {
       return Error.prototype.toString.call(this);
     }
@@ -218,9 +218,9 @@
     end = first_line === last_line ? last_column + 1 : codeLine.length;
     marker = codeLine.slice(0, start).replace(/[^\s]/g, ' ') + repeat('^', end - start);
     if (typeof process !== "undefined" && process !== null) {
-      colorsEnabled = process.stdout.isTTY && !process.env.NODE_DISABLE_COLORS;
+      colorsEnabled = ((ref2 = process.stdout) != null ? ref2.isTTY : void 0) && !((ref3 = process.env) != null ? ref3.NODE_DISABLE_COLORS : void 0);
     }
-    if ((ref2 = this.colorful) != null ? ref2 : colorsEnabled) {
+    if ((ref4 = this.colorful) != null ? ref4 : colorsEnabled) {
       colorize = function(str) {
         return "\x1B[1;31m" + str + "\x1B[0m";
       };

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -173,7 +173,7 @@ syntaxErrorToString = ->
 
   # Check to see if we're running on a color-enabled TTY.
   if process?
-    colorsEnabled = process.stdout.isTTY and not process.env.NODE_DISABLE_COLORS
+    colorsEnabled = process.stdout?.isTTY and not process.env?.NODE_DISABLE_COLORS
 
   if @colorful ? colorsEnabled
     colorize = (str) -> "\x1B[1;31m#{str}\x1B[0m"


### PR DESCRIPTION
Currently, browserify adds a shim of `process` to the global scope. The problem is that the shim created doesn't properly implement the process api, in particular it doesn't implement the `stdin` field. This leads to a `TypeError: Cannot read property 'isTTY' of undefined` in `helpers.js#syntaxErrorToString`.

The best solution is probably to also patch browserify but in this case the fix is quite small on the coffeescript side and makes the compiler usable in more environments.