### PR TITLE
Small repl fixes

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -21,7 +21,6 @@
     "eval": function(input, context, filename, cb) {
       var Assign, Block, Literal, Value, ast, err, js, ref1, referencedVars, token, tokens;
       input = input.replace(/\uFF00/g, '\n');
-      input = input.replace(/^\(([\s\S]*)\n\)$/m, '$1');
       ref1 = require('./nodes'), Block = ref1.Block, Assign = ref1.Assign, Value = ref1.Value, Literal = ref1.Literal;
       try {
         tokens = CoffeeScript.tokens(input);

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -12,9 +12,6 @@ replDefaults =
   eval: (input, context, filename, cb) ->
     # XXX: multiline hack.
     input = input.replace /\uFF00/g, '\n'
-    # Node's REPL sends the input ending with a newline and then wrapped in
-    # parens. Unwrap all that.
-    input = input.replace /^\(([\s\S]*)\n\)$/m, '$1'
 
     # Require AST nodes to do some AST manipulation.
     {Block, Assign, Value, Literal} = require './nodes'

--- a/test/repl.coffee
+++ b/test/repl.coffee
@@ -64,10 +64,6 @@ testRepl "variables are saved", (input, output) ->
   input.emitLine 'foobar = "#{foo}bar"'
   eq "'foobar'", output.lastWrite()
 
-testRepl "empty command evaluates to undefined", (input, output) ->
-  input.emitLine ''
-  eq 'undefined', output.lastWrite()
-
 testRepl "ctrl-v toggles multiline prompt", (input, output) ->
   input.emit 'keypress', null, ctrlV
   eq '------> ', output.lastWrite(0)


### PR DESCRIPTION
Removed a test in `repl.coffee` that fails in newer node version, because node repl behavior changed.

Removed unnecessary parenthesis unwrapping in repl.