### PR TITLE
Escape backticks and `${` within template literals; fixes #4380

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -3351,7 +3351,7 @@
     }
 
     StringWithInterpolations.prototype.compileNode = function(o) {
-      var element, elements, expr, fragments, j, len1;
+      var element, elements, expr, fragments, j, len1, value;
       if (!o.inTaggedTemplateCall) {
         return StringWithInterpolations.__super__.compileNode.apply(this, arguments);
       }
@@ -3372,7 +3372,10 @@
       for (j = 0, len1 = elements.length; j < len1; j++) {
         element = elements[j];
         if (element instanceof StringLiteral) {
-          fragments.push(this.makeCode(element.value.slice(1, -1)));
+          value = element.value.slice(1, -1);
+          value = value.replace(/`/g, '\\`');
+          value = value.replace(/\${/g, '\\${');
+          fragments.push(this.makeCode(value));
         } else {
           fragments.push(this.makeCode('${'));
           fragments.push.apply(fragments, element.compileToFragments(o, LEVEL_PAREN));

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -3373,8 +3373,13 @@
         element = elements[j];
         if (element instanceof StringLiteral) {
           value = element.value.slice(1, -1);
-          value = value.replace(/`/g, '\\`');
-          value = value.replace(/\${/g, '\\${');
+          value = value.replace(/(\\*)(`|\$\{)/g, function(match, backslashes, toBeEscaped) {
+            if (backslashes.length % 2 === 0) {
+              return backslashes + "\\" + toBeEscaped;
+            } else {
+              return match;
+            }
+          });
           fragments.push(this.makeCode(value));
         } else {
           fragments.push(this.makeCode('${'));

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2274,7 +2274,11 @@ exports.StringWithInterpolations = class StringWithInterpolations extends Parens
     fragments.push @makeCode '`'
     for element in elements
       if element instanceof StringLiteral
-        fragments.push @makeCode element.value.slice(1, -1)
+        value = element.value.slice(1, -1)
+        # Backticks or `${` inside template literals must be escaped
+        value = value.replace /`/g, '\\`'
+        value = value.replace /\${/g, '\\${'
+        fragments.push @makeCode value
       else
         fragments.push @makeCode '${'
         fragments.push element.compileToFragments(o, LEVEL_PAREN)...

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2276,8 +2276,11 @@ exports.StringWithInterpolations = class StringWithInterpolations extends Parens
       if element instanceof StringLiteral
         value = element.value.slice(1, -1)
         # Backticks or `${` inside template literals must be escaped
-        value = value.replace /`/g, '\\`'
-        value = value.replace /\${/g, '\\${'
+        value = value.replace /(\\*)(`|\$\{)/g, (match, backslashes, toBeEscaped) ->
+          if backslashes.length % 2 is 0
+            "#{backslashes}\\#{toBeEscaped}"
+          else
+            match
         fragments.push @makeCode value
       else
         fragments.push @makeCode '${'

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2274,8 +2274,8 @@ exports.StringWithInterpolations = class StringWithInterpolations extends Parens
     fragments.push @makeCode '`'
     for element in elements
       if element instanceof StringLiteral
-        value = element.value.slice(1, -1)
-        # Backticks or `${` inside template literals must be escaped
+        value = element.value[1...-1]
+        # Backticks and `${` inside template literals must be escaped.
         value = value.replace /(\\*)(`|\$\{)/g, (match, backslashes, toBeEscaped) ->
           if backslashes.length % 2 is 0
             "#{backslashes}\\#{toBeEscaped}"

--- a/test/tagged_template_literals.coffee
+++ b/test/tagged_template_literals.coffee
@@ -146,7 +146,7 @@ test "tagged template literal with escaped backticks", ->
   eq 'text: [ES template literals look like this: \\`foo bar\\`] expressions: []',
   func"ES template literals look like this: \\`foo bar\\`"
 
-test "tagged template literal with invalidly escaped backticks", ->
+test "tagged template literal with unnecessarily escaped backticks", ->
   eq 'text: [ES template literals look like this: `foo bar`] expressions: []',
   func"ES template literals look like this: \`foo bar\`"
 
@@ -162,7 +162,10 @@ test "tagged template literal with escaped ES interpolation", ->
   eq 'text: [ES template literals also look like this: `3 + 5 = \\${3+5}`] expressions: []',
   func"ES template literals also look like this: `3 + 5 = \\${3+5}`"
 
-test "tagged template literal with invalidly escaped ES interpolation", ->
-  eq 'text: [ES template literals also look like this: `3 + 5 = \${3+5}`] expressions: []',
+test "tagged template literal with unnecessarily escaped ES interpolation", ->
+  eq 'text: [ES template literals also look like this: `3 + 5 = ${3+5}`] expressions: []',
   func"ES template literals also look like this: `3 + 5 = \${3+5}`"
 
+test "tagged template literal special escaping", ->
+  eq 'text: [` ` \\` \\` \\\\` $ { ${ ${ \\${ \\${ \\\\${ | ` ${] expressions: [1]',
+  func"` \` \\` \\\` \\\\` $ { ${ \${ \\${ \\\${ \\\\${ #{1} ` ${"

--- a/test/tagged_template_literals.coffee
+++ b/test/tagged_template_literals.coffee
@@ -138,14 +138,31 @@ test "tagged template literal with an interpolated string that contains a tagged
   eq 'text: [inner tagged | literal] expressions: [text: [|] expressions: [template]]',
   func"inner tagged #{func"#{'template'}"} literal"
 
-test "tagged template literal with escaped backticks", ->
+test "tagged template literal with backticks", ->
   eq 'text: [ES template literals look like this: `foo bar`] expressions: []',
   func"ES template literals look like this: `foo bar`"
 
-test "tagged template literal with escaped interpolation", ->
+test "tagged template literal with escaped backticks", ->
+  eq 'text: [ES template literals look like this: \\`foo bar\\`] expressions: []',
+  func"ES template literals look like this: \\`foo bar\\`"
+
+test "tagged template literal with invalidly escaped backticks", ->
+  eq 'text: [ES template literals look like this: `foo bar`] expressions: []',
+  func"ES template literals look like this: \`foo bar\`"
+
+test "tagged template literal with ES interpolation", ->
   eq 'text: [ES template literals also look like this: `3 + 5 = ${3+5}`] expressions: []',
   func"ES template literals also look like this: `3 + 5 = ${3+5}`"
 
-test "tagged template literal with both escaped and unescaped interpolation", ->
+test "tagged template literal with both ES and CoffeeScript interpolation", ->
   eq "text: [ES template literals also look like this: `3 + 5 = ${3+5}` which equals |] expressions: [8]",
   func"ES template literals also look like this: `3 + 5 = ${3+5}` which equals #{3+5}"
+
+test "tagged template literal with escaped ES interpolation", ->
+  eq 'text: [ES template literals also look like this: `3 + 5 = \\${3+5}`] expressions: []',
+  func"ES template literals also look like this: `3 + 5 = \\${3+5}`"
+
+test "tagged template literal with invalidly escaped ES interpolation", ->
+  eq 'text: [ES template literals also look like this: `3 + 5 = \${3+5}`] expressions: []',
+  func"ES template literals also look like this: `3 + 5 = \${3+5}`"
+

--- a/test/tagged_template_literals.coffee
+++ b/test/tagged_template_literals.coffee
@@ -137,3 +137,15 @@ test "tagged template literal with an interpolated string that itself contains a
 test "tagged template literal with an interpolated string that contains a tagged template literal", ->
   eq 'text: [inner tagged | literal] expressions: [text: [|] expressions: [template]]',
   func"inner tagged #{func"#{'template'}"} literal"
+
+test "tagged template literal with escaped backticks", ->
+  eq 'text: [ES template literals look like this: `foo bar`] expressions: []',
+  func"ES template literals look like this: `foo bar`"
+
+test "tagged template literal with escaped interpolation", ->
+  eq 'text: [ES template literals also look like this: `3 + 5 = ${3+5}`] expressions: []',
+  func"ES template literals also look like this: `3 + 5 = ${3+5}`"
+
+test "tagged template literal with both escaped and unescaped interpolation", ->
+  eq "text: [ES template literals also look like this: `3 + 5 = ${3+5}` which equals |] expressions: [8]",
+  func"ES template literals also look like this: `3 + 5 = ${3+5}` which equals #{3+5}"


### PR DESCRIPTION
Closes #4380.