### PR TITLE
Improve inline source maps generation

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -54,7 +54,7 @@
   };
 
   exports.compile = compile = withPrettyErrors(function(code, options) {
-    var answer, currentColumn, currentLine, extend, fragment, fragments, generateSourceMap, header, i, js, len, map, merge, newLines, ref, sourceMapDataURI, sourceURL, token, tokens, v3SourceMap;
+    var currentColumn, currentLine, encoded, extend, fragment, fragments, generateSourceMap, header, i, js, len, map, merge, newLines, ref, sourceMapDataURI, sourceURL, token, tokens, v3SourceMap;
     merge = helpers.merge, extend = helpers.extend;
     options = extend({}, options);
     generateSourceMap = options.sourceMap || options.inlineMap;
@@ -109,17 +109,17 @@
       v3SourceMap = map.generate(options, code);
     }
     if (options.inlineMap) {
-      sourceMapDataURI = "//# sourceMappingURL=data:application/json;base64," + (base64encode(v3SourceMap));
+      encoded = base64encode(JSON.stringify(v3SourceMap));
+      sourceMapDataURI = "//# sourceMappingURL=data:application/json;base64," + encoded;
       sourceURL = "//# sourceURL=" + ((ref = options.filename) != null ? ref : 'coffeescript');
       js = js + "\n" + sourceMapDataURI + "\n" + sourceURL;
     }
     if (options.sourceMap) {
-      answer = {
-        js: js
+      return {
+        js: js,
+        sourceMap: map,
+        v3SourceMap: JSON.stringify(v3SourceMap, null, 2)
       };
-      answer.sourceMap = map;
-      answer.v3SourceMap = v3SourceMap;
-      return answer;
     } else {
       return js;
     }
@@ -253,6 +253,7 @@
         filename: filename,
         sourceMap: sourceMap,
         inlineMap: inlineMap,
+        sourceFiles: [filename],
         literate: helpers.isLiterate(filename)
       });
     } catch (error) {

--- a/lib/coffee-script/sourcemap.js
+++ b/lib/coffee-script/sourcemap.js
@@ -116,10 +116,10 @@
         names: [],
         mappings: buffer
       };
-      if (options.inline) {
+      if (options.inlineMap) {
         v3.sourcesContent = [code];
       }
-      return JSON.stringify(v3, null, 2);
+      return v3;
     };
 
     VLQ_SHIFT = 5;

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -97,15 +97,17 @@ exports.compile = compile = withPrettyErrors (code, options) ->
     v3SourceMap = map.generate(options, code)
 
   if options.inlineMap
-    sourceMapDataURI = "//# sourceMappingURL=data:application/json;base64,#{base64encode v3SourceMap}"
+    encoded = base64encode JSON.stringify v3SourceMap
+    sourceMapDataURI = "//# sourceMappingURL=data:application/json;base64,#{encoded}"
     sourceURL = "//# sourceURL=#{options.filename ? 'coffeescript'}"
     js = "#{js}\n#{sourceMapDataURI}\n#{sourceURL}"
 
   if options.sourceMap
-    answer = {js}
-    answer.sourceMap = map
-    answer.v3SourceMap = v3SourceMap
-    answer
+    {
+      js
+      sourceMap: map
+      v3SourceMap: JSON.stringify v3SourceMap, null, 2
+    }
   else
     js
 
@@ -204,7 +206,11 @@ exports._compileFile = (filename, sourceMap = no, inlineMap = no) ->
   stripped = if raw.charCodeAt(0) is 0xFEFF then raw.substring 1 else raw
 
   try
-    answer = compile(stripped, {filename, sourceMap, inlineMap, literate: helpers.isLiterate filename})
+    answer = compile stripped, {
+      filename, sourceMap, inlineMap
+      sourceFiles: [filename]
+      literate: helpers.isLiterate filename
+    }
   catch err
     # As the filename and code of a dynamically loaded file will be different
     # from the original file compiled with CoffeeScript.run, add that

--- a/src/sourcemap.litcoffee
+++ b/src/sourcemap.litcoffee
@@ -126,9 +126,9 @@ Produce the canonical JSON object format for a "v3" source map.
           names:      []
           mappings:   buffer
 
-        v3.sourcesContent = [code] if options.inline
+        v3.sourcesContent = [code] if options.inlineMap
 
-        JSON.stringify v3, null, 2
+        v3
 
 
 Base64 VLQ Encoding


### PR DESCRIPTION
- Inline source maps are now shorter by not using pretty-printed JSON.
- `.register()`ed files are now given more information in their inline source
  maps: The name and contents of the source file.
- Some code cleanup.

If you decode the inline source map generated (when using `.register()`) for a
file test.coffee with the contents `console.log "it works!"`, here is the
output:

Before:

    {
      "version": 3,
      "file": "",
      "sourceRoot": "",
      "sources": [
        ""
      ],
      "names": [],
      "mappings": "AAAA;EAAA,OAAO,CAAC,GAAR,CAAY,eAAZ;AAAA"
    }

After:

    {"version":3,"file":"","sourceRoot":"","sources":["test.coffee"],"names":[],"mappings":"AAAA;EAAA,OAAO,CAAC,GAAR,CAAY,WAAZ;AAAA","sourcesContent":["console.log \"it works!\"\n"]}

Related: #4214.