### PR TITLE
Don't copy arguments or caller from require

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -175,7 +175,7 @@
         ref3 = Object.getOwnPropertyNames(require);
         for (i = 0, len = ref3.length; i < len; i++) {
           r = ref3[i];
-          if (r !== 'paths') {
+          if (r !== 'paths' && r !== 'arguments' && r !== 'caller') {
             _require[r] = require[r];
           }
         }

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -157,7 +157,8 @@ exports.eval = (code, options = {}) ->
       sandbox.module  = _module  = new Module(options.modulename || 'eval')
       sandbox.require = _require = (path) ->  Module._load path, _module, true
       _module.filename = sandbox.__filename
-      _require[r] = require[r] for r in Object.getOwnPropertyNames require when r isnt 'paths'
+      for r in Object.getOwnPropertyNames require when r not in ['paths', 'arguments', 'caller']
+        _require[r] = require[r]
       # use the same hack node currently uses for their own REPL
       _require.paths = _module.paths = Module._nodeModulePaths process.cwd()
       _require.resolve = (request) -> Module._resolveFilename request, _module


### PR DESCRIPTION
Causes an error in io.js where strict-mode is set on internal modules.

Fixes: https://github.com/jashkenas/coffeescript/issues/3810

I'm trying to use CoffeeScript as part of the smoke tests for io.js releases and this is the blocker because it just doesn't run.