### PR TITLE
Use "Array.isArray" instead of "instanceof Array"

### DIFF
--- a/lib/coffee-script/browser.js
+++ b/lib/coffee-script/browser.js
@@ -97,7 +97,7 @@
     execute = function() {
       var param;
       param = coffees[index];
-      if (param instanceof Array) {
+      if (Array.isArray(param)) {
         CoffeeScript.run.apply(CoffeeScript, param);
         index++;
         return execute();

--- a/lib/coffee-script/helpers.js
+++ b/lib/coffee-script/helpers.js
@@ -67,7 +67,7 @@
     flattened = [];
     for (i = 0, len1 = array.length; i < len1; i++) {
       element = array[i];
-      if (element instanceof Array) {
+      if (Array.isArray(element)) {
         flattened = flattened.concat(flatten(element));
       } else {
         flattened.push(element);

--- a/src/browser.coffee
+++ b/src/browser.coffee
@@ -61,7 +61,7 @@ runScripts = ->
 
   execute = ->
     param = coffees[index]
-    if param instanceof Array
+    if Array.isArray param
       CoffeeScript.run param...
       index++
       execute()

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -49,7 +49,7 @@ extend = exports.extend = (object, properties) ->
 exports.flatten = flatten = (array) ->
   flattened = []
   for element in array
-    if element instanceof Array
+    if Array.isArray element
       flattened = flattened.concat flatten element
     else
       flattened.push element


### PR DESCRIPTION
Array.isArray allows arrays from another JS context to be properly handled. The specific use case here is to support jest, which sets up JS contexts using Node/io.js's "vm" module.

The downside to this patch is that IE8 needs a polyfill for Array.isArray. If IE8 support for the in-browser transform (not the output of the coffeescript compiler) is important, it would be simple to include a polyfill with coffee-script.