### PR TITLE
Fix #4137: Caught errors named `undefined`

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2740,7 +2740,9 @@
       tryPart = this.attempt.compileToFragments(o, LEVEL_TOP);
       catchPart = this.recovery ? (generatedErrorVariableName = o.scope.freeVariable('error', {
         reserve: false
-      }), placeholder = new Literal(generatedErrorVariableName), this.errorVariable ? this.recovery.unshift(new Assign(this.errorVariable, placeholder)) : void 0, [].concat(this.makeCode(" catch ("), placeholder.compileToFragments(o), this.makeCode(") {\n"), this.recovery.compileToFragments(o, LEVEL_TOP), this.makeCode("\n" + this.tab + "}"))) : !(this.ensure || this.recovery) ? [this.makeCode(" catch (" + generatedErrorVariableName + ") {}")] : [];
+      }), placeholder = new Literal(generatedErrorVariableName), this.errorVariable ? this.recovery.unshift(new Assign(this.errorVariable, placeholder)) : void 0, [].concat(this.makeCode(" catch ("), placeholder.compileToFragments(o), this.makeCode(") {\n"), this.recovery.compileToFragments(o, LEVEL_TOP), this.makeCode("\n" + this.tab + "}"))) : !(this.ensure || this.recovery) ? (generatedErrorVariableName = o.scope.freeVariable('error', {
+        reserve: false
+      }), [this.makeCode(" catch (" + generatedErrorVariableName + ") {}")]) : [];
       ensurePart = this.ensure ? [].concat(this.makeCode(" finally {\n"), this.ensure.compileToFragments(o, LEVEL_TOP), this.makeCode("\n" + this.tab + "}")) : [];
       return [].concat(this.makeCode(this.tab + "try {\n"), tryPart, this.makeCode("\n" + this.tab + "}"), catchPart, ensurePart);
     };

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -135,7 +135,7 @@
       }
       repl.rli.historyIndex = -1;
       lastLine = repl.rli.history[0];
-    } catch (undefined) {}
+    } catch (error) {}
     fd = fs.openSync(filename, 'a');
     repl.rli.addListener('line', function(code) {
       if (code && code.length && code !== '.history' && lastLine !== code) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1931,6 +1931,7 @@ exports.Try = class Try extends Base
       [].concat @makeCode(" catch ("), placeholder.compileToFragments(o), @makeCode(") {\n"),
         @recovery.compileToFragments(o, LEVEL_TOP), @makeCode("\n#{@tab}}")
     else unless @ensure or @recovery
+      generatedErrorVariableName = o.scope.freeVariable 'error', reserve: no
       [@makeCode(" catch (#{generatedErrorVariableName}) {}")]
     else
       []


### PR DESCRIPTION
Previously, `catch`-less `try`s named the caught error `undefined`, instead of
`error` like usual.

I don’t know how/if to test this, which is why I included no test.