### PR TITLE
Docs for `for…from`

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -59,7 +59,7 @@ codeFor = ->
     cshtml = "<pre><code>#{hljs.highlight('coffeescript', cs).value}</code></pre>"
     # Temporary fix until highlight.js adds support for newer CoffeeScript keywords
     # Added in https://github.com/isagalaev/highlight.js/pull/1357, awaiting release
-    if file in ['generators', 'modules']
+    if file in ['generator_iteration', 'generators', 'modules']
       cshtml = cshtml.replace /(yield|import|export|from|as|default) /g, '<span class="keyword">$1</span> '
     jshtml = "<pre><code>#{hljs.highlight('javascript', js).value}</code></pre>"
     append = if executable is yes then '' else "alert(#{executable});"

--- a/documentation/examples/generator_iteration.coffee
+++ b/documentation/examples/generator_iteration.coffee
@@ -1,0 +1,13 @@
+fibonacci = ->
+  [previous, current] = [1, 1]
+  loop
+    [previous, current] = [current, previous + current]
+    yield current
+  return
+
+getFibonacciNumbers = (length) ->
+  results = [1]
+  for n from fibonacci()
+    results.push n
+    break if results.length is length
+  results

--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -107,8 +107,17 @@
       compiles one-to-one into the equivalent JS, and there is
       no interpretation at runtime. You can use any existing JavaScript library
       seamlessly from CoffeeScript (and vice-versa). The compiled output is
-      readable and pretty-printed, will work in every JavaScript runtime, and tends
-      to run as fast or faster than the equivalent handwritten JavaScript.
+      readable, pretty-printed, and tends to run as fast or faster than the
+      equivalent handwritten JavaScript.
+    </p>
+
+    <p>
+      The CoffeeScript compiler goes to great lengths to generate output JavaScript
+      that runs in every JavaScript runtime, but there are exceptions. Use
+      <a href="#generator-functions">generator functions</a> only if you know that your
+      <a href="http://kangax.github.io/compat-table/es6/#test-generators">target
+      runtimes can support them</a>. If you use <a href="#modules">modules</a>, you
+      will need to <a href="#modules-note">use an additional tool to resolve them</a>.
     </p>
 
     <p>
@@ -862,6 +871,7 @@ Block
       constructed.
     </p>
     <p>
+      <span id="generator-functions" class="bookmark"></span>
       CoffeeScript functions also support
       <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">ES2015 generator functions</a>
       through the <code>yield</code> keyword. There's no <code>function*(){}</code>
@@ -978,6 +988,7 @@ Block
     </p>
     <%= codeFor('modules') %>
     <p>
+      <span id="modules-note" class="bookmark"></span>
       Note that the CoffeeScript compiler <strong>does not resolve modules</strong>; writing an
       <code>import</code> or <code>export</code> statement in CoffeeScript will produce an
       <code>import</code> or <code>export</code> statement in the resulting output.

--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -573,6 +573,9 @@ Block
       <code>for own key, value of object</code>
     </p>
     <p>
+      To iterate a generator function, use <code>from</code>.
+      See <a href="#generator-iteration">Generator Functions</a>.
+    <p>
       The only low-level loop that CoffeeScript provides is the <b>while</b> loop. The
       main difference from JavaScript is that the <b>while</b> loop can be used
       as an expression, returning an array containing the result of each iteration
@@ -860,7 +863,7 @@ Block
     </p>
     <p>
       CoffeeScript functions also support
-      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">ES6 generator functions</a>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*">ES2015 generator functions</a>
       through the <code>yield</code> keyword. There's no <code>function*(){}</code>
       nonsense &mdash; a generator in CoffeeScript is simply a function that yields.
     </p>
@@ -869,6 +872,11 @@ Block
       <code>yield*</code> is called <code>yield from</code>, and <code>yield return</code>
       may be used if you need to force a generator that doesn't yield.
     </p>
+    <p>
+      <span id="generator-iteration" class="bookmark"></span>
+      You can iterate over a generator function using <code>for&hellip;from</code>.
+    </p>
+    <%= codeFor('generator_iteration', 'getFibonacciNumbers(10)') %>
 
     <p>
       <span id="embedded" class="bookmark"></span>
@@ -1388,7 +1396,7 @@ six = -&gt;
       <%= releaseHeader('2015-09-03', '1.10.0', '1.9.3') %>
       <ul>
         <li>
-          CoffeeScript now supports ES6-style destructuring defaults.
+          CoffeeScript now supports ES2015-style destructuring defaults.
         </li>
         <li>
           <code>(offsetHeight: height) -&gt;</code> no longer compiles. That
@@ -1497,7 +1505,7 @@ six = -&gt;
       <%= releaseHeader('2015-01-29', '1.9.0', '1.8.0') %>
       <ul>
         <li>
-          CoffeeScript now supports ES6 generators. A generator is simply a function
+          CoffeeScript now supports ES2015 generators. A generator is simply a function
           that <code>yield</code>s.
         </li>
         <li>


### PR DESCRIPTION
Documentation for #4355. This adds documentation for the new `for…from` syntax. I put it in the Bound and Generator Functions section, with a link from the Loops section. I’m open to persuasion that it should go the other way around.

I also added a [note](https://github.com/GeoffreyBooth/coffeescript/blob/2dc35716478f58318540cc6be6fc44ca1c67620d/documentation/index.html.js#L109) that the CoffeeScript compiler does not, in fact, output JavaScript that can run in every JavaScript runtime. It’s a sad day, I know. But really we should’ve added this note when we added support for generators, and certainly for modules.