### PR TITLE
Reset @seenFor in lexer before tokenizing

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -23,6 +23,7 @@
       this.indents = [];
       this.ends = [];
       this.tokens = [];
+      this.seenFor = false;
       this.chunkLine = opts.line || 0;
       this.chunkColumn = opts.column || 0;
       code = this.clean(code);

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -42,6 +42,7 @@ exports.Lexer = class Lexer
     @indents    = []             # The stack of all current indentation levels.
     @ends       = []             # The stack for pairing up tokens.
     @tokens     = []             # Stream of parsed tokens in the form `['TYPE', value, location data]`.
+    @seenFor    = no             # Used to recognize FORIN and FOROF tokens.
 
     @chunkLine =
       opts.line or 0         # The start line for the current @chunk.

--- a/test/operators.coffee
+++ b/test/operators.coffee
@@ -215,6 +215,10 @@ test "#1714: lexer bug with raw range `for` followed by `in`", ->
   0 for [1..10] # comment ending
   ok not ('a' in ['b'])
 
+  # lexer state (specifically @seenFor) should be reset before each compilation
+  CoffeeScript.compile "0 for [1..2]"
+  CoffeeScript.compile "'a' in ['b']"
+
 test "#1099: statically determined `not in []` reporting incorrect result", ->
   ok 0 not in []
 


### PR DESCRIPTION
The #1714 bug still occurs when the lexer is used multiple times, e.g. in the REPL:

```coffeescript
$ coffee
coffee> 0 for [1..2]
[ 0, 0 ]
coffee> 'a' in ['b']
[stdin]:1:5: error: unexpected in
'a' in ['b']
    ^^
coffee> 'a' in ['b']
false
```

This PR fixes it by setting `@seenFor = no` in the same place the rest of the lexer state is initialized.