### PR TITLE
Fix empty source file when building with MINIFY=false, closes #4403

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -115,14 +115,14 @@ task 'build:browser', 'rebuild the merged script for inclusion in the browser', 
     }(this));
   """
   unless process.env.MINIFY is 'false'
-    {compiledCode} = require('google-closure-compiler-js').compile
+    {compiledCode: code} = require('google-closure-compiler-js').compile
       jsCode: [
         src: code
         languageOut: if majorVersion is 1 then 'ES5' else 'ES6'
       ]
   outputFolder = "docs/v#{majorVersion}/browser-compiler"
   fs.mkdirSync outputFolder unless fs.existsSync outputFolder
-  fs.writeFileSync "#{outputFolder}/coffee-script.js", header + '\n' + compiledCode
+  fs.writeFileSync "#{outputFolder}/coffee-script.js", header + '\n' + code
   console.log "built ... running browser tests:"
   invoke 'test:browser'
 


### PR DESCRIPTION
This fixes the empty source file issue.

Also related and closes https://github.com/rails/ruby-coffee-script/issues/13

