### PR TITLE
Allow `throw null`

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -248,7 +248,7 @@
       if (CoffeeScript.listeners('failure').length) {
         return;
       }
-      message = err.stack || ("" + err);
+      message = (err != null ? err.stack : void 0) || ("" + err);
       if (o.watch) {
         return printLine(message + '\x07');
       } else {

--- a/lib/coffee-script/helpers.js
+++ b/lib/coffee-script/helpers.js
@@ -192,7 +192,7 @@
   };
 
   exports.updateSyntaxError = function(error, code, filename) {
-    if (error.toString === syntaxErrorToString) {
+    if ((error != null ? error.toString : void 0) === syntaxErrorToString) {
       error.code || (error.code = code);
       error.filename || (error.filename = filename);
       error.stack = error.toString();

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -197,7 +197,7 @@ compileScript = (file, input, base = null) ->
   catch err
     CoffeeScript.emit 'failure', err, task
     return if CoffeeScript.listeners('failure').length
-    message = err.stack or "#{err}"
+    message = err?.stack or "#{err}"
     if o.watch
       printLine message + '\x07'
     else

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -151,7 +151,7 @@ exports.throwSyntaxError = (message, location) ->
 # it already.
 exports.updateSyntaxError = (error, code, filename) ->
   # Avoid screwing up the `stack` property of other errors (i.e. possible bugs).
-  if error.toString is syntaxErrorToString
+  if error?.toString is syntaxErrorToString
     error.code or= code
     error.filename or= filename
     error.stack = error.toString()

--- a/test/exception_handling.coffee
+++ b/test/exception_handling.coffee
@@ -140,3 +140,10 @@ test "parameter-less catch clause", ->
   try throw new Error 'failed' catch finally ok true
 
   ok try throw new Error 'failed' catch then true
+
+test "Allow throwing `null`", ->
+	try
+		throw null
+	catch err
+		error = err
+	ok error is null

--- a/test/helpers.coffee
+++ b/test/helpers.coffee
@@ -2,7 +2,7 @@
 # -------
 
 # pull the helpers from `CoffeeScript.helpers` into local variables
-{starts, ends, repeat, compact, count, merge, extend, flatten, del, baseFileName} = CoffeeScript.helpers
+{starts, ends, repeat, compact, count, merge, extend, flatten, del, baseFileName, updateSyntaxError} = CoffeeScript.helpers
 
 
 # `starts`
@@ -123,3 +123,6 @@ test "the `baseFileName` helper returns the file name to write to", ->
     name = baseFileName sourceFileName, yes
     filename = name + ext
     eq filename, expectedFileName
+
+test "the `updateSyntaxError` helper handles `null` argument", ->
+    eq null, updateSyntaxError null


### PR DESCRIPTION
Throwing `null` results in a `TypeError` due to a property check in `helpers.updateSyntaxError` and an `err.stack` access in `command.compileScript()`
