### PR TITLE
Optimises class creation when new arguments contain splats

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1037,7 +1037,7 @@
       }
       if (this.isNew) {
         idt = this.tab + TAB;
-        return [].concat(this.makeCode("(function(func, args, ctor) {\n" + idt + "ctor.prototype = func.prototype;\n" + idt + "var child = new ctor, result = func.apply(child, args);\n" + idt + "return Object(result) === result ? result : child;\n" + this.tab + "})("), this.variable.compileToFragments(o, LEVEL_LIST), this.makeCode(", "), splatArgs, this.makeCode(", function(){})"));
+        return [].concat(this.makeCode((utility('applyCtor', o)) + "("), this.variable.compileToFragments(o, LEVEL_LIST), this.makeCode(", "), splatArgs, this.makeCode(")"));
       }
       answer = [];
       base = new Value(this.variable);
@@ -3177,6 +3177,9 @@
   UTILITIES = {
     extend: function(o) {
       return "function(child, parent) { for (var key in parent) { if (" + (utility('hasProp', o)) + ".call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; }";
+    },
+    applyCtor: function(ctor, args) {
+      return "function(ctor, args) { var child = Object.create(ctor.prototype); var result = ctor.apply(child, args); return result && Object(result) === result ? result : child; }";
     },
     bind: function() {
       return 'function(fn, me){ return function(){ return fn.apply(me, arguments); }; }';

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -700,8 +700,8 @@ exports.Call = class Call extends Base
 
   # If you call a function with a splat, it's converted into a JavaScript
   # `.apply()` call to allow an array of arguments to be passed.
-  # If it's a constructor, then things get real tricky. We have to inject an
-  # inner constructor in order to be able to pass the varargs.
+  # If it's a class constructor then we create a new Object
+  # and apply the class constructor to the Object instance
   #
   # splatArgs is an array of CodeFragments to put into the 'apply'.
   compileSplat: (o, splatArgs) ->
@@ -711,14 +711,9 @@ exports.Call = class Call extends Base
 
     if @isNew
       idt = @tab + TAB
-      return [].concat @makeCode("""
-        (function(func, args, ctor) {
-        #{idt}ctor.prototype = func.prototype;
-        #{idt}var child = new ctor, result = func.apply(child, args);
-        #{idt}return Object(result) === result ? result : child;
-        #{@tab}})("""),
+      return [].concat @makeCode("#{ utility 'applyCtor', o }("),
         (@variable.compileToFragments o, LEVEL_LIST),
-        @makeCode(", "), splatArgs, @makeCode(", function(){})")
+        @makeCode(", "), splatArgs, @makeCode(")")
 
     answer = []
     base = new Value @variable
@@ -2245,7 +2240,14 @@ UTILITIES =
       return child;
     }
   "
-
+  # Creates and applies arguments to a class constructor.
+  applyCtor: (ctor, args) -> "
+    function(ctor, args) {
+      var child = Object.create(ctor.prototype);
+      var result = ctor.apply(child, args);
+      return result && Object(result) === result ? result : child;
+    }
+  "
   # Create a function bound to the current value of "this".
   bind: -> '
     function(fn, me){


### PR DESCRIPTION
Comparison of 100000 iterations heap memory ->

Before:
![image](https://cloud.githubusercontent.com/assets/1727302/6888677/5ff097f6-d67d-11e4-865b-bd525734ab6e.png)

After:
![image](https://cloud.githubusercontent.com/assets/1727302/6888663/28eacdc6-d67d-11e4-9088-d8d35bc86602.png)

Script source used and other comparisons [here](https://github.com/jashkenas/coffeescript/issues/3236#issuecomment-85102994)

This also results in being 5 times faster than it's predecessor.

closes #3236 