### PR TITLE
Fix "export" squashing variable declarations

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2059,7 +2059,7 @@
 
     ModuleSpecifier.prototype.compileNode = function(o) {
       var code;
-      o.scope.add(this.identifier, this.moduleDeclarationType);
+      o.scope.find(this.identifier, this.moduleDeclarationType);
       code = [];
       code.push(this.makeCode(this.original.value));
       if (this.alias != null) {

--- a/lib/coffee-script/scope.js
+++ b/lib/coffee-script/scope.js
@@ -45,11 +45,14 @@
       return this.parent.namedMethod();
     };
 
-    Scope.prototype.find = function(name) {
+    Scope.prototype.find = function(name, type) {
+      if (type == null) {
+        type = 'var';
+      }
       if (this.check(name)) {
         return true;
       }
-      this.add(name, 'var');
+      this.add(name, type);
       return false;
     };
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1352,7 +1352,7 @@ exports.ModuleSpecifier = class ModuleSpecifier extends Base
   children: ['original', 'alias']
 
   compileNode: (o) ->
-    o.scope.add @identifier, @moduleDeclarationType
+    o.scope.find @identifier, @moduleDeclarationType
     code = []
     code.push @makeCode @original.value
     code.push @makeCode " as #{@alias.value}" if @alias?

--- a/src/scope.litcoffee
+++ b/src/scope.litcoffee
@@ -44,9 +44,9 @@ function object that has a name filled in, or bottoms out.
 Look up a variable name in lexical scope, and declare it if it does not
 already exist.
 
-      find: (name) ->
+      find: (name, type = 'var') ->
         return yes if @check name
-        @add name, 'var'
+        @add name, type
         no
 
 Reserve a variable name as originating from a function parameter for this
@@ -116,4 +116,3 @@ of this scope.
 
       assignedVariables: ->
         "#{v.name} = #{v.type.value}" for v in @variables when v.type.assigned
-

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -733,3 +733,19 @@ test "export an imported aliased member named default", ->
       default as def
     } from 'lib';"""
   eq toJS(input), output
+
+test "#4394: export shouldn't prevent variable declarations", ->
+  input = """
+    x = 1
+    export { x }
+  """
+  output = """
+    var x;
+
+    x = 1;
+
+    export {
+      x
+    };
+  """
+  eq toJS(input), output


### PR DESCRIPTION
Exports that referenced variables assigned in the module would prevent the referenced variables from being declared, resulting in ReferenceErrors at run time.

Fixes #4394.