### PR TITLE
Node 6 deprecated `new Buffer` in favor of `Buffer.from` and `Buffer.…

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -26,7 +26,7 @@
   base64encode = function(src) {
     switch (false) {
       case typeof Buffer !== 'function':
-        return new Buffer(src).toString('base64');
+        return Buffer.from(src).toString('base64');
       case typeof btoa !== 'function':
         return btoa(src);
       default:

--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -123,7 +123,7 @@
       stat = fs.statSync(filename);
       size = Math.min(maxSize, stat.size);
       readFd = fs.openSync(filename, 'r');
-      buffer = new Buffer(size);
+      buffer = Buffer.alloc(size);
       fs.readSync(readFd, buffer, 0, size, stat.size - size);
       fs.close(readFd);
       repl.rli.history = buffer.toString().split('\n').reverse();
@@ -174,8 +174,8 @@
       ref1 = process.versions.node.split('.').map(function(n) {
         return parseInt(n);
       }), major = ref1[0], minor = ref1[1], build = ref1[2];
-      if (major === 0 && minor < 8) {
-        console.warn("Node 0.8.0+ required for CoffeeScript REPL");
+      if (major < 6) {
+        console.warn("Node 6+ required for CoffeeScript REPL");
         process.exit(1);
       }
       CoffeeScript.register();

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "compiler"
   ],
   "author": "Jeremy Ashkenas",
-  "version": "1.11.1",
+  "version": "2.0.0-alpha",
   "license": "MIT",
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=6.9.0"
   },
   "directories": {
     "lib": "./lib/coffee-script"

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -22,7 +22,7 @@ exports.helpers = helpers
 # Function that allows for btoa in both nodejs and the browser.
 base64encode = (src) -> switch
   when typeof Buffer is 'function'
-    new Buffer(src).toString('base64')
+    Buffer.from(src).toString('base64')
   when typeof btoa is 'function'
     btoa(src)
   else

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -106,7 +106,7 @@ addHistory = (repl, filename, maxSize) ->
     size = Math.min maxSize, stat.size
     # Read last `size` bytes from the file
     readFd = fs.openSync filename, 'r'
-    buffer = new Buffer(size)
+    buffer = Buffer.alloc size
     fs.readSync readFd, buffer, 0, size, stat.size - size
     fs.close readFd
     # Set the history on the interpreter
@@ -144,8 +144,8 @@ module.exports =
   start: (opts = {}) ->
     [major, minor, build] = process.versions.node.split('.').map (n) -> parseInt(n)
 
-    if major is 0 and minor < 8
-      console.warn "Node 0.8.0+ required for CoffeeScript REPL"
+    if major < 6
+      console.warn "Node 6+ required for CoffeeScript REPL"
       process.exit 1
 
     CoffeeScript.register()

--- a/test/repl.coffee
+++ b/test/repl.coffee
@@ -13,7 +13,7 @@ class MockInputStream extends Stream
   resume: ->
 
   emitLine: (val) ->
-    @emit 'data', new Buffer("#{val}\n")
+    @emit 'data', Buffer.from("#{val}\n")
 
 class MockOutputStream extends Stream
   constructor: ->
@@ -21,7 +21,7 @@ class MockOutputStream extends Stream
     @written = []
 
   write: (data) ->
-    #console.log 'output write', arguments
+    # console.log 'output write', arguments
     @written.push data
 
   lastWrite: (fromEnd = -1) ->


### PR DESCRIPTION
Node 6 [deprecated `new Buffer` in favor of `Buffer.from` and `Buffer.alloc`](https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe). This PR updates our calls to `Buffer` to use the new syntax. As a result of that, I also set the required version of Node per `package.json` to be >= 6.9.0, and set the overall version of the project to be 2.0.0-alpha for now.