### PR TITLE
adds coverage reporting using nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ test/*.js
 examples/beautiful_code/parse.coffee
 *.gem
 /node_modules
+coverage
+nyc_output

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "bugs": "https://github.com/jashkenas/coffeescript/issues",
   "repository": {
     "type": "git",
-    "url": "gi:t//github.com/jashkenas/coffeescript.git"
+    "url": "git://github.com/jashkenas/coffeescript.git"
   },
   "devDependencies": {
     "docco": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -23,20 +23,22 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "test":         "node ./bin/cake test",
-    "test-harmony": "node --harmony ./bin/cake test"
+    "test": "node ./bin/cake test",
+    "test-harmony": "node --harmony ./bin/cake test",
+    "coverage": "nyc npm test && nyc report"
   },
   "homepage": "http://coffeescript.org",
   "bugs": "https://github.com/jashkenas/coffeescript/issues",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jashkenas/coffeescript.git"
+    "url": "gi:t//github.com/jashkenas/coffeescript.git"
   },
   "devDependencies": {
-    "uglify-js": "~2.2",
-    "jison": ">=0.2.0",
+    "docco": "~0.7.0",
     "highlight.js": "~8.0.0",
-    "underscore": "~1.5.2",
-    "docco": "~0.7.0"
+    "jison": ">=0.2.0",
+    "nyc": "^2.1.3",
+    "uglify-js": "~2.2",
+    "underscore": "~1.5.2"
   }
 }


### PR DESCRIPTION
This pull request adds coverage reporting using [nyc](https://www.npmjs.com/package/nyc):
- run `npm run coverage` to get a human readable coverage report.
- run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.

``` shell
passed 636 tests in 5.99 seconds 
-----------------------|-----------|-----------|-----------|-----------|
File                   |   % Stmts |% Branches |   % Funcs |   % Lines |
-----------------------|-----------|-----------|-----------|-----------|
   bin/                |       100 |       100 |       100 |       100 |
      cake             |       100 |       100 |       100 |       100 |
      coffee           |       100 |       100 |       100 |       100 |
   lib/coffee-script/  |     89.38 |     85.81 |     86.02 |     89.75 |
      cake.js          |     62.69 |     22.22 |     66.67 |     62.69 |
      coffee-script.js |     90.73 |     77.24 |     80.77 |     92.59 |
      command.js       |     30.26 |     22.35 |      12.5 |     30.49 |
      helpers.js       |     87.34 |     74.12 |        92 |     87.34 |
      index.js         |       100 |       100 |       100 |       100 |
      lexer.js         |     97.26 |     95.42 |     97.73 |     97.73 |
      nodes.js         |     97.32 |     93.04 |     97.83 |     97.44 |
      optparse.js      |      80.9 |     78.57 |      87.5 |      80.9 |
      parser.js        |     90.82 |     89.46 |     64.29 |     90.98 |
      register.js      |     95.45 |     57.14 |       100 |     95.45 |
      repl.js          |     89.06 |     69.39 |     82.35 |     89.06 |
      rewriter.js      |     96.71 |     91.72 |     97.87 |     97.58 |
      scope.js         |     94.68 |     85.71 |     94.12 |      97.8 |
      sourcemap.js     |     92.93 |     81.82 |     92.31 |     92.93 |
-----------------------|-----------|-----------|-----------|-----------|
All files              |      89.4 |     85.81 |     86.02 |     89.77 |
-----------------------|-----------|-----------|-----------|-----------|
```
