### PR TITLE
 fix history file descriptor leak

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -125,6 +125,7 @@
       readFd = fs.openSync(filename, 'r');
       buffer = new Buffer(size);
       fs.readSync(readFd, buffer, 0, size, stat.size - size);
+      fs.close(readFd);
       repl.rli.history = buffer.toString().split('\n').reverse();
       if (stat.size > maxSize) {
         repl.rli.history.pop();
@@ -142,7 +143,7 @@
         return lastLine = code;
       }
     });
-    repl.rli.on('exit', function() {
+    repl.on('exit', function() {
       return fs.close(fd);
     });
     return repl.commands[getCommandId(repl, 'history')] = {

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -108,6 +108,7 @@ addHistory = (repl, filename, maxSize) ->
     readFd = fs.openSync filename, 'r'
     buffer = new Buffer(size)
     fs.readSync readFd, buffer, 0, size, stat.size - size
+    fs.close readFd
     # Set the history on the interpreter
     repl.rli.history = buffer.toString().split('\n').reverse()
     # If the history file was truncated we should pop off a potential partial line
@@ -125,7 +126,7 @@ addHistory = (repl, filename, maxSize) ->
       fs.write fd, "#{code}\n"
       lastLine = code
 
-  repl.rli.on 'exit', -> fs.close fd
+  repl.on 'exit', -> fs.close fd
 
   # Add a command to show the history stack
   repl.commands[getCommandId(repl, 'history')] =


### PR DESCRIPTION
You can see history file remains open if you connect the repl via socket.

```
repl = require 'coffee-script/repl'
net = require 'net'

net.createServer (socket) ->
  repl.start
    prompt: 'test> '
    input: socket
    output: socket
    historyFile: __dirname + '/history'
  .on 'exit', ->
    socket.end()
.listen 5001
```