### PR TITLE
Failing tests exit code; separate building and testing browser compiler

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -407,7 +407,8 @@ runTests = (CoffeeScript) ->
 
 
 task 'test', 'run the CoffeeScript language test suite', ->
-  runTests CoffeeScript
+  testResults = runTests CoffeeScript
+  process.exit 1 unless testResults
 
 
 task 'test:browser', 'run the test suite against the merged browser script', ->
@@ -415,4 +416,5 @@ task 'test:browser', 'run the test suite against the merged browser script', ->
   result = {}
   global.testingBrowser = yes
   (-> eval source).call result
-  runTests result.CoffeeScript
+  testResults = runTests result.CoffeeScript
+  process.exit 1 unless testResults

--- a/Cakefile
+++ b/Cakefile
@@ -116,7 +116,7 @@ task 'build:full', 'build the CoffeeScript compiler from source twice, and run t
   build ->
     build testBuiltCode
 
-task 'build:browser', 'build the merged script for inclusion in the browser', ->
+task 'build:browser', 'merge the built scripts into a single file for use in a browser', ->
   code = """
   require['../../package.json'] = (function() {
     return #{fs.readFileSync "./package.json"};
@@ -154,6 +154,9 @@ task 'build:browser', 'build the merged script for inclusion in the browser', ->
   outputFolder = "docs/v#{majorVersion}/browser-compiler"
   fs.mkdirSync outputFolder unless fs.existsSync outputFolder
   fs.writeFileSync "#{outputFolder}/coffee-script.js", header + '\n' + code
+
+task 'build:browser:full', 'merge the built scripts into a single file for use in a browser, and test it', ->
+  invoke 'build:browser'
   console.log "built ... running browser tests:"
   invoke 'test:browser'
 
@@ -321,7 +324,7 @@ task 'doc:source:watch', 'watch and continually rebuild the annotated source doc
 
 task 'release', 'build and test the CoffeeScript source, and build the documentation', ->
   invoke 'build:full'
-  invoke 'build:browser'
+  invoke 'build:browser:full'
   invoke 'doc:site'
   invoke 'doc:test'
   invoke 'doc:source'


### PR DESCRIPTION
Fixes #4503.

Also, `cake build:browser` should just assemble the browser build, not also test it. Added `cake build:browser:full` to both build and run the tests. (We already had `cake test:browser`.)