### PR TITLE
Call synchronous `fs` methods using the `Sync` variants

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -136,7 +136,7 @@ task 'build:parser', 'rebuild the Jison parser (run build first)', ->
   helpers.extend global, require('util')
   require 'jison'
   parser = require('./lib/coffee-script/grammar').parser
-  fs.writeFile 'lib/coffee-script/parser.js', parser.generate()
+  fs.writeFileSync 'lib/coffee-script/parser.js', parser.generate()
 
 task 'build:browser', 'rebuild the merged script for inclusion in the browser', ->
   code = ''

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -125,7 +125,7 @@
       readFd = fs.openSync(filename, 'r');
       buffer = new Buffer(size);
       fs.readSync(readFd, buffer, 0, size, stat.size - size);
-      fs.close(readFd);
+      fs.closeSync(readFd);
       repl.rli.history = buffer.toString().split('\n').reverse();
       if (stat.size > maxSize) {
         repl.rli.history.pop();
@@ -139,12 +139,12 @@
     fd = fs.openSync(filename, 'a');
     repl.rli.addListener('line', function(code) {
       if (code && code.length && code !== '.history' && code !== '.exit' && lastLine !== code) {
-        fs.write(fd, code + "\n");
+        fs.writeSync(fd, code + "\n");
         return lastLine = code;
       }
     });
     repl.on('exit', function() {
-      return fs.close(fd);
+      return fs.closeSync(fd);
     });
     return repl.commands[getCommandId(repl, 'history')] = {
       help: 'Show command history',

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -108,7 +108,7 @@ addHistory = (repl, filename, maxSize) ->
     readFd = fs.openSync filename, 'r'
     buffer = new Buffer(size)
     fs.readSync readFd, buffer, 0, size, stat.size - size
-    fs.close readFd
+    fs.closeSync readFd
     # Set the history on the interpreter
     repl.rli.history = buffer.toString().split('\n').reverse()
     # If the history file was truncated we should pop off a potential partial line
@@ -123,10 +123,10 @@ addHistory = (repl, filename, maxSize) ->
   repl.rli.addListener 'line', (code) ->
     if code and code.length and code isnt '.history' and code isnt '.exit' and lastLine isnt code
       # Save the latest command in the file
-      fs.write fd, "#{code}\n"
+      fs.writeSync fd, "#{code}\n"
       lastLine = code
 
-  repl.on 'exit', -> fs.close fd
+  repl.on 'exit', -> fs.closeSync fd
 
   # Add a command to show the history stack
   repl.commands[getCommandId(repl, 'history')] =

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -83,7 +83,7 @@ if require?
                       ^^
       """
     finally
-      fs.unlink 'test/syntax-error.coffee'
+      fs.unlinkSync 'test/syntax-error.coffee'
 
 
 test "#1096: unexpected generated tokens", ->


### PR DESCRIPTION
Node 7-nightly throws deprecation warnings when calling `fs` non-`Sync` functions without callbacks, for example `fs.close fd` instead of `fs.closeSync fd`. We always want the synchronous versions, so we should just call the *`Sync` methods in the first place.

As far as I know this should be backward-compatible through ancient versions of Node, so I’m submitting this against `master`. I couldn’t get Node 0.8.0 to run on my machine, but I tested this in both 0.12.17 and 6.9.0 and in each version the code built and the tests pass.