### PR TITLE
Replace Uglify.js with Google Closure Compiler, JS version

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -169,10 +169,14 @@ task 'build:browser', 'rebuild the merged script for inclusion in the browser', 
     }(this));
   """
   unless process.env.MINIFY is 'false'
-    {code} = require('uglify-js').minify code, fromString: true
+    {compiledCode} = require('google-closure-compiler-js').compile
+      jsCode: [
+        src: code
+        languageOut: if majorVersion is 1 then 'ES5' else 'ES6'
+      ]
   outputFolder = "docs/v#{majorVersion}/browser-compiler"
   fs.mkdirSync outputFolder unless fs.existsSync outputFolder
-  fs.writeFileSync "#{outputFolder}/coffee-script.js", header + '\n' + code
+  fs.writeFileSync "#{outputFolder}/coffee-script.js", header + '\n' + compiledCode
   console.log "built ... running browser tests:"
   invoke 'test:browser'
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "preferGlobal": true,
   "scripts": {
-    "test":         "node ./bin/cake test",
+    "test": "node ./bin/cake test",
     "test-harmony": "node --harmony ./bin/cake test"
   },
   "homepage": "http://coffeescript.org",
@@ -39,10 +39,10 @@
     "url": "git://github.com/jashkenas/coffeescript.git"
   },
   "devDependencies": {
-    "uglify-js": "~2.7",
-    "jison": ">=0.4.17",
+    "docco": "~0.7.0",
+    "google-closure-compiler-js": "^20161024.0.0",
     "highlight.js": "~9.8.0",
-    "underscore": "~1.8.3",
-    "docco": "~0.7.0"
+    "jison": ">=0.4.17",
+    "underscore": "~1.8.3"
   }
 }


### PR DESCRIPTION
[closure-compiler-js](https://github.com/google/closure-compiler-js) can handle the CS2 input without complaint; and it also produces a compiled browser `.js` file half the size of Uglify.js, so why not use Closure Compiler for both branches?