### PR TITLE
Fix #4533: chained calls incorrectly wrapping enclosing implicit objects

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -171,7 +171,7 @@
       stack = [];
       start = null;
       return this.scanTokens(function(token, i, tokens) {
-        var endImplicitCall, endImplicitObject, forward, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, newLine, nextTag, offset, prevTag, prevToken, ref, ref1, ref2, ref3, ref4, ref5, s, sameLine, stackIdx, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
+        var endImplicitCall, endImplicitObject, forward, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, offset, prevTag, prevToken, ref, ref1, ref2, ref3, ref4, ref5, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
         tag = token[0];
         prevTag = (prevToken = i > 0 ? tokens[i - 1] : [])[0];
         nextTag = (i < tokens.length - 1 ? tokens[i + 1] : [])[0];
@@ -182,17 +182,24 @@
         forward = function(n) {
           return i - startIdx + n;
         };
+        isImplicit = function(stackItem) {
+          var ref;
+          return stackItem != null ? (ref = stackItem[2]) != null ? ref.ours : void 0 : void 0;
+        };
+        isImplicitObject = function(stackItem) {
+          return isImplicit(stackItem) && (stackItem != null ? stackItem[0] : void 0) === '{';
+        };
+        isImplicitCall = function(stackItem) {
+          return isImplicit(stackItem) && (stackItem != null ? stackItem[0] : void 0) === '(';
+        };
         inImplicit = function() {
-          var ref, ref1;
-          return (ref = stackTop()) != null ? (ref1 = ref[2]) != null ? ref1.ours : void 0 : void 0;
+          return isImplicit(stackTop());
         };
         inImplicitCall = function() {
-          var ref;
-          return inImplicit() && ((ref = stackTop()) != null ? ref[0] : void 0) === '(';
+          return isImplicitCall(stackTop());
         };
         inImplicitObject = function() {
-          var ref;
-          return inImplicit() && ((ref = stackTop()) != null ? ref[0] : void 0) === '{';
+          return isImplicitObject(stackTop());
         };
         inImplicitControl = function() {
           var ref;
@@ -316,8 +323,13 @@
           startImplicitObject(s, !!startsLine);
           return forward(2);
         }
-        if (inImplicitObject() && indexOf.call(LINEBREAKS, tag) >= 0) {
-          stackTop()[2].sameLine = false;
+        if (indexOf.call(LINEBREAKS, tag) >= 0) {
+          for (k = stack.length - 1; k >= 0; k += -1) {
+            stackItem = stack[k];
+            if (isImplicitObject(stackItem)) {
+              stackItem[2].sameLine = false;
+            }
+          }
         }
         newLine = prevTag === 'OUTDENT' || prevToken.newLine;
         if (indexOf.call(IMPLICIT_END, tag) >= 0 || indexOf.call(CALL_CLOSERS, tag) >= 0 && newLine) {

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -128,6 +128,9 @@ test "indented heredoc", ->
 #   * single line arguments
 #   * inline function literal
 #   * inline object literal
+#
+# * chaining inside
+#   * implicit object literal
 
 test "chaining after outdent", ->
   id = (x) -> x
@@ -220,6 +223,14 @@ test "chaining should work within spilling ternary", ->
       a: 3
       .a
   eq 3, result.h
+
+test "method call chaining inside objects", ->
+  f = (x) -> c: 42
+  result =
+    a: f 1
+    b: f a: 1
+      .c
+  eq 42, result.b
 
 # Nested blocks caused by paren unwrapping
 test "#1492: Nested blocks don't cause double semicolons", ->


### PR DESCRIPTION
Fixes #4533.

I looked through the other open and closed method chaining issues and this doesn't seem to fix any of them. It's possible it fixes some other issues I'm not aware of (I kinda feel like it should change some behavior, but we don't have any existing tests covering it).