### PR TITLE
 	Fix formatting of `#`-only lines in herecomments

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -74,7 +74,7 @@
     for (i = 0, len = fragments.length; i < len; i++) {
       fragment = fragments[i];
       if (options.sourceMap) {
-        if (fragment.locationData) {
+        if (fragment.locationData && !/^[;\s]*$/.test(fragment.code)) {
           map.add([fragment.locationData.first_line, fragment.locationData.first_column], [currentLine, currentColumn], {
             noReplace: true
           });

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -868,7 +868,7 @@
 
     Comment.prototype.compileNode = function(o, level) {
       var code, comment;
-      comment = this.comment.replace(/^(\s*)# /gm, "$1 * ");
+      comment = this.comment.replace(/^(\s*)#(?=\s)/gm, "$1 *");
       code = "/*" + (multident(comment, this.tab)) + (indexOf.call(comment, '\n') >= 0 ? "\n" + this.tab : '') + " */";
       if ((level || o.level) === LEVEL_TOP) {
         code = o.indent + code;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -584,7 +584,7 @@ exports.Comment = class Comment extends Base
   makeReturn:      THIS
 
   compileNode: (o, level) ->
-    comment = @comment.replace /^(\s*)# /gm, "$1 * "
+    comment = @comment.replace /^(\s*)#(?=\s)/gm, "$1 *"
     code = "/*#{multident comment, @tab}#{if '\n' in comment then "\n#{@tab}" else ''} */"
     code = o.indent + code if (level or o.level) is LEVEL_TOP
     [@makeCode("\n"), @makeCode(code)]


### PR DESCRIPTION
Before:

    $ ./bin/coffee -bpe '###
    > # paragraph 1
    > #
    > # paragraph 2
    > ###'
    /*
     * paragraph 1
    #
     * paragraph 2
     */

After:

    $ ./bin/coffee -bpe '###
    # paragraph 1
    #
    # paragraph 2
    ###'
    /*
     * paragraph 1
     *
     * paragraph 2
     */

This does not re-break #3638:

    $ ./bin/coffee -bpe '###
    > #/
    > ###'
    /*
    #/
     */