### PR TITLE
Replace "instanceof Array" in transformer with "[object Array]" comparison

### DIFF
--- a/lib/coffee-script/helpers.js
+++ b/lib/coffee-script/helpers.js
@@ -67,7 +67,7 @@
     flattened = [];
     for (i = 0, len1 = array.length; i < len1; i++) {
       element = array[i];
-      if (element instanceof Array) {
+      if ('[object Array]' === Object.prototype.toString.call(element)) {
         flattened = flattened.concat(flatten(element));
       } else {
         flattened.push(element);

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -49,7 +49,7 @@ extend = exports.extend = (object, properties) ->
 exports.flatten = flatten = (array) ->
   flattened = []
   for element in array
-    if element instanceof Array
+    if '[object Array]' is Object::toString.call element
       flattened = flattened.concat flatten element
     else
       flattened.push element


### PR DESCRIPTION
Testing with `'[object Array]' is Object::toString.call element` allows arrays from another JS context to be properly handled. The specific use case here is to support jest, which sets up JS contexts using Node/io.js's "vm" module. This approach works in ES3 environments in contrast with ES5's `Array.isArray`.