### PR TITLE
Docs for triple-backticks and escaping backticks

### DIFF
--- a/documentation/examples/embedded_block.coffee
+++ b/documentation/examples/embedded_block.coffee
@@ -1,0 +1,5 @@
+```
+function time() {
+  return `The time is ${new Date().toLocaleTimeString()}`;
+}
+```

--- a/documentation/examples/embedded_escaped.coffee
+++ b/documentation/examples/embedded_escaped.coffee
@@ -1,0 +1,3 @@
+markdown = `function () {
+  return \`In Markdown, write code like \\\`this\\\`\`;
+}`

--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -887,8 +887,8 @@ Block
     </p>
     <%= codeFor('embedded_escaped', 'markdown()') %>
     <p>
-      You can embed blocks of JavaScript using triple backticks. Within triple-backtick
-      blocks, single backticks are ignored.
+      You can also embed blocks of JavaScript using triple backticks. That's easier
+      than escaping backticks, if you need them inside your JavaScript block.
     </p>
     <%= codeFor('embedded_block', 'time()') %>
 

--- a/documentation/index.html.js
+++ b/documentation/index.html.js
@@ -878,6 +878,19 @@ Block
       use backticks to pass it straight through.
     </p>
     <%= codeFor('embedded', 'hi()') %>
+    <p>
+      Escape backticks with backslashes: <code>\`</code> becomes <code>`</code>.
+    </p>
+    <p>
+      Escape backslashes before backticks with more backslashes: <code>\\\`</code>
+      becomes <code>\`</code>.
+    </p>
+    <%= codeFor('embedded_escaped', 'markdown()') %>
+    <p>
+      You can embed blocks of JavaScript using triple backticks. Within triple-backtick
+      blocks, single backticks are ignored.
+    </p>
+    <%= codeFor('embedded_block', 'time()') %>
 
     <p>
       <span id="switch" class="bookmark"></span>


### PR DESCRIPTION
Documentation for #4357. Demonstrates the new triple-backtick syntax, and how to escape backticks and escaped escaped backticks.