### PR TITLE
Refactor Cake tasks

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -280,6 +280,13 @@ task 'doc:source:watch', 'watch and continually rebuild the annotated source doc
   buildAnnotatedSource yes
 
 
+task 'release', 'build and test the CoffeeScript source, and build the documentation', ->
+  invoke 'build:full'
+  invoke 'build:browser'
+  invoke 'doc:site'
+  invoke 'doc:test'
+  invoke 'doc:source'
+
 task 'bench', 'quick benchmark of compilation time', ->
   {Rewriter} = require './lib/coffee-script/rewriter'
   sources = ['coffee-script', 'grammar', 'helpers', 'lexer', 'nodes', 'rewriter']

--- a/Cakefile
+++ b/Cakefile
@@ -45,27 +45,6 @@ run = (args, cb) ->
 log = (message, color, explanation) ->
   console.log color + message + reset + ' ' + (explanation or '')
 
-option '-p', '--prefix [DIR]', 'set the installation prefix for `cake install`'
-
-task 'install', 'install CoffeeScript into /usr/local (or --prefix)', (options) ->
-  base = options.prefix or '/usr/local'
-  lib  = "#{base}/lib/coffee-script"
-  bin  = "#{base}/bin"
-  node = "~/.node_libraries/coffee-script"
-  console.log "Installing CoffeeScript to #{lib}"
-  console.log "Linking to #{node}"
-  console.log "Linking 'coffee' to #{bin}/coffee"
-  exec([
-    "mkdir -p #{lib} #{bin}"
-    "cp -rf bin lib LICENSE README.md package.json src #{lib}"
-    "ln -sfn #{lib}/bin/coffee #{bin}/coffee"
-    "ln -sfn #{lib}/bin/cake #{bin}/cake"
-    "mkdir -p ~/.node_libraries"
-    "ln -sfn #{lib}/lib/coffee-script #{node}"
-  ].join(' && '), (err, stdout, stderr) ->
-    if err then console.log stderr.trim() else log 'done', green
-  )
-
 
 task 'build', 'build the CoffeeScript language from source', build
 

--- a/Cakefile
+++ b/Cakefile
@@ -100,10 +100,7 @@ watchAndBuildAndTest = (harmony = no) ->
     if eventType is 'change'
       log "src/#{filename} changed, rebuilding..."
       buildAndTest (filename is 'grammar.coffee'), harmony
-  fs.watch 'test/',
-    interval: 200
-    recursive: yes
-  , (eventType, filename) ->
+  fs.watch 'test/', {interval: 200, recursive: yes}, (eventType, filename) ->
     if eventType is 'change'
       log "test/#{filename} changed, rebuilding..."
       buildAndTest no, harmony

--- a/Cakefile
+++ b/Cakefile
@@ -51,6 +51,17 @@ build = (cb) ->
   buildParser()
   buildExceptParser cb
 
+testBuiltCode = (watch = no) ->
+  csPath = './lib/coffee-script'
+  csDir  = path.dirname require.resolve csPath
+
+  for mod of require.cache when csDir is mod[0 ... csDir.length]
+    delete require.cache[mod]
+
+  testResults = runTests require csPath
+  unless watch
+    process.exit 1 unless testResults
+
 
 # Run a CoffeeScript through our node/coffee interpreter.
 run = (args, cb) ->
@@ -74,15 +85,7 @@ task 'build:except-parser', 'build the CoffeeScript compiler, except for the Jis
 
 task 'build:full', 'build the CoffeeScript compiler from source twice, and run the tests', ->
   build ->
-    build ->
-      csPath = './lib/coffee-script'
-      csDir  = path.dirname require.resolve csPath
-
-      for mod of require.cache when csDir is mod[0 ... csDir.length]
-        delete require.cache[mod]
-
-      unless runTests require csPath
-        process.exit 1
+    build testBuiltCode
 
 task 'build:browser', 'build the merged script for inclusion in the browser', ->
   code = """
@@ -202,7 +205,7 @@ buildDocs = (watch = no) ->
   if watch
     for target in [indexFile, versionedSourceFolder, examplesSourceFolder, sectionsSourceFolder]
       fs.watch target, interval: 200, renderIndex
-    log 'watching...' , green
+    log 'watching...', green
 
 task 'doc:site', 'build the documentation for the website', ->
   buildDocs()
@@ -252,7 +255,7 @@ buildDocTests = (watch = no) ->
   if watch
     for target in [testFile, testsSourceFolder]
       fs.watch target, interval: 200, renderTest
-    log 'watching...' , green
+    log 'watching...', green
 
 task 'doc:test', 'build the browser-based tests', ->
   buildDocTests()
@@ -268,7 +271,7 @@ buildAnnotatedSource = (watch = no) ->
 
   if watch
     fs.watch 'src/', interval: 200, generateAnnotatedSource
-    log 'watching...' , green
+    log 'watching...', green
 
 task 'doc:source', 'build the annotated source documentation', ->
   buildAnnotatedSource()

--- a/README.md
+++ b/README.md
@@ -25,15 +25,10 @@ CoffeeScript is a little language that compiles into JavaScript.
 If you have the node package manager, npm, installed:
 
 ```shell
-npm install -g coffee-script
+npm install --global coffee-script
 ```
 
-Leave off the `-g` if you don't wish to install globally. If you don't wish to use npm:
-
-```shell
-git clone https://github.com/jashkenas/coffeescript.git
-sudo coffeescript/bin/cake install
-```
+Leave off the `--global` if you don’t wish to install globally.
 
 ## Getting Started
 
@@ -53,7 +48,7 @@ For documentation, usage, and examples, see: http://coffeescript.org/
 
 To suggest a feature or report a bug: http://github.com/jashkenas/coffeescript/issues
 
-If you'd like to chat, drop by #coffeescript on Freenode IRC.
+If you’d like to chat, drop by #coffeescript on Freenode IRC.
 
 The source repository: https://github.com/jashkenas/coffeescript.git
 

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -2584,9 +2584,9 @@ task(<span class="string">'build:parser'</span>, <span class="string">'rebuild t
 <li><p><a href="http://github.com/jashkenas/coffeescript/">Source Code</a><br>
 Use <code>bin/coffee</code> to test your changes,<br>
 <code>bin/cake test</code> to run the test suite,<br>
-<code>bin/cake build</code> to rebuild the CoffeeScript compiler, and<br>
-<code>bin/cake build:parser</code> to regenerate the Jison parser if you’re working on the grammar.</p>
-<p><code>git checkout lib &amp;&amp; bin/cake build:full</code> is a good command to run when you’re working on the core language. It’ll refresh the lib directory (in case you broke something), build your altered compiler, use that to rebuild itself (a good sanity test) and then run all of the tests. If they pass, there’s a good chance you’ve made a successful change.</p>
+<code>bin/cake build</code> to rebuild the full CoffeeScript compiler, and<br>
+<code>bin/cake build:except-parser</code> to recompile much faster if you’re not editing <code>grammar.coffee</code>.</p>
+<p><code>git checkout lib &amp;&amp; bin/cake build:full</code> is a good command to run when you’re working on the core language. It’ll refresh the <code>lib</code> folder (in case you broke something), build your altered compiler, use that to rebuild itself (a good sanity test) and then run all of the tests. If they pass, there’s a good chance you’ve made a successful change.</p>
 </li>
 <li><a href="v1/test.html">Browser Tests</a><br>
 Run CoffeeScript’s test suite in your current browser.</li>

--- a/documentation/sections/resources.md
+++ b/documentation/sections/resources.md
@@ -3,10 +3,10 @@
 *   [Source Code](http://github.com/jashkenas/coffeescript/)<br>
     Use `bin/coffee` to test your changes,<br>
     `bin/cake test` to run the test suite,<br>
-    `bin/cake build` to rebuild the CoffeeScript compiler, and<br>
-    `bin/cake build:parser` to regenerate the Jison parser if you’re working on the grammar.
+    `bin/cake build` to rebuild the full CoffeeScript compiler, and<br>
+    `bin/cake build:except-parser` to recompile much faster if you’re not editing `grammar.coffee`.
 
-    `git checkout lib && bin/cake build:full` is a good command to run when you’re working on the core language. It’ll refresh the lib directory (in case you broke something), build your altered compiler, use that to rebuild itself (a good sanity test) and then run all of the tests. If they pass, there’s a good chance you’ve made a successful change.
+    `git checkout lib && bin/cake build:full` is a good command to run when you’re working on the core language. It’ll refresh the `lib` folder (in case you broke something), build your altered compiler, use that to rebuild itself (a good sanity test) and then run all of the tests. If they pass, there’s a good chance you’ve made a successful change.
 *   [Browser Tests](v<%= majorVersion %>/test.html)<br>
     Run CoffeeScript’s test suite in your current browser.
 *   [CoffeeScript Issues](http://github.com/jashkenas/coffeescript/issues)<br>

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -71,20 +71,21 @@ if require?
 
   test "#2849: compilation error in a require()d file", ->
     # Create a temporary file to require().
-    ok not fs.existsSync 'test/syntax-error.coffee'
-    fs.writeFileSync 'test/syntax-error.coffee', 'foo in bar or in baz'
+    tempFile = path.join os.tmpdir(), 'syntax-error.coffee'
+    ok not fs.existsSync tempFile
+    fs.writeFileSync tempFile, 'foo in bar or in baz'
 
     try
-      assertErrorFormat '''
-        require './test/syntax-error'
-      ''',
+      assertErrorFormat """
+        require '#{tempFile}'
+      """,
       """
-        #{path.join __dirname, 'syntax-error.coffee'}:1:15: error: unexpected in
+        #{fs.realpathSync tempFile}:1:15: error: unexpected in
         foo in bar or in baz
                       ^^
       """
     finally
-      fs.unlinkSync 'test/syntax-error.coffee'
+      fs.unlinkSync tempFile
 
   test "#3890 Error.prepareStackTrace doesn't throw an error if a compiled file is deleted", ->
     # Adapted from https://github.com/atom/coffee-cash/blob/master/spec/coffee-cash-spec.coffee

--- a/test/repl.coffee
+++ b/test/repl.coffee
@@ -109,4 +109,6 @@ testRepl "keeps running after runtime error", (input, output) ->
   eq 'undefined', output.lastWrite()
 
 process.on 'exit', ->
-  fs.unlinkSync historyFile
+  try
+    fs.unlinkSync historyFile
+  catch exception # Already deleted, nothing else to do.


### PR DESCRIPTION
- All the documentation tasks now have watch and non-watch versions.
- New `cake release` task to cut a release.
- Remove `install` task.
- New `cake build:watch` and `cake build:watch:harmony` tasks to build and test and rebuild on changes to the source or tests; based on https://github.com/GeoffreyBooth/coffeescript-gulp