### PR TITLE
Add incrementing index to make sourceURL unique

### DIFF
--- a/src/browser.coffee
+++ b/src/browser.coffee
@@ -25,11 +25,12 @@ return unless window?
 # JSON serializer, and tools for escaping unicode characters, we're good to go.
 # Ported from https://developer.mozilla.org/en-US/docs/DOM/window.btoa
 if btoa? and JSON? and unescape? and encodeURIComponent?
+  index=0
   compile = (code, options = {}) ->
     options.sourceMap = true
     options.inline = true
     {js, v3SourceMap} = CoffeeScript.compile code, options
-    "#{js}\n//# sourceMappingURL=data:application/json;base64,#{btoa unescape encodeURIComponent v3SourceMap}\n//# sourceURL=coffeescript"
+    "#{js}\n//# sourceMappingURL=data:application/json;base64,#{btoa unescape encodeURIComponent v3SourceMap}\n//# sourceURL=coffeescript#{index++}"
 
 # Load a remote script from the current domain via XHR.
 CoffeeScript.load = (url, callback, options = {}, hold = false) ->


### PR DESCRIPTION
Firefox debugging with source maps and multiple in browser transpiled coffeescript segments fails miserably.
Adding index helps debugger to be able to use breakpoints etc.
