### PR TITLE
[CS2] Fix handling of parameters that are function calls

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -3085,7 +3085,7 @@
       }
 
       isComplex() {
-        return this.name.isComplex() || ((this.value != null) && this.value instanceof Call);
+        return this.name.isComplex() || this.value instanceof Call;
       }
 
       eachName(iterator, name = this.name) {

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2850,7 +2850,7 @@
             }
             o.scope.parameter(splatParamName);
           } else {
-            if (param.isComplex() || param.isCall()) {
+            if (param.isComplex()) {
               val = ref = param.asReference(o);
               if (param.value) {
                 val = new Op('?', ref, param.value);
@@ -2860,7 +2860,7 @@
               }));
             }
             if (!haveSplatParam) {
-              if (!(param.isComplex() || param.isCall())) {
+              if (!param.isComplex()) {
                 ref = param.value != null ? new Assign(new Value(param.name), param.value, '=') : param;
               }
               o.scope.parameter(fragmentsToText((param.value != null ? param : ref).compileToFragments(o)));
@@ -3083,11 +3083,7 @@
       }
 
       isComplex() {
-        return this.name.isComplex();
-      }
-
-      isCall() {
-        return (this.value != null) && this.value instanceof Call;
+        return this.name.isComplex() || ((this.value != null) && this.value instanceof Call);
       }
 
       eachName(iterator, name = this.name) {

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2906,10 +2906,9 @@
         if (this.isAsync) {
           modifiers.push('async');
         }
-        if (!this.isMethod && !this.bound) {
-          modifiers.push('function');
-        }
-        if (this.isGenerator) {
+        if (!(this.isMethod || this.bound)) {
+          modifiers.push(`function${(this.isGenerator ? '*' : '')}`);
+        } else if (this.isGenerator) {
           modifiers.push('*');
         }
         signature = [this.makeCode('(')];

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2850,7 +2850,7 @@
             }
             o.scope.parameter(splatParamName);
           } else {
-            if (param.isComplex()) {
+            if (param.isComplex() || param.isCall()) {
               val = ref = param.asReference(o);
               if (param.value) {
                 val = new Op('?', ref, param.value);
@@ -2860,7 +2860,7 @@
               }));
             }
             if (!haveSplatParam) {
-              if (!param.isComplex()) {
+              if (!(param.isComplex() || param.isCall())) {
                 ref = param.value != null ? new Assign(new Value(param.name), param.value, '=') : param;
               }
               o.scope.parameter(fragmentsToText((param.value != null ? param : ref).compileToFragments(o)));
@@ -3085,6 +3085,10 @@
 
       isComplex() {
         return this.name.isComplex();
+      }
+
+      isCall() {
+        return (this.value != null) && this.value instanceof Call;
       }
 
       eachName(iterator, name = this.name) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1945,7 +1945,7 @@ exports.Code = class Code extends Base
       # encountered, add these other parameters to the list to be output in
       # the function definition.
       else
-        if param.isComplex()
+        if param.isComplex() or param.isCall()
           # This parameter is destructured. So add a statement to the function
           # body assigning it, e.g. `(arg) => { var a = arg.a; }` or with a
           # default value if it has one.
@@ -1960,7 +1960,7 @@ exports.Code = class Code extends Base
           # set by the `isComplex()` block above, define it as a statement in
           # the function body. This parameter comes after the splat parameter,
           # so we can’t define its default value in the parameter list.
-          unless param.isComplex()
+          unless param.isComplex() or param.isCall()
             ref = if param.value? then new Assign new Value(param.name), param.value, '=' else param
           # Add this parameter’s reference to the function scope
           o.scope.parameter fragmentsToText (if param.value? then param else ref).compileToFragments o
@@ -2109,6 +2109,11 @@ exports.Param = class Param extends Base
 
   isComplex: ->
     @name.isComplex()
+
+  isCall: ->
+    # We need to be careful that parameters whose default value is a function
+    # call do not call that function more than once.
+    @value? and @value instanceof Call
 
   # Iterates the name or names of a `Param`.
   # In a sense, a destructured parameter represents multiple JS parameters. This

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1945,7 +1945,7 @@ exports.Code = class Code extends Base
       # encountered, add these other parameters to the list to be output in
       # the function definition.
       else
-        if param.isComplex() or param.isCall()
+        if param.isComplex()
           # This parameter is destructured. So add a statement to the function
           # body assigning it, e.g. `(arg) => { var a = arg.a; }` or with a
           # default value if it has one.
@@ -1960,7 +1960,7 @@ exports.Code = class Code extends Base
           # set by the `isComplex()` block above, define it as a statement in
           # the function body. This parameter comes after the splat parameter,
           # so we can’t define its default value in the parameter list.
-          unless param.isComplex() or param.isCall()
+          unless param.isComplex()
             ref = if param.value? then new Assign new Value(param.name), param.value, '=' else param
           # Add this parameter’s reference to the function scope
           o.scope.parameter fragmentsToText (if param.value? then param else ref).compileToFragments o
@@ -2110,12 +2110,7 @@ exports.Param = class Param extends Base
     @reference = node
 
   isComplex: ->
-    @name.isComplex()
-
-  isCall: ->
-    # We need to be careful that parameters whose default value is a function
-    # call do not call that function more than once.
-    @value? and @value instanceof Call
+    @name.isComplex() or (@value? and @value instanceof Call)
 
   # Iterates the name or names of a `Param`.
   # In a sense, a destructured parameter represents multiple JS parameters. This

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2112,7 +2112,7 @@ exports.Param = class Param extends Base
     @reference = node
 
   isComplex: ->
-    @name.isComplex() or (@value? and @value instanceof Call)
+    @name.isComplex() or @value instanceof Call
 
   # Iterates the name or names of a `Param`.
   # In a sense, a destructured parameter represents multiple JS parameters. This

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1993,10 +1993,12 @@ exports.Code = class Code extends Base
 
     # Assemble the output
     modifiers = []
-    modifiers.push 'static'   if @isMethod and @isStatic
-    modifiers.push 'async'    if @isAsync
-    modifiers.push 'function' if not @isMethod and not @bound
-    modifiers.push '*'        if @isGenerator
+    modifiers.push 'static' if @isMethod and @isStatic
+    modifiers.push 'async'  if @isAsync
+    unless @isMethod or @bound
+      modifiers.push "function#{if @isGenerator then '*' else ''}"
+    else if @isGenerator
+      modifiers.push '*'
 
     signature = [@makeCode '(']
     for param, i in params

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -341,3 +341,9 @@ test "#1038 Optimize trailing return statements", ->
                                                    foo()
                                                    return
                                                  """)
+
+test "#4406 Destructured parameter default evaluation order", ->
+  current = 0
+  next    = -> ++current
+  foo = ({ a = next() }, b = next()) -> [ a, b ]
+  arrayEq foo({}), [1, 2]


### PR DESCRIPTION
Fixes #4406. Also revises output of generator functions to be `function*` rather than `function *`, to follow [accepted idiom](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*).

@connec, any notes?