### PR TITLE
Fix syntaxErrorToString helper

### DIFF
--- a/lib/coffee-script/helpers.js
+++ b/lib/coffee-script/helpers.js
@@ -217,7 +217,7 @@
     start = first_column;
     end = first_line === last_line ? last_column + 1 : codeLine.length;
     marker = codeLine.slice(0, start).replace(/[^\s]/g, ' ') + repeat('^', end - start);
-    if (typeof process !== "undefined" && process !== null) {
+    if (typeof process !== "undefined" && process !== null && process.browser !== true) {
       colorsEnabled = ((ref2 = process.stdout) != null ? ref2.isTTY : void 0) && !((ref3 = process.env) != null ? ref3.NODE_DISABLE_COLORS : void 0);
     }
     if ((ref4 = this.colorful) != null ? ref4 : colorsEnabled) {


### PR DESCRIPTION
To avoid uncaught error "Cannot read property 'isTTY' of undefined" with browserify and ect
