### PR TITLE
Save alias names in the origin of tokens

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -64,7 +64,7 @@
     };
 
     Lexer.prototype.identifierToken = function() {
-      var colon, colonOffset, forcedIdentifier, id, idLength, input, match, poppedToken, prev, ref2, ref3, ref4, ref5, tag, tagToken;
+      var alias, colon, colonOffset, forcedIdentifier, id, idLength, input, match, poppedToken, prev, ref2, ref3, ref4, ref5, tag, tagToken;
       if (!(match = IDENTIFIER.exec(this.chunk))) {
         return 0;
       }
@@ -118,6 +118,7 @@
       }
       if (!forcedIdentifier) {
         if (indexOf.call(COFFEE_ALIASES, id) >= 0) {
+          alias = id;
           id = COFFEE_ALIAS_MAP[id];
         }
         tag = (function() {
@@ -142,6 +143,9 @@
         })();
       }
       tagToken = this.token(tag, id, 0, idLength);
+      if (alias) {
+        tagToken.origin = [tag, alias, tagToken[2]];
+      }
       tagToken.variable = !forcedIdentifier;
       if (poppedToken) {
         ref5 = [poppedToken[2].first_line, poppedToken[2].first_column], tagToken[2].first_line = ref5[0], tagToken[2].first_column = ref5[1];
@@ -500,6 +504,9 @@
       ref2 = this.tokens, prev = ref2[ref2.length - 1];
       if (value === '=' && prev) {
         if (!prev[1].reserved && (ref3 = prev[1], indexOf.call(JS_FORBIDDEN, ref3) >= 0)) {
+          if (prev.origin) {
+            prev = prev.origin;
+          }
           this.error("reserved word '" + prev[1] + "' can't be assigned", prev[2]);
         }
         if ((ref4 = prev[1]) === '||' || ref4 === '&&') {

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -147,7 +147,9 @@ exports.Lexer = class Lexer
         @error "reserved word '#{id}'", length: id.length
 
     unless forcedIdentifier
-      id  = COFFEE_ALIAS_MAP[id] if id in COFFEE_ALIASES
+      if id in COFFEE_ALIASES
+        alias = id
+        id = COFFEE_ALIAS_MAP[id]
       tag = switch id
         when '!'                 then 'UNARY'
         when '==', '!='          then 'COMPARE'
@@ -157,6 +159,7 @@ exports.Lexer = class Lexer
         else  tag
 
     tagToken = @token tag, id, 0, idLength
+    tagToken.origin = [tag, alias, tagToken[2]] if alias
     tagToken.variable = not forcedIdentifier
     if poppedToken
       [tagToken[2].first_line, tagToken[2].first_column] =
@@ -405,6 +408,7 @@ exports.Lexer = class Lexer
     [..., prev] = @tokens
     if value is '=' and prev
       if not prev[1].reserved and prev[1] in JS_FORBIDDEN
+        prev = prev.origin if prev.origin
         @error "reserved word '#{prev[1]}' can't be assigned", prev[2]
       if prev[1] in ['||', '&&']
         prev[0] = 'COMPOUND_ASSIGN'

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -663,6 +663,14 @@ test "reserved words", ->
     for = 1
     ^^^
   '''
+  # #2306: Show unaliased name in error messages.
+  assertErrorFormat '''
+    on = 1
+  ''', '''
+    [stdin]:1:1: error: reserved word 'on' can't be assigned
+    on = 1
+    ^^
+  '''
 
 test "invalid numbers", ->
   assertErrorFormat '''


### PR DESCRIPTION
... and use it for "reserved word can't be assigned" errors. Fixes #2306.