### PR TITLE
Be much more careful about parsing `*` in import and export statements

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -68,7 +68,7 @@
     };
 
     Lexer.prototype.identifierToken = function() {
-      var alias, colon, colonOffset, id, idLength, input, match, poppedToken, prev, ref2, ref3, ref4, ref5, ref6, tag, tagToken;
+      var alias, colon, colonOffset, id, idLength, input, match, poppedToken, prev, ref2, ref3, ref4, ref5, tag, tagToken;
       if (!(match = IDENTIFIER.exec(this.chunk))) {
         return 0;
       }
@@ -83,7 +83,14 @@
         this.token('FROM', id);
         return id.length;
       }
-      if (id === 'as' && (this.seenImport || this.seenExport) && ((ref2 = this.tag()) === 'IDENTIFIER' || ref2 === 'IMPORT_ALL' || ref2 === 'EXPORT_ALL')) {
+      if (id === 'as' && this.seenImport && (this.tag() === 'IDENTIFIER' || this.value() === '*')) {
+        if (this.value() === '*') {
+          this.tokens[this.tokens.length - 1][0] = 'IMPORT_ALL';
+        }
+        this.token('AS', id);
+        return id.length;
+      }
+      if (id === 'as' && this.seenExport && this.tag() === 'IDENTIFIER') {
         this.token('AS', id);
         return id.length;
       }
@@ -91,11 +98,11 @@
         this.token('DEFAULT', id);
         return id.length;
       }
-      ref3 = this.tokens, prev = ref3[ref3.length - 1];
-      tag = colon || (prev != null) && (((ref4 = prev[0]) === '.' || ref4 === '?.' || ref4 === '::' || ref4 === '?::') || !prev.spaced && prev[0] === '@') ? 'PROPERTY' : 'IDENTIFIER';
+      ref2 = this.tokens, prev = ref2[ref2.length - 1];
+      tag = colon || (prev != null) && (((ref3 = prev[0]) === '.' || ref3 === '?.' || ref3 === '::' || ref3 === '?::') || !prev.spaced && prev[0] === '@') ? 'PROPERTY' : 'IDENTIFIER';
       if (tag === 'IDENTIFIER' && (indexOf.call(JS_KEYWORDS, id) >= 0 || indexOf.call(COFFEE_KEYWORDS, id) >= 0)) {
         tag = id.toUpperCase();
-        if (tag === 'WHEN' && (ref5 = this.tag(), indexOf.call(LINE_BREAK, ref5) >= 0)) {
+        if (tag === 'WHEN' && (ref4 = this.tag(), indexOf.call(LINE_BREAK, ref4) >= 0)) {
           tag = 'LEADING_WHEN';
         } else if (tag === 'FOR') {
           this.seenFor = true;
@@ -157,7 +164,7 @@
         tagToken.origin = [tag, alias, tagToken[2]];
       }
       if (poppedToken) {
-        ref6 = [poppedToken[2].first_line, poppedToken[2].first_column], tagToken[2].first_line = ref6[0], tagToken[2].first_column = ref6[1];
+        ref5 = [poppedToken[2].first_line, poppedToken[2].first_column], tagToken[2].first_line = ref5[0], tagToken[2].first_column = ref5[1];
       }
       if (colon) {
         colonOffset = input.lastIndexOf(':');
@@ -540,8 +547,8 @@
       if (value === ';') {
         this.seenFor = this.seenImport = this.seenExport = false;
         tag = 'TERMINATOR';
-      } else if (value === '*' && this.indent === 0 && (this.seenImport || this.seenExport)) {
-        tag = this.seenImport ? 'IMPORT_ALL' : 'EXPORT_ALL';
+      } else if (value === '*' && prev[0] === 'EXPORT') {
+        tag = 'EXPORT_ALL';
       } else if (indexOf.call(MATH, value) >= 0) {
         tag = 'MATH';
       } else if (indexOf.call(COMPARE, value) >= 0) {

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -115,7 +115,11 @@ exports.Lexer = class Lexer
     if id is 'from' and @tag() is 'YIELD'
       @token 'FROM', id
       return id.length
-    if id is 'as' and (@seenImport or @seenExport) and @tag() in ['IDENTIFIER', 'IMPORT_ALL', 'EXPORT_ALL']
+    if id is 'as' and @seenImport and (@tag() is 'IDENTIFIER' or @value() is '*')
+      @tokens[@tokens.length - 1][0] = 'IMPORT_ALL' if @value() is '*'
+      @token 'AS', id
+      return id.length
+    if id is 'as' and @seenExport and @tag() is 'IDENTIFIER'
       @token 'AS', id
       return id.length
     if id is 'default' and @seenExport
@@ -450,8 +454,8 @@ exports.Lexer = class Lexer
     if value is ';'
       @seenFor = @seenImport = @seenExport = no
       tag = 'TERMINATOR'
-    else if value is '*' and @indent is 0 and (@seenImport or @seenExport)
-      tag = if @seenImport then 'IMPORT_ALL' else 'EXPORT_ALL'
+    else if value is '*' and prev[0] is 'EXPORT'
+      tag = 'EXPORT_ALL'
     else if value in MATH            then tag = 'MATH'
     else if value in COMPARE         then tag = 'COMPARE'
     else if value in COMPOUND_ASSIGN then tag = 'COMPOUND_ASSIGN'

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -608,6 +608,22 @@ test "`as` can be used as an alias name", ->
     } from 'lib';"""
   eq toJS(input), output
 
+test "`*` can be used in an expression on the same line as an export keyword", ->
+  input = "export foo = (x) -> x * x"
+  output = """
+    export var foo = function(x) {
+      return x * x;
+    };"""
+  eq toJS(input), output
+  input = "export default foo = (x) -> x * x"
+  output = """
+    var foo;
+
+    export default foo = function(x) {
+      return x * x;
+    };"""
+  eq toJS(input), output
+
 test "`*` and `from` can be used in an export default expression", ->
   input = """
     export default foo.extend


### PR DESCRIPTION
While writing the documentation for modules, I stumbled across a bug. Yes, I broke it already.

I was writing this as an example:
```coffee
export square = (x) -> x * x
```

Which choked on the `*`, because our check for whether `*` should be treated as `EXPORT_ALL` was whether we’ve seen an `EXPORT` token and that the indent was 0. [I knew that indent check was going to be trouble](https://github.com/GeoffreyBooth/coffeescript/pull/2#issuecomment-241963249); but I gave it a lot more thought this time, and noticed two things:

- In `import` statements, an `*` always precedes an `as`.
- In `export` statements, the only time `*` can appear is in a statement like `export * from 'lib'`

So I made the check for converting `*` to `IMPORT_ALL` or `EXPORT_ALL` much narrower, based on these two rules. This made my example compile properly, and broke no other tests. I added two new tests like this example, where `*` is used on the same line (and indentation level) as an `export` keyword. I also re-ran the [Meteor todos test](https://github.com/GeoffreyBooth/coffeescript-modules-test-meteor-todos).

@lydell you were wondering why we can’t just put `*` in the grammar? It’s because the lexer converts `*` to tag `MATH`, and I don’t want to write grammar like `EXPORT MATH FROM String`. That doesn’t make much sense, and then in `ExportAllDeclaration` I would need to filter whether `MATH` was an `*` and throw an error otherwise. Better to intercept `*` in the lexer and convert it to `IMPORT_ALL` or `EXPORT_ALL` there rather than `MATH`.