### PR TITLE
Trivial: Remove trailing whitespace in test/error_messages.coffee

### DIFF
--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -428,7 +428,7 @@ test "#3795: invalid escapes", ->
   assertErrorFormat '''
     ///a \\u002 0 space///
   ''', '''
-    [stdin]:1:6: error: invalid escape sequence \\u002 
+    [stdin]:1:6: error: invalid escape sequence \\u002 \n\
     ///a \\u002 0 space///
          ^\^^^^^
   '''


### PR DESCRIPTION
Trailing whitespace is generally considered 'bad style' and is often linted against or even simply removed by text editors.

One of the tests in test/error_messages.coffee depended on trailing whitespace, making the file tricky to work with for people whose editor is configured to remove trailing whitespace. The alternative is to use a literal "\n" and escape the line break.

I suppose this is personal preference, but given the proliferation of tools to remove trailing whitespace it makes sense to not depend on them when there's an alternative.