### PR TITLE
Fix scoping error

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -209,9 +209,11 @@
     for (i = 0, len = ref.length; i < len; i++) {
       ext = ref[i];
       if ((base = require.extensions)[ext] == null) {
+        (function (ext) {
         base[ext] = function() {
           throw new Error("Use CoffeeScript.register() or require the coffee-script/register module to require " + ext + " files.");
         };
+        })(ext);
       }
     }
   }


### PR DESCRIPTION
I understand these are generated files, but there's an error in the generated javascript. The `ext` variable isn't scoped, so the `ext` in the error string is always the last value in the array, regardless of what the actual error is.

I expect you will decline this PR, but I hope this will point you in the right direction.