### PR TITLE
Pass through octal and binary literals as-is

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -211,9 +211,8 @@ exports.Lexer = class Lexer
       when 'o' then 8
       when 'x' then 16
       else null
+
     numberValue = if base? then parseInt(number[2..], base) else parseFloat(number)
-    if number.charAt(1) in ['b', 'o']
-      number = "0x#{numberValue.toString 16}"
 
     tag = if numberValue is Infinity then 'INFINITY' else 'NUMBER'
     @token tag, number, 0, lexedLength


### PR DESCRIPTION
See https://github.com/coffeescript6/discuss/issues/45

Note: I'm deliberately creating this PR towards branch 2 because it is not opt-in and I'm not sure how many current JS environments implement the binary and octal literals as ES2015 does.