### PR TITLE
Fix #4178: an issue of processing Unicode characters in stdin

### DIFF
--- a/lib/coffee-script/command.js
+++ b/lib/coffee-script/command.js
@@ -259,16 +259,16 @@
   };
 
   compileStdio = function() {
-    var code, stdin;
-    code = '';
+    var buffers, stdin;
+    buffers = [];
     stdin = process.openStdin();
     stdin.on('data', function(buffer) {
       if (buffer) {
-        return code += buffer.toString();
+        return buffers.push(buffer);
       }
     });
     return stdin.on('end', function() {
-      return compileScript(null, code);
+      return compileScript(null, Buffer.concat(buffers).toString());
     });
   };
 

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -207,12 +207,12 @@ compileScript = (file, input, base = null) ->
 # Attach the appropriate listeners to compile scripts incoming over **stdin**,
 # and write them back to **stdout**.
 compileStdio = ->
-  code = ''
+  buffers = []
   stdin = process.openStdin()
   stdin.on 'data', (buffer) ->
-    code += buffer.toString() if buffer
+    buffers.push buffer if buffer
   stdin.on 'end', ->
-    compileScript null, code
+    compileScript null, Buffer.concat(buffers).toString()
 
 # If all of the source files are done being read, concatenate and compile
 # them together.


### PR DESCRIPTION
To reproduce this bug, create a coffee file (for example abc.coffee) with approximately 150 lines of Unicode string, like this:

```coffee
a = """
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一一
<the remaining 140 lines>
"""
```

Then in node console:

```
input=fs.readFileSync("abc.coffee",{encoding:"utf8"})
```

Then:

```
child_process.execSync("coffee -bcs",{encoding:"utf8",input:input})
```

The return value will contain this:

```
一一一\\n一一一一一一一一一一一一一���一一一一一一一一一一一一一一一一一一一一一一
```

This can be reproduced on OS X, but seems not on Windows or Linux, maybe because Linux and Windows has a larger buffer size.

Reason: The current code uses "first convert then concat", but should be "first concat then convert".

The modified code has been tested. The built JS isn't included in this commit.