### PR TITLE
Allow mixing of tabs and spaces if an explicit tabstop size is set

### DIFF
--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -254,3 +254,11 @@ test "#1275: allow indentation before closing brackets", ->
     a = 1
    )
   eq 1, a
+
+test "allow mixing of spaces and tabs for indentation by passing a width for tabs to the lexer", ->
+  doesNotThrow -> CoffeeScript.compile '''
+    new Layer
+    		x: 0
+        y: 1
+    	 	z: 2
+  ''', tabSize: 2 


### PR DESCRIPTION
[“CoffeeScript just counts tabs and counts spaces -- you can't possibly expect it to guess how wide your text editor is configured to visually show tab characters.”](https://github.com/jashkenas/coffeescript/issues/2141#issuecomment-4180847)

But, what if you could tell CoffeeScript how wide a tab stop is? Following the [Robustness principle](https://en.wikipedia.org/wiki/Robustness_principle) I think it would be great if you could instruct CoffeeScript to treat indentation just as it is visually. This of course requires cooperation of the editor / environment or explicit configuration by the user, making this an opt-in feature ([we](https://framerjs.com) can do this).

I’ve read the discussions about tabs/spaces in a couple of issues and have seen that the sentiment generally is to not allow mixing, although it’s currently not enforced. However, while CoffeeScript is a really nice language to learn to program, the requirement to carefully manage your whitespace is quite unfriendly. The current behavior, where a tab is equivalent to a space in width is imho a poor choice: no editor is configured like that. (Python 2’s behavior of having a tabstop width of 8 makes a bit more sense).

The implementation in this pull request is mostly a ‘proof of concept’, to show what I’m talking about. Having this option would make parsing dependent on a specific option, meaning that some files won’t parse unless the exact right size is passed. A better way to do it (albeit still breaking backwards compatibility) might be to have it set via modeline at the start of the file.

I’m interested to hear from the maintainers and the community if anybody thinks pursuing a feature like this has merit.