### PR TITLE
Fix `CoffeeScript.nodes(tokens)`; fix the repl

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -34,6 +34,9 @@
         return fn.call(this, code, options);
       } catch (_error) {
         err = _error;
+        if (typeof code !== 'string') {
+          throw err;
+        }
         throw helpers.updateSyntaxError(err, code, options.filename);
       }
     };

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -26,6 +26,7 @@ withPrettyErrors = (fn) ->
     try
       fn.call @, code, options
     catch err
+      throw err if typeof code isnt 'string' # Support `CoffeeScript.nodes(tokens)`.
       throw helpers.updateSyntaxError err, code, options.filename
 
 # Compile CoffeeScript code to JavaScript, using the Coffee/Jison compiler.


### PR DESCRIPTION
If you passed an array of tokens (as opposed to a string of code) to
`CoffeeScript.nodes`, its attempts to prettify error messages would break. Now
it does not attempt to prettify error messages in that case anymore (because it
is not possible to prettify the errors without a string of code).

The repl was affected by the above bug.

Fixes #3887.