### PR TITLE
[CS2] Un-prefer global

### DIFF
--- a/bin/cake
+++ b/bin/cake
@@ -2,6 +2,17 @@
 
 var path = require('path');
 var fs   = require('fs');
-var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
-require(lib + '/coffeescript/cake').run();
+var potentialPaths = [
+  path.join(process.cwd(), 'node_modules/coffeescript/lib/coffeescript'),
+  path.join(process.cwd(), 'node_modules/coffeescript/lib/coffee-script'),
+  path.join(process.cwd(), 'node_modules/coffee-script/lib/coffee-script'),
+  path.join(path.dirname(fs.realpathSync(__filename)), '../lib/coffeescript')
+];
+
+for (var i = 0; i < 4; i++) {
+  if (fs.existsSync(potentialPaths[i])) {
+    require(potentialPaths[i] + '/cake').run();
+    break;
+  }
+}

--- a/bin/cake
+++ b/bin/cake
@@ -7,10 +7,10 @@ var potentialPaths = [
   path.join(process.cwd(), 'node_modules/coffeescript/lib/coffeescript'),
   path.join(process.cwd(), 'node_modules/coffeescript/lib/coffee-script'),
   path.join(process.cwd(), 'node_modules/coffee-script/lib/coffee-script'),
-  path.join(path.dirname(fs.realpathSync(__filename)), '../lib/coffeescript')
+  path.join(__dirname, '../lib/coffeescript')
 ];
 
-for (var i = 0; i < 4; i++) {
+for (var i = 0, len = potentialPaths.length; i < len; i++) {
   if (fs.existsSync(potentialPaths[i])) {
     require(potentialPaths[i] + '/cake').run();
     break;

--- a/bin/coffee
+++ b/bin/coffee
@@ -2,6 +2,17 @@
 
 var path = require('path');
 var fs   = require('fs');
-var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
-require(lib + '/coffeescript/command').run();
+var potentialPaths = [
+  path.join(process.cwd(), 'node_modules/coffeescript/lib/coffeescript'),
+  path.join(process.cwd(), 'node_modules/coffeescript/lib/coffee-script'),
+  path.join(process.cwd(), 'node_modules/coffee-script/lib/coffee-script'),
+  path.join(path.dirname(fs.realpathSync(__filename)), '../lib/coffeescript')
+];
+
+for (var i = 0; i < 4; i++) {
+  if (fs.existsSync(potentialPaths[i])) {
+    require(potentialPaths[i] + '/command').run();
+    break;
+  }
+}

--- a/bin/coffee
+++ b/bin/coffee
@@ -7,10 +7,10 @@ var potentialPaths = [
   path.join(process.cwd(), 'node_modules/coffeescript/lib/coffeescript'),
   path.join(process.cwd(), 'node_modules/coffeescript/lib/coffee-script'),
   path.join(process.cwd(), 'node_modules/coffee-script/lib/coffee-script'),
-  path.join(path.dirname(fs.realpathSync(__filename)), '../lib/coffeescript')
+  path.join(__dirname, '../lib/coffeescript')
 ];
 
-for (var i = 0; i < 4; i++) {
+for (var i = 0, len = potentialPaths.length; i < len; i++) {
   if (fs.existsSync(potentialPaths[i])) {
     require(potentialPaths[i] + '/command').run();
     break;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "register.js",
     "repl.js"
   ],
-  "preferGlobal": true,
   "scripts": {
     "test": "node ./bin/cake test",
     "test-harmony": "node --harmony ./bin/cake test"


### PR DESCRIPTION
Closes #4049.

- [x] Installing CoffeeScript no longer triggers NPM’s “prefer global” warning
- [x] The `coffee` and `cake` commands now first check if you have a locally-installed CoffeeScript module under the current path, and execute that version if so, similar to how Gulp works; and fall back to the global version otherwise.

This enables using different versions of the CoffeeScript CLI on a per-project basis:

```bash
/tmp ▶ coffee -v
CoffeeScript version 1.12.5
/tmp ▶ mkdir coffeescript1.11
/tmp ▶ cd coffeescript1.11
/tmp/coffeescript1.11 ▶ npm install coffeescript@1.11.0
/private/tmp/coffeescript1.11
└── coffeescript@1.11.0

npm WARN enoent ENOENT: no such file or directory, open '/private/tmp/coffeescript1.11/package.json'
npm WARN coffeescript1.11 No description
npm WARN coffeescript1.11 No repository field.
npm WARN coffeescript1.11 No README data
npm WARN coffeescript1.11 No license field.
/tmp/coffeescript1.11 ▶ coffee -v
CoffeeScript version 1.11.0
/tmp/coffeescript1.11 ▶ cd ..
/tmp ▶ mkdir coffee-script1.11
/tmp ▶ cd coffee-script1.11
/tmp/coffee-script1.11 ▶ npm install coffee-script@1.11.0
/private/tmp/coffee-script1.11
└── coffee-script@1.11.0

npm WARN enoent ENOENT: no such file or directory, open '/private/tmp/coffee-script1.11/package.json'
npm WARN coffee-script1.11 No description
npm WARN coffee-script1.11 No repository field.
npm WARN coffee-script1.11 No README data
npm WARN coffee-script1.11 No license field.
/tmp/coffee-script1.11 ▶ coffee -v
CoffeeScript version 1.11.0
/tmp/coffee-script1.11 ▶ cd ..
/tmp ▶ mkdir coffeescript2
/tmp ▶ cd coffeescript2
/tmp/coffeescript2 ▶ npm install coffeescript@next
/private/tmp/coffeescript2
└─┬ coffeescript@2.0.0-beta1
  └─┬ markdown-it@8.3.1
    ├─┬ argparse@1.0.9
    │ └── sprintf-js@1.0.3
    ├── entities@1.1.1
    ├── linkify-it@2.0.3
    ├── mdurl@1.0.1
    └── uc.micro@1.0.3

npm WARN enoent ENOENT: no such file or directory, open '/private/tmp/coffeescript2/package.json'
npm WARN coffeescript2 No description
npm WARN coffeescript2 No repository field.
npm WARN coffeescript2 No README data
npm WARN coffeescript2 No license field.
/tmp/coffeescript2 ▶ coffee -v
CoffeeScript version 2.0.0-beta1
```

If you don’t have a globally-installed version, the `coffee` or `cake` commands don’t do anything; you either have to use the locally-installed module via Node, like a normal module, or access the CLI via `./node_modules/coffeescript/bin/coffee`.