### PR TITLE
Fix the browser compiler crashing on extended characters in script blocks

### DIFF
--- a/lib/coffee-script/coffee-script.js
+++ b/lib/coffee-script/coffee-script.js
@@ -28,7 +28,9 @@
       case typeof Buffer !== 'function':
         return new Buffer(src).toString('base64');
       case typeof btoa !== 'function':
-        return btoa(src);
+        return btoa(encodeURIComponent(src).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+          return String.fromCharCode('0x' + p1);
+        }));
       default:
         throw new Error('Unable to base64 encode inline sourcemap.');
     }

--- a/src/coffee-script.coffee
+++ b/src/coffee-script.coffee
@@ -24,7 +24,12 @@ base64encode = (src) -> switch
   when typeof Buffer is 'function'
     new Buffer(src).toString('base64')
   when typeof btoa is 'function'
-    btoa(src)
+    # The contents of a <script> block are encoded via UTF-16, so if any extended
+    # characters are used in the block, btoa will fail as it maxes out at UTF-8.
+    # See https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem
+    # for the gory details, and for the solution implemented here.
+    btoa encodeURIComponent(src).replace /%([0-9A-F]{2})/g, (match, p1) ->
+      String.fromCharCode '0x' + p1
   else
     throw new Error('Unable to base64 encode inline sourcemap.')
 


### PR DESCRIPTION
Closes #4263, which is rather important because `test/test.html` has Japanese characters in a comment and therefore it doesn’t actually run in a browser without this fix 😄