### PR TITLE
Fix getSourceMap with extention ".coffee.md"

### DIFF
--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -321,7 +321,8 @@ sourceMaps = {}
 # Generates the source map for a coffee file and stores it in the local cache variable.
 getSourceMap = (filename) ->
   return sourceMaps[filename] if sourceMaps[filename]
-  return unless path?.extname(filename) in exports.FILE_EXTENSIONS
+  return unless exports.FILE_EXTENSIONS.filter((suffix) -> filename.indexOf(suffix, filename.length - suffix.length) isnt -1).length
+  # return unless path?.extname(filename) in exports.FILE_EXTENSIONS
   answer = exports._compileFile filename, true
   sourceMaps[filename] = answer.sourceMap
 


### PR DESCRIPTION
The call `path?.extname(filename) in exports.FILE_EXTENSIONS` fails for extension ".coffee.md" because extname return only ".md". This produce  incorrect line numbers The current approad fixes the issue by testing if the end of the filename match at least one extension.