### PR TITLE
Write .coffee_history in $XDG_CACHE_HOME

### DIFF
--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -7,7 +7,8 @@ CoffeeScript = require './coffeescript'
 
 replDefaults =
   prompt: 'coffee> ',
-  historyFile: path.join process.env.HOME, '.coffee_history' if process.env.HOME
+  historyFile: do (p = process.env.XDG_CACHE_HOME or process.env.HOME) ->
+    path.join p, '.coffee_history' if p
   historyMaxInputSize: 10240
   eval: (input, context, filename, cb) ->
     # XXX: multiline hack.

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -7,8 +7,9 @@ CoffeeScript = require './coffeescript'
 
 replDefaults =
   prompt: 'coffee> ',
-  historyFile: do (p = process.env.XDG_CACHE_HOME or process.env.HOME) ->
-    path.join p, '.coffee_history' if p
+  historyFile: do ->
+    historyPath = process.env.XDG_CACHE_HOME or process.env.HOME
+    path.join historyPath, '.coffee_history' if historyPath
   historyMaxInputSize: 10240
   eval: (input, context, filename, cb) ->
     # XXX: multiline hack.


### PR DESCRIPTION
Previously, if the `$HOME` environmental variable was set, the `.coffee_history` file was written there. This is still the case, but first we check if `$XDG_CACHE_HOME` is set, and if so we write it there instead. This allows users who want to follow the [XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) to do so. Actually, this helps out *all* users who want to keep their home directory a bit cleaner. It seems that using this standardized environmental variable is the cleanest way to do this, rather than involving configuration files or command line flags or anything else.

Fixes #3705.