### PR TITLE
Pipe Operator

### DIFF
--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -582,6 +582,9 @@ grammar =
     # [The existential operator](http://jashkenas.github.com/coffee-script/#existence).
     o 'Expression ?',                           -> new Existence $1
 
+    o 'Expression PIPE Value',                  -> new Call $3, [$1]
+    o 'Expression PIPE Invocation',             -> $3.pipe $1
+
     o 'Expression +  Expression',               -> new Op '+' , $1, $3
     o 'Expression -  Expression',               -> new Op '-' , $1, $3
 
@@ -631,6 +634,7 @@ operators = [
   ['left',      'RELATION']
   ['left',      'COMPARE']
   ['left',      'LOGIC']
+  ['left',      'PIPE']
   ['nonassoc',  'INDENT', 'OUTDENT']
   ['right',     'YIELD']
   ['right',     '=', ':', 'COMPOUND_ASSIGN', 'RETURN', 'THROW', 'EXTENDS']

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -377,7 +377,6 @@ exports.Lexer = class Lexer
   # as being "spaced", because there are some cases where it makes a difference.
   whitespaceToken: ->
     return 0 unless (match = WHITESPACE.exec @chunk) or
-                    (match = /^\s+(?=\|>)/.exec @chunk) or
                     (nline = @chunk.charAt(0) is '\n')
     [..., prev] = @tokens
     prev[if match then 'spaced' else 'newLine'] = true if prev
@@ -685,7 +684,7 @@ exports.Lexer = class Lexer
   unfinished: ->
     LINE_CONTINUER.test(@chunk) or
     @tag() in ['\\', '.', '?.', '?::', 'UNARY', 'MATH', 'UNARY_MATH', '+', '-',
-               '**', 'SHIFT', 'RELATION', 'COMPARE', 'LOGIC', 'THROW', 'EXTENDS', 'PIPE']
+               '**', 'SHIFT', 'RELATION', 'COMPARE', 'LOGIC', 'THROW', 'EXTENDS']
 
   formatString: (str) ->
     str.replace STRING_OMIT, '$1'
@@ -871,7 +870,7 @@ POSSIBLY_DIVISION   = /// ^ /=?\s ///
 # Other regexes.
 HERECOMMENT_ILLEGAL = /\*\//
 
-LINE_CONTINUER      = /// ^ \s* (?: , | \??\.(?![.\d]) | :: ) ///
+LINE_CONTINUER      = /// ^ \s* (?: , | \??\.(?![.\d]) | :: | \|> ) ///
 
 INVALID_ESCAPE      = ///
   ( (?:^|[^\\]) (?:\\\\)* )        # make sure the escape isn’t escaped

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -377,6 +377,7 @@ exports.Lexer = class Lexer
   # as being "spaced", because there are some cases where it makes a difference.
   whitespaceToken: ->
     return 0 unless (match = WHITESPACE.exec @chunk) or
+                    (match = /^\s+(?=\|>)/.exec @chunk) or
                     (nline = @chunk.charAt(0) is '\n')
     [..., prev] = @tokens
     prev[if match then 'spaced' else 'newLine'] = true if prev

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -420,6 +420,7 @@ exports.Lexer = class Lexer
       tag = 'TERMINATOR'
     else if value in MATH            then tag = 'MATH'
     else if value in COMPARE         then tag = 'COMPARE'
+    else if value in PIPE            then tag = 'PIPE'
     else if value in COMPOUND_ASSIGN then tag = 'COMPOUND_ASSIGN'
     else if value in UNARY           then tag = 'UNARY'
     else if value in UNARY_MATH      then tag = 'UNARY_MATH'
@@ -683,7 +684,7 @@ exports.Lexer = class Lexer
   unfinished: ->
     LINE_CONTINUER.test(@chunk) or
     @tag() in ['\\', '.', '?.', '?::', 'UNARY', 'MATH', 'UNARY_MATH', '+', '-',
-               '**', 'SHIFT', 'RELATION', 'COMPARE', 'LOGIC', 'THROW', 'EXTENDS']
+               '**', 'SHIFT', 'RELATION', 'COMPARE', 'LOGIC', 'THROW', 'EXTENDS', 'PIPE']
 
   formatString: (str) ->
     str.replace STRING_OMIT, '$1'
@@ -806,6 +807,7 @@ NUMBER     = ///
 
 OPERATOR   = /// ^ (
   ?: [-=]>             # function
+   | \|>               # pipe
    | [-+*/%<>&|^!?=]=  # compound assign / compare
    | >>>=?             # zero-fill right shift
    | ([-+:])\1         # doubles
@@ -900,6 +902,8 @@ LOGIC = ['&&', '||', '&', '|', '^']
 
 # Bit-shifting tokens.
 SHIFT = ['<<', '>>', '>>>']
+
+PIPE = ['|>']
 
 # Comparison tokens.
 COMPARE = ['==', '!=', '<', '>', '<=', '>=']

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -609,6 +609,10 @@ exports.Call = class Call extends Base
 
   children: ['variable', 'args']
 
+  pipe: (arg) ->
+    @args.unshift arg
+    this
+
   # Tag this invocation as creating a new instance.
   newInstance: ->
     base = @variable?.base or @variable

--- a/test/pipe.coffee
+++ b/test/pipe.coffee
@@ -27,3 +27,13 @@ test "Pipe chain", ->
   eq 45, 4 |> mul(10) |> add 5
   eq 70, 4 |> add(10) |> mul 5
 
+test "Pipe on the next line", ->
+
+  fn = (x,y) -> "#{x},#{y}"
+
+  eq '1,2', 1
+    |> fn(2)
+
+  eq '1,2', 1
+    |> fn 2
+

--- a/test/pipe.coffee
+++ b/test/pipe.coffee
@@ -1,0 +1,29 @@
+
+test "Pipe to function", ->
+
+  fn = (x) -> x * 100
+
+  eq 100, 1 |> fn
+  eq 300, 3 |> fn
+
+test "Pipe to partialy filled function", ->
+
+  fn = (x,y) -> "#{x},#{y}"
+
+  eq '1,2', 1 |> fn(2)
+  eq '1,2', 1 |> fn 2
+
+test "Pipe chain", ->
+
+  f = (x) -> x * 10
+  g = (x) -> x + 5
+
+  eq 15, 1 |> f |> g
+  eq 60, 1 |> g |> f
+
+  add = (x,y) -> x + y
+  mul = (x,y) -> x * y
+
+  eq 45, 4 |> mul(10) |> add 5
+  eq 70, 4 |> add(10) |> mul 5
+


### PR DESCRIPTION
Pipe operator `|>` adds its right hand expression as first argument to the left hand function invocation.

Selecting first operand was a smart choice in Elixir as they don't have function currying. I think it's also a good choice for CoffeeScript, because of JS libraries common structure on accepting "subject" (i.e. `Object|Array|String|...`) as first arg.

An answer to #1339 and #3600

```coffeescript
_ = require 'lodash'

users = [
  { user: 'barney',  active: false, age: 37}
  { user: 'fred',    active: true,  age: 21}
  { user: 'pebbles', active: true,  age: 19}
]

youngest = users
  |> _.select('active')
  |> _.sortBy('age')
  |> _.first
  |> _.get('user')
  |> _.capitalize

console.log youngest
```