### PR TITLE
Allow middle mouse button scrolling

### DIFF
--- a/documentation/v2/docs.coffee
+++ b/documentation/v2/docs.coffee
@@ -74,6 +74,10 @@ $(document).ready ->
           editors[index + 1].setValue output
         , lastCompilationElapsedTime
 
+  # Allow middle mouse button scrolling
+  $('.CodeMirror-sizer').on 'mousedown', (event) ->
+    event.stopPropagation() if event.button is 1
+
 
   # Handle the code example buttons
   $('[data-action="run-code-example"]').click ->


### PR DESCRIPTION
Fixes autoscrolling the page when starting MMB dragging on a code example.

The code examples auto-expand so you don't need to scroll them. You would want to scroll in Try CoffeeScript but CodeMirror doesn't support autoscrolling anyways, it only prevents it.

Note: This likely breaks the MMB pasting found in some Linux systems, i.e. `X-selection-paste`.
If that's the case and is deemed unacceptable, we could at *least* allow autoscrolling on the readonly editors.