### PR TITLE
use markdown parser to identify code blocks in literate coffeescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "test":         "node ./bin/cake test",
+    "test": "node ./bin/cake test",
     "test-harmony": "node --harmony ./bin/cake test"
   },
   "homepage": "http://coffeescript.org",
@@ -38,5 +38,8 @@
     "highlight.js": "~8.0.0",
     "underscore": "~1.5.2",
     "docco": "~0.7.0"
+  },
+  "dependencies": {
+    "marked": "~0.3.3"
   }
 }

--- a/test/literate.litcoffee
+++ b/test/literate.litcoffee
@@ -55,3 +55,111 @@ Tabs work too:
 
 				test "tabbed code", ->
 					ok yes
+
+---
+
+    # keep track of whether code blocks are executed or not
+    executed = false
+
+<p>
+
+    executed = true # should not execute, this is just HTML para, not code!
+
+</p>
+
+    test "should ignore indented sections inside HTML", ->
+      eq executed, false
+
+---
+
+*   A list item with a code block:
+
+        test "basic literate CoffeeScript parsing", ->
+          ok yes
+
+---
+
+*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
+    viverra nec, fringilla in, laoreet vitae, risus.
+
+*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
+    Suspendisse id sem consectetuer libero luctus adipiscing.
+
+---
+
+1.  This is a list item with two paragraphs. Lorem ipsum dolor
+    sit amet, consectetuer adipiscing elit. Aliquam hendrerit
+    mi posuere lectus.
+
+    Vestibulum enim wisi, viverra nec, fringilla in, laoreet
+    vitae, risus. Donec sit amet nisl. Aliquam semper ipsum
+    sit amet velit.
+
+2.  Suspendisse id sem consectetuer libero luctus adipiscing.
+
+---
+
+1.  This is a list item with two paragraphs. Lorem ipsum dolor
+    sit amet, consectetuer adipiscing elit. Aliquam hendrerit
+    mi posuere lectus.
+
+    Vestibulum enim wisi, viverra nec, fringilla in, laoreet
+    vitae, risus. Donec sit amet nisl. Aliquam semper ipsum
+    sit amet velit.
+
+2.  Suspendisse id sem consectetuer libero luctus adipiscing.
+
+---
+
+*   A list item with a blockquote:
+
+    > This is a blockquote
+    > inside a list item.
+
+---
+
+This next one probably passes because a string is inoffensive in compiled js, also, can't get `marked` to parse it correctly, and not sure if empty line is permitted between title and reference
+
+This is [an example][id] reference-style link.
+[id]: http://example.com/
+
+    "Optional Title Here"
+
+---
+
+    executed = no
+
+1986. What a great season.
+          executed = yes
+
+and test...
+
+    test "should recognise indented code blocks in lists", ->
+      ok executed
+
+---
+
+    executed = no
+
+1986. What a great season.
+
+          executed = yes
+
+and test...
+
+    test "should recognise indented code blocks in lists with empty line as separator", ->
+      ok executed
+
+---
+
+    executed = no
+
+1986\. What a great season.
+           executed = yes
+
+and test...
+
+    test "should ignore indented code in escaped list like number", ->
+      eq executed, no
+


### PR DESCRIPTION
There are many false positive matches for code blocks made by the current coffee-script parser which are not really code blocks in the markdown. This fixes it by using a markdown parser to identify code blocks.