### PR TITLE
Fix compiler crash with renamed destrucured params with defaults

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2169,6 +2169,9 @@
           obj = obj.variable;
         }
         if (obj instanceof Assign) {
+          if (obj.value instanceof Assign) {
+            obj = obj.value;
+          }
           this.eachName(iterator, obj.value.unwrap());
         } else if (obj instanceof Splat) {
           node = obj.name.unwrap();

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1532,6 +1532,9 @@ exports.Param = class Param extends Base
         obj = obj.variable
       # * assignments within destructured parameters `{foo:bar}`
       if obj instanceof Assign
+        # ... possibly with a default value
+        if obj.value instanceof Assign
+          obj = obj.value
         @eachName iterator, obj.value.unwrap()
       # * splats within destructured parameters `[xs...]`
       else if obj instanceof Splat

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -149,6 +149,11 @@ test "destructuring in function definition", ->
     eq e, 4
   ).call context, {a: [1], d: 3}
 
+  (({a: aa = 1, b: bb = 2}) ->
+    eq 5, aa
+    eq 2, bb
+  ) {a: 5}
+
   ajax = (url, {
     async = true,
     beforeSend = (->),

--- a/test/strict.coffee
+++ b/test/strict.coffee
@@ -94,6 +94,8 @@ test "duplicate formal parameters are prohibited", ->
   strict '(_,[__,{_}])->',   'param, [param2, {param}]'
   strict '(__,[_,{_}])->',   'param, [param2, {param2}]'
   strict '({0:a,1:a})->',    '{0:param,1:param}'
+  strict '(a=b=true,a)->',   'param=assignment, param'
+  strict '({a=b=true},a)->', '{param=assignment}, param'
   # the following function expressions should **not** throw errors
   strictOk '(_,@_)->'
   strictOk '(@_,_...)->'


### PR DESCRIPTION
`({a = 1}) ->` and `({a: b}) ->` worked, but not the combination of the two:
`({a: b = 1}) ->`. That destrucuring worked for normal assignments, though:
`{a: b = 1} = c`. This commit fixes the param case.