### PR TITLE
Fix #4150: Correctly outdent ternary followed by method call

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -395,7 +395,7 @@
       starter = indent = outdent = null;
       condition = function(token, i) {
         var ref, ref1, ref2, ref3;
-        return token[1] !== ';' && (ref = token[0], indexOf.call(SINGLE_CLOSERS, ref) >= 0) && !(token[0] === 'TERMINATOR' && (ref1 = this.tag(i + 1), indexOf.call(EXPRESSION_CLOSE, ref1) >= 0)) && !(token[0] === 'ELSE' && starter !== 'THEN') && !(((ref2 = token[0]) === 'CATCH' || ref2 === 'FINALLY') && (starter === '->' || starter === '=>')) || (ref3 = token[0], indexOf.call(CALL_CLOSERS, ref3) >= 0) && this.tokens[i - 1].newLine;
+        return token[1] !== ';' && (ref = token[0], indexOf.call(SINGLE_CLOSERS, ref) >= 0) && !(token[0] === 'TERMINATOR' && (ref1 = this.tag(i + 1), indexOf.call(EXPRESSION_CLOSE, ref1) >= 0)) && !(token[0] === 'ELSE' && starter !== 'THEN') && !(((ref2 = token[0]) === 'CATCH' || ref2 === 'FINALLY') && (starter === '->' || starter === '=>')) || (ref3 = token[0], indexOf.call(CALL_CLOSERS, ref3) >= 0) && (this.tokens[i - 1].newLine || this.tokens[i - 1][0] === 'OUTDENT');
       };
       action = function(token, i) {
         return this.tokens.splice((this.tag(i - 1) === ',' ? i - 1 : i), 0, outdent);

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -398,7 +398,8 @@ class exports.Rewriter
       not (token[0] is 'TERMINATOR' and @tag(i + 1) in EXPRESSION_CLOSE) and
       not (token[0] is 'ELSE' and starter isnt 'THEN') and
       not (token[0] in ['CATCH', 'FINALLY'] and starter in ['->', '=>']) or
-      token[0] in CALL_CLOSERS and @tokens[i - 1].newLine
+      token[0] in CALL_CLOSERS and
+      (@tokens[i - 1].newLine or @tokens[i - 1][0] is 'OUTDENT')
 
     action = (token, i) ->
       @tokens.splice (if @tag(i - 1) is ',' then i - 1 else i), 0, outdent

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -198,6 +198,29 @@ test "#1495, method call chaining", ->
   ).join ', '
   eq 'a, b, c', result
 
+test "chaining should not wrap spilling ternary", ->
+  throws -> CoffeeScript.compile """
+    if 0 then 1 else g
+      a: 42
+    .h()
+  """
+
+test "chaining should wrap calls containing spilling ternary", ->
+  f = (x) -> h: x
+  id = (x) -> x
+  result = f if true then 42 else id
+      a: 2
+  .h
+  eq 42, result
+
+test "chaining should work within spilling ternary", ->
+  f = (x) -> h: x
+  id = (x) -> x
+  result = f if false then 1 else id
+      a: 3
+      .a
+  eq 3, result.h
+
 # Nested blocks caused by paren unwrapping
 test "#1492: Nested blocks don't cause double semicolons", ->
   js = CoffeeScript.compile '(0;0)'


### PR DESCRIPTION
I think the code in #4150 is pretty horrible, and the fact that an inline ternary can continue after a method call in else just seems bizarre. But I do think that:
```coffee
if 0 then 1 else g
  a: 1
.h()
```
should not compile (certainly not as `.h()` being called on the inline object inside the ternary).

So this PR makes it cause a syntax error, as it should. I would guess that implementation-wise this is not the right fix, but it works and I'm not an expert on the `rewriter` logic.