### PR TITLE
Disallow exporting anonymous classes

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -1906,6 +1906,9 @@
         code.push(this.makeCode('default '));
       }
       if (!(this instanceof ExportDefaultDeclaration) && (this.clause instanceof Assign || this.clause instanceof Class)) {
+        if (this.clause instanceof Class && !this.clause.variable) {
+          this.clause.error('anonymous classes cannot be exported');
+        }
         code.push(this.makeCode('var '));
         this.clause.moduleDeclaration = 'export';
       }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1285,6 +1285,10 @@ exports.ExportDeclaration = class ExportDeclaration extends ModuleDeclaration
 
     if @ not instanceof ExportDefaultDeclaration and
        (@clause instanceof Assign or @clause instanceof Class)
+      # Prevent exporting an anonymous class; all exported members must be named
+      if @clause instanceof Class and not @clause.variable
+        @clause.error 'anonymous classes cannot be exported'
+
       # When the ES2015 `class` keyword is supported, don’t add a `var` here
       code.push @makeCode 'var '
       @clause.moduleDeclaration = 'export'

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1012,7 +1012,9 @@ test "anonymous classes cannot be exported", ->
       constructor: ->
         console.log 'hello, world!'
   ''', '''
-    SyntaxError: Unexpected token export
+    [stdin]:1:8: error: anonymous classes cannot be exported
+    export class
+           ^^^^^
   '''
 
 test "unless enclosed by curly braces, only * can be aliased", ->


### PR DESCRIPTION
See [this comment](https://github.com/jashkenas/coffeescript/pull/4300#pullrequestreview-4370786).

We had a test for making sure the compiler wasn’t allowing `export class` (without a name given for the class) but it was a poorly written test, and wasn’t actually checking that the export wasn’t happening. The error message it was checking for was actually getting thrown by the Node runtime (for not understanding the `export` keyword) rather than checking that anonymous classes can’t be exported.

I added a check in `nodes.coffee` that exported classes have names, and I fixed the test.