### PR TITLE
Remove unnecessary brackets and empty spaces around yield

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2567,7 +2567,7 @@
     };
 
     Op.prototype.compileYield = function(o) {
-      var op, parts;
+      var op, parts, ref3;
       parts = [];
       op = this.operator;
       if (o.scope.parent == null) {
@@ -2580,9 +2580,17 @@
           parts.push(this.first.expression.compileToFragments(o, LEVEL_OP));
         }
       } else {
-        parts.push([this.makeCode("(" + op + " ")]);
+        if (o.level >= LEVEL_PAREN) {
+          parts.push([this.makeCode("(")]);
+        }
+        parts.push([this.makeCode("" + op)]);
+        if (((ref3 = this.first.base) != null ? ref3.value : void 0) !== '') {
+          parts.push([this.makeCode(" ")]);
+        }
         parts.push(this.first.compileToFragments(o, LEVEL_OP));
-        parts.push([this.makeCode(")")]);
+        if (o.level >= LEVEL_PAREN) {
+          parts.push([this.makeCode(")")]);
+        }
       }
       return this.joinFragmentArrays(parts, '');
     };

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1837,9 +1837,11 @@ exports.Op = class Op extends Base
       else if @first.expression?
         parts.push @first.expression.compileToFragments o, LEVEL_OP
     else
-      parts.push [@makeCode "(#{op} "]
+      parts.push [@makeCode "("] if o.level >= LEVEL_PAREN
+      parts.push [@makeCode op]
+      parts.push [@makeCode " "] if @first.base?.value isnt ''
       parts.push @first.compileToFragments o, LEVEL_OP
-      parts.push [@makeCode ")"]
+      parts.push [@makeCode ")"] if o.level >= LEVEL_PAREN
     @joinFragmentArrays parts, ''
 
   compilePower: (o) ->


### PR DESCRIPTION
This removes unnecessary brackets and empty spaces around yield when not needed. We still need brackets for if(a === (yield)).