### PR TITLE
[CS2] Remove support for bound instance methods

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1741,16 +1741,13 @@
 
       compileClassDeclaration(o) {
         var ref1, result;
-        if (this.externalCtor || this.boundMethods.length) {
+        if (this.externalCtor) {
           if (this.ctor == null) {
             this.ctor = this.makeDefaultConstructor();
           }
         }
         if ((ref1 = this.ctor) != null) {
           ref1.noReturn = true;
-        }
-        if (this.boundMethods.length) {
-          this.proxyBoundMethods(o);
         }
         o.indent += TAB;
         result = [];
@@ -1799,7 +1796,6 @@
       walkBody() {
         var assign, end, executableBody, expression, expressions, exprs, i, initializer, initializerExpression, j, k, len1, len2, method, properties, pushSlice, ref1, start;
         this.ctor = null;
-        this.boundMethods = [];
         executableBody = null;
         initializer = [];
         ({expressions} = this.body);
@@ -1851,11 +1847,8 @@
                 method.error('Cannot define more than one constructor in a class');
               }
               this.ctor = method;
-            } else if (method.bound && method.isStatic) {
+            } else if (method.isStatic && method.bound) {
               method.context = this.name;
-            } else if (method.bound) {
-              this.boundMethods.push(method.name);
-              method.bound = false;
             }
           }
         }
@@ -1911,8 +1904,8 @@
           if (methodName.value === 'constructor') {
             method.ctor = (this.parent ? 'derived' : 'base');
           }
-          if (method.bound && method.ctor) {
-            method.error('Cannot define a constructor as a bound function');
+          if (method.bound) {
+            method.error('Methods cannot be bound functions');
           }
         }
         return method;
@@ -1932,22 +1925,6 @@
           ctor.body.makeReturn();
         }
         return ctor;
-      }
-
-      proxyBoundMethods(o) {
-        var name;
-        this.ctor.thisAssignments = (function() {
-          var j, ref1, results;
-          ref1 = this.boundMethods;
-          results = [];
-          for (j = ref1.length - 1; j >= 0; j += -1) {
-            name = ref1[j];
-            name = new Value(new ThisLiteral, [name]).compile(o);
-            results.push(new Literal(`${name} = ${name}.bind(this)`));
-          }
-          return results;
-        }).call(this);
-        return null;
       }
 
     };

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -562,9 +562,8 @@ test "Assignment to variables similar to helper functions", ->
     extend = 3
     hasProp = 4
     value: 5
-    method: (bind, bind1) => [bind, bind1, extend, hasProp, @value]
-  {method} = new B
-  arrayEq [1, 2, 3, 4, 5], method 1, 2
+    method: (bind, bind1) -> [bind, bind1, extend, hasProp, @value]
+  arrayEq [1, 2, 3, 4, 5], new B().method 1, 2
 
   modulo = -1 %% 3
   eq 2, modulo

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -136,40 +136,18 @@ test "classes with JS-keyword properties", ->
   ok instance.name() is 'class'
 
 
-test "Classes with methods that are pre-bound to the instance, or statically, to the class", ->
+test "Classes with methods that are pre-bound statically, to the class", ->
 
   class Dog
     constructor: (name) ->
       @name = name
 
-    bark: =>
-      "#{@name} woofs!"
-
     @static = =>
       new this('Dog')
-
-  spark = new Dog('Spark')
-  fido  = new Dog('Fido')
-  fido.bark = spark.bark
-
-  ok fido.bark() is 'Spark woofs!'
 
   obj = func: Dog.static
 
   ok obj.func().name is 'Dog'
-
-
-test "a bound function in a bound function", ->
-
-  class Mini
-    num: 10
-    generate: =>
-      for i in [1..3]
-        =>
-          @num
-
-  m = new Mini
-  eq (func() for func in m.generate()).join(' '), '10 10 10'
 
 
 test "contructor called with varargs", ->
@@ -476,21 +454,6 @@ test "#1182: execution order needs to be considered as well", ->
     @B: makeFn 2
     constructor: makeFn 3
 
-test "#1182: external constructors with bound functions", ->
-  fn = ->
-    {one: 1}
-    this
-  class B
-  class A
-    constructor: fn
-    method: => this instanceof A
-  ok (new A).method.call(new B)
-
-test "#1372: bound class methods with reserved names", ->
-  class C
-    delete: =>
-  ok C::delete
-
 test "#1380: `super` with reserved names", ->
   class C
     do: -> super()
@@ -559,7 +522,7 @@ test "#1842: Regression with bound functions within bound class methods", ->
     @unbound: ->
       eq this, Store
 
-    instance: =>
+    instance: ->
       ok this instanceof Store
 
   Store.bound()
@@ -721,57 +684,6 @@ test "extending native objects works with and without defining a constructor", -
   overrideArray = new OverrideArray
   ok overrideArray instanceof OverrideArray
   eq 'yes!', overrideArray.method()
-
-
-test "#2782: non-alphanumeric-named bound functions", ->
-  class A
-    'b:c': =>
-      'd'
-
-  eq (new A)['b:c'](), 'd'
-
-
-test "#2781: overriding bound functions", ->
-  class A
-    a: ->
-        @b()
-    b: =>
-        1
-
-  class B extends A
-    b: =>
-        2
-
-  b = (new A).b
-  eq b(), 1
-
-  b = (new B).b
-  eq b(), 2
-
-
-test "#2791: bound function with destructured argument", ->
-  class Foo
-    method: ({a}) => 'Bar'
-
-  eq (new Foo).method({a: 'Bar'}), 'Bar'
-
-
-test "#2796: ditto, ditto, ditto", ->
-  answer = null
-
-  outsideMethod = (func) ->
-    func.call message: 'wrong!'
-
-  class Base
-    constructor: ->
-      @message = 'right!'
-      outsideMethod @echo
-
-    echo: =>
-      answer = @message
-
-  new Base
-  eq answer, 'right!'
 
 test "#3063: Class bodies cannot contain pure statements", ->
   throws -> CoffeeScript.compile """
@@ -984,9 +896,6 @@ test "`this` access after `super` in extended classes", ->
       eq result.super, this
       eq result.param, @param
       eq result.method, @method
-      ok result.method isnt Test::method
-
-    method: =>
 
   nonce = {}
   new Test nonce, {}
@@ -1006,8 +915,6 @@ test "`@`-params and bound methods with multiple `super` paths (blocks)", ->
         super 'not param'
         eq @name, 'not param'
       eq @param, nonce
-      ok @method isnt Test::method
-    method: =>
   new Test true, nonce
   new Test false, nonce
 
@@ -1026,16 +933,13 @@ test "`@`-params and bound methods with multiple `super` paths (expressions)", -
           eq (super 'param'), @;
           eq @name, 'param';
           eq @param, nonce;
-          ok @method isnt Test::method
         )
       else
         result = (
           eq (super 'not param'), @;
           eq @name, 'not param';
           eq @param, nonce;
-          ok @method isnt Test::method
         )
-    method: =>
   new Test true, nonce
   new Test false, nonce
 
@@ -1237,7 +1141,7 @@ test "super in a bound function", ->
     make: -> "Making a #{@drink}"
 
   class B extends A
-    make: (@flavor) =>
+    make: (@flavor) ->
       super() + " with #{@flavor}"
 
   b = new B('Machiato')
@@ -1245,7 +1149,7 @@ test "super in a bound function", ->
 
   # super in a bound function in a bound function
   class C extends A
-    make: (@flavor) =>
+    make: (@flavor) ->
       func = () =>
         super() + " with #{@flavor}"
       func()

--- a/test/scope.coffee
+++ b/test/scope.coffee
@@ -107,16 +107,6 @@ test "#1183: super + closures", ->
       ret
   eq (new B).foo(), 10
 
-test "#2331: bound super regression", ->
-  class A
-    @value = 'A'
-    method: -> @constructor.value
-
-  class B extends A
-    method: => super()
-
-  eq (new B).method(), 'A'
-
 test "#3259: leak with @-params within destructured parameters", ->
   fn = ({@foo}, [@bar], [{@baz}]) ->
     foo = bar = baz = false


### PR DESCRIPTION
Bound methods are implemented as assignments to `this` in the constructor. In derived classes, where `this` is unavailable until after `super` has been called, the binding is applied and assigned after the `super` call. This means that any references to ‘bound’ methods reachable from the parent constructor will actually point to the unbound prototype methods.

This can lead to very subtle bugs where a method that is thought to be bound is handed off and later called with an incorrect context, and the only defence is for users to be vigilant about referencing bound methods in constructors.

___

This is probably the most extreme solution to the problem, and would leave heavy users of bound methods with an unpleasant refactoring task, however the alternatives aren’t terribly appetising either:

- Restrict the error to derived classes only. A common use of bound methods is for event handlers in frontend frameworks such as Backbone and React, both of which rely on extending base classes. Choosing this approach would not help these users, and would make bound instance methods even more of a fringe feature.

- Hoist the entire method definition into the constructor, ensuring it isn’t assigned at all until `super` has been called. This would at least make any bugs easier to spot, and also looks very similar to the [class public fields ECMA Stage 2 proposal](https://babeljs.io/repl/#?babili=false&evaluate=true&lineWrap=true&presets=stage-2&targets=&browsers=&builtIns=false&debug=false&code=class%20A%20%7B%0A%20%20bound%20%3D%20()%20%3D%3E%20%7B%7D%0A%7D&experimental=false&loose=false&spec=false&playground=false). Matching some ES equivalent is probably the best strategy long term, but as this proposal is only Stage 2 we can’t rely on it not being changed.

- Leave everything as it is. We would could simply document the caveats of bound method interactions with `super` and let everyone figure it out.

*Edit:* #4512, #3093, and others propose a binding property access (as - @vendethiel would be quick to add - is [available Coco/LS](https://github.com/satyr/coco/wiki/additions#binding-access-)). This would make the necessary refactoring for this or option 1 slightly easier, and is also an [ES proposal](https://github.com/tc39/proposal-bind-operator).