### PR TITLE
Fix 'Error: EBADF: bad file descriptor, write' on `.exit` in REPL

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -138,7 +138,7 @@
     } catch (error) {}
     fd = fs.openSync(filename, 'a');
     repl.rli.addListener('line', function(code) {
-      if (code && code.length && code !== '.history' && lastLine !== code) {
+      if (code && code.length && code !== '.history' && code !== '.exit' && lastLine !== code) {
         fs.write(fd, code + "\n");
         return lastLine = code;
       }

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -121,7 +121,7 @@ addHistory = (repl, filename, maxSize) ->
   fd = fs.openSync filename, 'a'
 
   repl.rli.addListener 'line', (code) ->
-    if code and code.length and code isnt '.history' and lastLine isnt code
+    if code and code.length and code isnt '.history' and code isnt '.exit' and lastLine isnt code
       # Save the latest command in the file
       fs.write fd, "#{code}\n"
       lastLine = code


### PR DESCRIPTION
Fixes issue #4252.

> Running a simple coffee REPL with `coffee`, and exiting with `.exit`, it outputs this error:

> ```
fs.js:60
      throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
      ^
Error: EBADF: bad file descriptor, write
  at Error (native)
```

> It appears to be because it's trying to fd.write after fd.close() has been called.
> This seems like a simple thing, I'm surprised no one's reported this yet (looking at repo-issue and google searches). Am I missing something?

The issue only manifests with `.exit`, not `ctrl+d`, so this fixes it simply by not trying to write on `.exit`.

Thank you.