### PR TITLE
Fix #4491: import- and export-specific lexing should stop

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -28,6 +28,7 @@
       this.seenImport = false;
       this.seenExport = false;
       this.exportSpecifierList = false;
+      this.importSpecifierList = false;
       this.chunkLine = opts.line || 0;
       this.chunkColumn = opts.column || 0;
       code = this.clean(code);
@@ -425,6 +426,12 @@
       }
       indent = match[0];
       this.seenFor = false;
+      if (!this.importSpecifierList) {
+        this.seenImport = false;
+      }
+      if (!this.exportSpecifierList) {
+        this.seenExport = false;
+      }
       size = indent.length - 1 - indent.lastIndexOf('\n');
       noNewlines = this.unfinished();
       if (size - this.indebt === this.indent) {
@@ -570,6 +577,10 @@
         this.exportSpecifierList = true;
       } else if (this.exportSpecifierList && value === '}') {
         this.exportSpecifierList = false;
+      } else if (value === '{' && this.seenImport) {
+        this.importSpecifierList = true;
+      } else if (this.importSpecifierList && value === '}') {
+        this.importSpecifierList = false;
       }
       if (value === ';') {
         this.seenFor = this.seenImport = this.seenExport = false;

--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -27,8 +27,8 @@
       this.seenFor = false;
       this.seenImport = false;
       this.seenExport = false;
-      this.exportSpecifierList = false;
       this.importSpecifierList = false;
+      this.exportSpecifierList = false;
       this.chunkLine = opts.line || 0;
       this.chunkColumn = opts.column || 0;
       code = this.clean(code);
@@ -573,14 +573,14 @@
           return value.length;
         }
       }
-      if (value === '{' && (prev != null ? prev[0] : void 0) === 'EXPORT') {
-        this.exportSpecifierList = true;
-      } else if (this.exportSpecifierList && value === '}') {
-        this.exportSpecifierList = false;
-      } else if (value === '{' && this.seenImport) {
+      if (value === '{' && this.seenImport) {
         this.importSpecifierList = true;
       } else if (this.importSpecifierList && value === '}') {
         this.importSpecifierList = false;
+      } else if (value === '{' && (prev != null ? prev[0] : void 0) === 'EXPORT') {
+        this.exportSpecifierList = true;
+      } else if (this.exportSpecifierList && value === '}') {
+        this.exportSpecifierList = false;
       }
       if (value === ';') {
         this.seenFor = this.seenImport = this.seenExport = false;
@@ -879,12 +879,12 @@
     };
 
     Lexer.prototype.validateEscapes = function(str, options) {
-      var before, hex, invalidEscape, invalid_escape_regex, match, message, octal, ref2, unicode;
+      var before, hex, invalidEscape, invalidEscapeRegex, match, message, octal, ref2, unicode;
       if (options == null) {
         options = {};
       }
-      invalid_escape_regex = options.isRegex ? REGEX_INVALID_ESCAPE : STRING_INVALID_ESCAPE;
-      match = invalid_escape_regex.exec(str);
+      invalidEscapeRegex = options.isRegex ? REGEX_INVALID_ESCAPE : STRING_INVALID_ESCAPE;
+      match = invalidEscapeRegex.exec(str);
       if (!match) {
         return;
       }

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -46,6 +46,7 @@ exports.Lexer = class Lexer
     @seenImport = no             # Used to recognize IMPORT FROM? AS? tokens.
     @seenExport = no             # Used to recognize EXPORT FROM? AS? tokens.
     @exportSpecifierList = no    # Used to identify when in an EXPORT {...} FROM? ...
+    @importSpecifierList = no    # Used to identify when in an IMPORT {...} FROM? ...
 
     @chunkLine =
       opts.line or 0             # The start line for the current @chunk.
@@ -365,6 +366,8 @@ exports.Lexer = class Lexer
     indent = match[0]
 
     @seenFor = no
+    @seenImport = no unless @importSpecifierList
+    @seenExport = no unless @exportSpecifierList
 
     size = indent.length - 1 - indent.lastIndexOf '\n'
     noNewlines = @unfinished()
@@ -477,6 +480,10 @@ exports.Lexer = class Lexer
       @exportSpecifierList = yes
     else if @exportSpecifierList and value is '}'
       @exportSpecifierList = no
+    else if value is '{' and @seenImport
+      @importSpecifierList = yes
+    else if @importSpecifierList and value is '}'
+      @importSpecifierList = no
 
     if value is ';'
       @seenFor = @seenImport = @seenExport = no

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -45,8 +45,8 @@ exports.Lexer = class Lexer
     @seenFor    = no             # Used to recognize FORIN, FOROF and FORFROM tokens.
     @seenImport = no             # Used to recognize IMPORT FROM? AS? tokens.
     @seenExport = no             # Used to recognize EXPORT FROM? AS? tokens.
-    @exportSpecifierList = no    # Used to identify when in an EXPORT {...} FROM? ...
     @importSpecifierList = no    # Used to identify when in an IMPORT {...} FROM? ...
+    @exportSpecifierList = no    # Used to identify when in an EXPORT {...} FROM? ...
 
     @chunkLine =
       opts.line or 0             # The start line for the current @chunk.
@@ -476,14 +476,14 @@ exports.Lexer = class Lexer
         @error message, origin[2] if message
       return value.length if skipToken
 
-    if value is '{' and prev?[0] is 'EXPORT'
-      @exportSpecifierList = yes
-    else if @exportSpecifierList and value is '}'
-      @exportSpecifierList = no
-    else if value is '{' and @seenImport
+    if value is '{' and @seenImport
       @importSpecifierList = yes
     else if @importSpecifierList and value is '}'
       @importSpecifierList = no
+    else if value is '{' and prev?[0] is 'EXPORT'
+      @exportSpecifierList = yes
+    else if @exportSpecifierList and value is '}'
+      @exportSpecifierList = no
 
     if value is ';'
       @seenFor = @seenImport = @seenExport = no
@@ -770,12 +770,12 @@ exports.Lexer = class Lexer
 
   # Validates escapes in strings and regexes.
   validateEscapes: (str, options = {}) ->
-    invalid_escape_regex =
+    invalidEscapeRegex =
       if options.isRegex
         REGEX_INVALID_ESCAPE
       else
         STRING_INVALID_ESCAPE
-    match = invalid_escape_regex.exec str
+    match = invalidEscapeRegex.exec str
     return unless match
     [[], before, octal, hex, unicode] = match
     message =

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -773,3 +773,50 @@ test "#4451: `default` in an export statement is only treated as a keyword when 
       "default": 1
     };
   """
+  eq toJS(input), output
+
+test "#4491: import- and export-specific lexing should stop after import/export statement", ->
+  input = """
+    import {
+      foo,
+      bar as baz
+    } from 'lib'
+    import { qux, bar as quux } from 'lib'
+    import * as lib from 'lib'
+    export {
+      foo,
+      bar
+    }
+    export * from 'lib'
+
+    foo as
+    3 * as 4
+    from 'foo'
+    """
+  output = """
+    import {
+      foo,
+      bar as baz
+    } from 'lib';
+
+    import {
+      qux,
+      bar as quux
+    } from 'lib';
+
+    import * as lib from 'lib';
+
+    export {
+      foo,
+      bar
+    };
+
+    export * from 'lib';
+
+    foo(as);
+
+    3 * as(4);
+
+    from('foo');
+    """
+  eq toJS(input), output

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -781,13 +781,6 @@ test "#4491: import- and export-specific lexing should stop after import/export 
       foo,
       bar as baz
     } from 'lib'
-    import { qux, bar as quux } from 'lib'
-    import * as lib from 'lib'
-    export {
-      foo,
-      bar
-    }
-    export * from 'lib'
 
     foo as
     3 * as 4
@@ -799,18 +792,85 @@ test "#4491: import- and export-specific lexing should stop after import/export 
       bar as baz
     } from 'lib';
 
+    foo(as);
+
+    3 * as(4);
+
+    from('foo');
+    """
+  eq toJS(input), output
+
+  input = """
+    import { foo, bar as baz } from 'lib'
+
+    foo as
+    3 * as 4
+    from 'foo'
+    """
+  output = """
     import {
-      qux,
-      bar as quux
+      foo,
+      bar as baz
     } from 'lib';
 
+    foo(as);
+
+    3 * as(4);
+
+    from('foo');
+    """
+  eq toJS(input), output
+
+  input = """
+    import * as lib from 'lib'
+
+    foo as
+    3 * as 4
+    from 'foo'
+    """
+  output = """
     import * as lib from 'lib';
 
+    foo(as);
+
+    3 * as(4);
+
+    from('foo');
+    """
+  eq toJS(input), output
+
+  input = """
+    export {
+      foo,
+      bar
+    }
+
+    foo as
+    3 * as 4
+    from 'foo'
+    """
+  output = """
     export {
       foo,
       bar
     };
 
+    foo(as);
+
+    3 * as(4);
+
+    from('foo');
+    """
+  eq toJS(input), output
+
+  input = """
+    export * from 'lib'
+
+    foo as
+    3 * as 4
+    from 'foo'
+    """
+  output = """
     export * from 'lib';
 
     foo(as);


### PR DESCRIPTION
Fixes #4491 (I think)

I'm not really familiar with the `import`/`export` syntax but it looks like the only the time that the import-/export-specific lexing controlled by `@seenImport`/`@seenExport` (which lexes `as`, `from`, `default` differently) needs to continue beyond a line break is if we're inside a `{...}` specifier list. So I added an `@importSpecifierList` (corresponding to the existing `@exportSpecifierList`), and unless one of these is set (indicating we're inside a specifier list) then seeing a `lineToken()` clears `@seenImport` and `@seenExport`

Not sure if I should add additional tests for any of the other various `import`/`export` syntaxes?

