### PR TITLE
Selectively ignore CS-only keywords in ES imports and exports

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -27,6 +27,7 @@
       this.seenFor = false;
       this.seenImport = false;
       this.seenExport = false;
+      this.exportList = false;
       this.chunkLine = opts.line || 0;
       this.chunkColumn = opts.column || 0;
       code = this.clean(code);
@@ -68,7 +69,7 @@
     };
 
     Lexer.prototype.identifierToken = function() {
-      var alias, colon, colonOffset, id, idLength, input, match, poppedToken, prev, ref2, ref3, ref4, ref5, tag, tagToken;
+      var alias, colon, colonOffset, id, idLength, input, match, poppedToken, prev, ref2, ref3, ref4, ref5, ref6, tag, tagToken;
       if (!(match = IDENTIFIER.exec(this.chunk))) {
         return 0;
       }
@@ -83,12 +84,18 @@
         this.token('FROM', id);
         return id.length;
       }
-      if (id === 'as' && this.seenImport && (this.tag() === 'IDENTIFIER' || this.value() === '*')) {
-        if (this.value() === '*') {
-          this.tokens[this.tokens.length - 1][0] = 'IMPORT_ALL';
+      if (id === 'as' && this.seenImport) {
+        while (true) {
+          if (this.value() === '*') {
+            this.tokens[this.tokens.length - 1][0] = 'IMPORT_ALL';
+          } else if (ref2 = this.value(), indexOf.call(COFFEE_KEYWORDS, ref2) >= 0) {
+            this.tokens[this.tokens.length - 1][0] = 'IDENTIFIER';
+          } else if (this.tag() !== 'IDENTIFIER') {
+            break;
+          }
+          this.token('AS', id);
+          return id.length;
         }
-        this.token('AS', id);
-        return id.length;
       }
       if (id === 'as' && this.seenExport && this.tag() === 'IDENTIFIER') {
         this.token('AS', id);
@@ -98,11 +105,11 @@
         this.token('DEFAULT', id);
         return id.length;
       }
-      ref2 = this.tokens, prev = ref2[ref2.length - 1];
-      tag = colon || (prev != null) && (((ref3 = prev[0]) === '.' || ref3 === '?.' || ref3 === '::' || ref3 === '?::') || !prev.spaced && prev[0] === '@') ? 'PROPERTY' : 'IDENTIFIER';
-      if (tag === 'IDENTIFIER' && (indexOf.call(JS_KEYWORDS, id) >= 0 || indexOf.call(COFFEE_KEYWORDS, id) >= 0)) {
+      ref3 = this.tokens, prev = ref3[ref3.length - 1];
+      tag = colon || (prev != null) && (((ref4 = prev[0]) === '.' || ref4 === '?.' || ref4 === '::' || ref4 === '?::') || !prev.spaced && prev[0] === '@') ? 'PROPERTY' : 'IDENTIFIER';
+      if (tag === 'IDENTIFIER' && (indexOf.call(JS_KEYWORDS, id) >= 0 || indexOf.call(COFFEE_KEYWORDS, id) >= 0) && !(this.exportList && indexOf.call(COFFEE_KEYWORDS, id) >= 0)) {
         tag = id.toUpperCase();
-        if (tag === 'WHEN' && (ref4 = this.tag(), indexOf.call(LINE_BREAK, ref4) >= 0)) {
+        if (tag === 'WHEN' && (ref5 = this.tag(), indexOf.call(LINE_BREAK, ref5) >= 0)) {
           tag = 'LEADING_WHEN';
         } else if (tag === 'FOR') {
           this.seenFor = true;
@@ -164,7 +171,7 @@
         tagToken.origin = [tag, alias, tagToken[2]];
       }
       if (poppedToken) {
-        ref5 = [poppedToken[2].first_line, poppedToken[2].first_column], tagToken[2].first_line = ref5[0], tagToken[2].first_column = ref5[1];
+        ref6 = [poppedToken[2].first_line, poppedToken[2].first_column], tagToken[2].first_line = ref6[0], tagToken[2].first_column = ref6[1];
       }
       if (colon) {
         colonOffset = input.lastIndexOf(':');
@@ -554,6 +561,12 @@
         if (skipToken) {
           return value.length;
         }
+      }
+      if (value === '{' && (prev != null ? prev[0] : void 0) === 'EXPORT') {
+        this.exportList = true;
+      }
+      if (value === '}') {
+        this.exportList = false;
       }
       if (value === ';') {
         this.seenFor = this.seenImport = this.seenExport = false;

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1154,3 +1154,23 @@ test "imported members cannot be reassigned", ->
     export foo = 'bar'
            ^^^
   '''
+
+test "CS only keywords can't be used as unaliased names in import lists", ->
+  assertErrorFormat """
+    import { unless, baz as bar } from 'lib'
+    bar.barMethod()
+  """, '''
+    [stdin]:1:10: error: unexpected unless
+    import { unless, baz as bar } from 'lib'
+             ^^^^^^
+  '''
+
+test "CS only keywords can't be used as local names in import list aliases", ->
+  assertErrorFormat """
+    import { bar as unless, baz as bar } from 'lib'
+    bar.barMethod()
+  """, '''
+    [stdin]:1:17: error: unexpected unless
+    import { bar as unless, baz as bar } from 'lib'
+                    ^^^^^^
+  '''

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -638,18 +638,6 @@ test "CS only keywords can be used as imported names in import lists", ->
     bar.barMethod();"""
   eq toJS(input), output
 
-test "CS only keywords can't be used as unaliased names in import lists", ->
-  throws ->
-    CoffeeScript.compile """
-      import { unless, baz as bar } from 'lib'
-      bar.barMethod()"""
-
-test "CS only keywords can't be used as local names in import list aliases", ->
-  throws ->
-    CoffeeScript.compile """
-      import { bar as unless, baz as bar } from 'lib'
-      bar.barMethod()"""
-
 test "`*` can be used in an expression on the same line as an export keyword", ->
   input = "export foo = (x) -> x * x"
   output = """

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -510,6 +510,24 @@ test "export as aliases members imported from another module", ->
     } from 'lib';"""
   eq toJS(input), output
 
+test "export list can contain CS only keywords", ->
+  input = "export { unless } from 'lib'"
+  output = """
+    export {
+      unless
+    } from 'lib';"""
+  eq toJS(input), output
+
+test "export list can contain CS only keywords when aliasing", ->
+  input = "export { when as bar, baz as unless } from 'lib'"
+  output = """
+    export {
+      when as bar,
+      baz as unless
+    } from 'lib';"""
+  eq toJS(input), output
+
+
 
 # Edge cases
 
@@ -607,6 +625,30 @@ test "`as` can be used as an alias name", ->
       foo as as
     } from 'lib';"""
   eq toJS(input), output
+
+test "CS only keywords can be used as imported names in import lists", ->
+  input = """
+    import { unless as bar } from 'lib'
+    bar.barMethod()"""
+  output = """
+    import {
+      unless as bar
+    } from 'lib';
+
+    bar.barMethod();"""
+  eq toJS(input), output
+
+test "CS only keywords can't be used as unaliased names in import lists", ->
+  throws ->
+    CoffeeScript.compile """
+      import { unless, baz as bar } from 'lib'
+      bar.barMethod()"""
+
+test "CS only keywords can't be used as local names in import list aliases", ->
+  throws ->
+    CoffeeScript.compile """
+      import { bar as unless, baz as bar } from 'lib'
+      bar.barMethod()"""
 
 test "`*` can be used in an expression on the same line as an export keyword", ->
   input = "export foo = (x) -> x * x"


### PR DESCRIPTION
@GeoffreyBooth To address your JS interoperability concerns in #3757, this PR enables usage of CS-only keywords as local names in import lists and as any name in export lists. This will enable people to do the following

```js
// now possible
import {unless as someLocalName} from 'foo'

// but not
import {someImportedName as unless} from 'bar'

// for exports CS keywords are allowed everywhere
export {someLocalVar as unless}
export {unless, loop as until} from 'baz'
```