### PR TITLE
fix write after FIN error when using repl via socket

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -185,7 +185,9 @@
         runInContext(opts.prelude, repl.context, 'prelude');
       }
       repl.on('exit', function() {
-        return repl.outputStream.write('\n');
+        if (!repl.rli.closed) {
+          return repl.outputStream.write('\n');
+        }
       });
       addMultilineHandler(repl);
       if (opts.historyFile) {

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -152,7 +152,7 @@ module.exports =
     opts = merge replDefaults, opts
     repl = nodeREPL.start opts
     runInContext opts.prelude, repl.context, 'prelude' if opts.prelude
-    repl.on 'exit', -> repl.outputStream.write '\n'
+    repl.on 'exit', -> repl.outputStream.write '\n' if not repl.rli.closed
     addMultilineHandler repl
     addHistory repl, opts.historyFile, opts.historyMaxInputSize if opts.historyFile
     # Adapt help inherited from the node REPL


### PR DESCRIPTION
if repl.outputStream is a socket, it is closed when 'exit' event
occurred, so write throws an exception

This is the test application code.

```
repl = require 'coffee-script/repl'
net = require 'net'

net.createServer (socket) ->
  repl.start
    prompt: 'test> '
    input: socket
    output: socket
  .on 'exit', ->
    socket.end()
.listen 5001
```