### PR TITLE
Fix broken REPL test in Node 4

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -173,7 +173,7 @@
         opts = {};
       }
       ref1 = process.versions.node.split('.').map(function(n) {
-        return parseInt(n);
+        return parseInt(n, 10);
       }), major = ref1[0], minor = ref1[1], build = ref1[2];
       if (major === 0 && minor < 8) {
         console.warn("Node 0.8.0+ required for CoffeeScript REPL");

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -145,7 +145,7 @@ getCommandId = (repl, commandName) ->
 
 module.exports =
   start: (opts = {}) ->
-    [major, minor, build] = process.versions.node.split('.').map (n) -> parseInt(n)
+    [major, minor, build] = process.versions.node.split('.').map (n) -> parseInt(n, 10)
 
     if major is 0 and minor < 8
       console.warn "Node 0.8.0+ required for CoffeeScript REPL"

--- a/test/repl.coffee
+++ b/test/repl.coffee
@@ -67,6 +67,11 @@ testRepl "variables are saved", (input, output) ->
   eq "'foobar'", output.lastWrite()
 
 testRepl "empty command evaluates to undefined", (input, output) ->
+  # A regression fixed in Node 5.11.0 broke the handling of pressing enter in
+  # the Node REPL; see https://github.com/nodejs/node/pull/6090 and
+  # https://github.com/jashkenas/coffeescript/issues/4502.
+  # Just skip this test for versions of Node < 6.
+  return if parseInt(process.versions.node.split('.')[0], 10) < 6
   input.emitLine ''
   eq 'undefined', output.lastWrite()
 


### PR DESCRIPTION
Fixes #4502.

A particular REPL test is broken in Node 4.8.2 because of a regression that was fixed in Node 5.11.0. This PR simply disables the test for Node < 6.