### PR TITLE
[CS2] No need for `break;` after a switch case that `throw`s

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4014,7 +4014,7 @@
             break;
           }
           expr = this.lastNonComment(block.expressions);
-          if (expr instanceof Return || (expr instanceof Literal && expr.jumps() && expr.value !== 'debugger')) {
+          if (expr instanceof Return || expr instanceof Throw || (expr instanceof Literal && expr.jumps() && expr.value !== 'debugger')) {
             continue;
           }
           fragments.push(cond.makeCode(idt2 + 'break;\n'));

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3000,7 +3000,7 @@ exports.Switch = class Switch extends Base
       fragments = fragments.concat body, @makeCode('\n') if (body = block.compileToFragments o, LEVEL_TOP).length > 0
       break if i is @cases.length - 1 and not @otherwise
       expr = @lastNonComment block.expressions
-      continue if expr instanceof Return or (expr instanceof Literal and expr.jumps() and expr.value isnt 'debugger')
+      continue if expr instanceof Return or expr instanceof Throw or (expr instanceof Literal and expr.jumps() and expr.value isnt 'debugger')
       fragments.push cond.makeCode(idt2 + 'break;\n')
     if @otherwise and @otherwise.expressions.length
       fragments.push @makeCode(idt1 + "default:\n"), (@otherwise.compileToFragments o, LEVEL_TOP)..., @makeCode("\n")


### PR DESCRIPTION
Fix #4020: No need for `break;` after a switch case that `throw`s. Solution [shamelessly stolen](https://github.com/jashkenas/coffeescript/issues/4020#issuecomment-118588369) from @lydell for all credit.

Not sure how to test without checking for generated JavaScript. Not sure this really needs its own test. Current tests all still pass.