### PR TITLE
Fix #3965, sourcemaps for bare programs.

### DIFF
--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -62,7 +62,8 @@ exports.compile = compile = withPrettyErrors (code, options) ->
   for fragment in fragments
     # Update the sourcemap with data from each fragment
     if options.sourceMap
-      if fragment.locationData
+      # Do not include empty, whitespace, or semicolon-only fragments.
+      if fragment.locationData and not /^[;\s]*$/.test fragment.code
         map.add(
           [fragment.locationData.first_line, fragment.locationData.first_column]
           [currentLine, currentColumn]


### PR DESCRIPTION
Instead of mapping all generated spaces and semicolons and newlines
to the source position (0,0), we avoid generating sourcemap information
for generated space-or-semicolon-only fragments.

(In addition to shortening sourcemaps, this fixes a correctness issue
where an empty fragment at the beginning of each line maps from (0,0),
but in a bare program, that position at the begining of the line
should map from the actual source line.  When this conflict occurred,
(0,0) would win, resulting in an incorrect sourcemap, where each
top-level function call mapped to (0,0).)