### PR TITLE
Fix #4544: postfix conditional on first line of implicit object

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -657,14 +657,15 @@
     }
 
     tagParameters() {
-      var i, stack, tok, tokens;
+      var i, paramEndToken, stack, tok, tokens;
       if (this.tag() !== ')') {
         return this;
       }
       stack = [];
       ({tokens} = this);
       i = tokens.length;
-      tokens[--i][0] = 'PARAM_END';
+      paramEndToken = tokens[--i];
+      paramEndToken[0] = 'PARAM_END';
       while (tok = tokens[--i]) {
         switch (tok[0]) {
           case ')':
@@ -678,6 +679,7 @@
               tok[0] = 'PARAM_START';
               return this;
             } else {
+              paramEndToken[0] = 'CALL_END';
               return this;
             }
         }

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -96,7 +96,8 @@
       closeOpenIndexes() {
         var action, condition;
         condition = function(token, i) {
-          return token[0] === [']', 'INDEX_END'];
+          var ref;
+          return (ref = token[0]) === ']' || ref === 'INDEX_END';
         };
         action = function(token, i) {
           return token[0] = 'INDEX_END';

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -38,7 +38,7 @@
         return true;
       }
 
-      detectEnd(i, condition, action) {
+      detectEnd(i, condition, action, opts = {}) {
         var levels, ref, ref1, token, tokens;
         ({tokens} = this);
         levels = 0;
@@ -46,13 +46,16 @@
           if (levels === 0 && condition.call(this, token, i)) {
             return action.call(this, token, i);
           }
-          if (!token || levels < 0) {
-            return action.call(this, token, i - 1);
-          }
           if (ref = token[0], indexOf.call(EXPRESSION_START, ref) >= 0) {
             levels += 1;
           } else if (ref1 = token[0], indexOf.call(EXPRESSION_END, ref1) >= 0) {
             levels -= 1;
+          }
+          if (levels < 0) {
+            if (opts.returnOnNegativeLevel) {
+              return;
+            }
+            return action.call(this, token, i);
           }
           i += 1;
         }
@@ -77,10 +80,10 @@
         var action, condition;
         condition = function(token, i) {
           var ref;
-          return ((ref = token[0]) === ')' || ref === 'CALL_END') || token[0] === 'OUTDENT' && this.tag(i - 1) === ')';
+          return (ref = token[0]) === ')' || ref === 'CALL_END';
         };
         action = function(token, i) {
-          return this.tokens[token[0] === 'OUTDENT' ? i - 1 : i][0] = 'CALL_END';
+          return token[0] = 'CALL_END';
         };
         return this.scanTokens(function(token, i) {
           if (token[0] === 'CALL_START') {
@@ -93,8 +96,7 @@
       closeOpenIndexes() {
         var action, condition;
         condition = function(token, i) {
-          var ref;
-          return (ref = token[0]) === ']' || ref === 'INDEX_END';
+          return token[0] === [']', 'INDEX_END'];
         };
         action = function(token, i) {
           return token[0] = 'INDEX_END';
@@ -168,10 +170,10 @@
         stack = [];
         start = null;
         return this.scanTokens(function(token, i, tokens) {
-          var endImplicitCall, endImplicitObject, forward, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, offset, prevTag, prevToken, ref, ref1, ref2, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
+          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
           [tag] = token;
           [prevTag] = prevToken = i > 0 ? tokens[i - 1] : [];
-          [nextTag] = i < tokens.length - 1 ? tokens[i + 1] : [];
+          [nextTag] = nextToken = i < tokens.length - 1 ? tokens[i + 1] : [];
           stackTop = function() {
             return stack[stack.length - 1];
           };
@@ -202,27 +204,21 @@
             var ref;
             return inImplicit() && ((ref = stackTop()) != null ? ref[0] : void 0) === 'CONTROL';
           };
-          startImplicitCall = function(j) {
-            var idx;
-            idx = j != null ? j : i;
+          startImplicitCall = function(idx) {
             stack.push([
               '(', idx, {
                 ours: true
               }
             ]);
-            tokens.splice(idx, 0, generate('CALL_START', '('));
-            if (j == null) {
-              return i += 1;
-            }
+            return tokens.splice(idx, 0, generate('CALL_START', '('));
           };
           endImplicitCall = function() {
             stack.pop();
             tokens.splice(i, 0, generate('CALL_END', ')', ['', 'end of input', token[2]]));
             return i += 1;
           };
-          startImplicitObject = function(j, startsLine = true) {
-            var idx, val;
-            idx = j != null ? j : i;
+          startImplicitObject = function(idx, startsLine = true) {
+            var val;
             stack.push([
               '{', idx, {
                 sameLine: true,
@@ -232,16 +228,28 @@
             ]);
             val = new String('{');
             val.generated = true;
-            tokens.splice(idx, 0, generate('{', val, token));
-            if (j == null) {
-              return i += 1;
-            }
+            return tokens.splice(idx, 0, generate('{', val, token));
           };
           endImplicitObject = function(j) {
             j = j != null ? j : i;
             stack.pop();
             tokens.splice(j, 0, generate('}', '}', token));
             return i += 1;
+          };
+          implicitObjectContinues = (j) => {
+            var nextTerminatorIdx;
+            nextTerminatorIdx = null;
+            this.detectEnd(j, function(token) {
+              return token[0] === 'TERMINATOR';
+            }, function(token, i) {
+              return nextTerminatorIdx = i;
+            }, {
+              returnOnNegativeLevel: true
+            });
+            if (nextTerminatorIdx == null) {
+              return false;
+            }
+            return this.looksObjectish(nextTerminatorIdx + 1);
           };
           if (inImplicitCall() && (tag === 'IF' || tag === 'TRY' || tag === 'FINALLY' || tag === 'CATCH' || tag === 'CLASS' || tag === 'SWITCH')) {
             stack.push([
@@ -252,7 +260,7 @@
             return forward(1);
           }
           if (tag === 'INDENT' && inImplicit()) {
-            if (prevTag !== '=>' && prevTag !== '->' && prevTag !== '[' && prevTag !== '(' && prevTag !== ',' && prevTag !== '{' && prevTag !== 'TRY' && prevTag !== 'ELSE' && prevTag !== '=') {
+            if (prevTag !== '=>' && prevTag !== '->' && prevTag !== '[' && prevTag !== '(' && prevTag !== ',' && prevTag !== '{' && prevTag !== 'ELSE' && prevTag !== '=') {
               while (inImplicitCall()) {
                 endImplicitCall();
               }
@@ -279,7 +287,7 @@
             }
             start = stack.pop();
           }
-          if ((indexOf.call(IMPLICIT_FUNC, tag) >= 0 && token.spaced || tag === '?' && i > 0 && !tokens[i - 1].spaced) && (indexOf.call(IMPLICIT_CALL, nextTag) >= 0 || indexOf.call(IMPLICIT_UNSPACED_CALL, nextTag) >= 0 && !((ref = tokens[i + 1]) != null ? ref.spaced : void 0) && !((ref1 = tokens[i + 1]) != null ? ref1.newLine : void 0))) {
+          if ((indexOf.call(IMPLICIT_FUNC, tag) >= 0 && token.spaced || tag === '?' && i > 0 && !tokens[i - 1].spaced) && (indexOf.call(IMPLICIT_CALL, nextTag) >= 0 || indexOf.call(IMPLICIT_UNSPACED_CALL, nextTag) >= 0 && !nextToken.spaced && !nextToken.newLine)) {
             if (tag === '?') {
               tag = token[0] = 'FUNC_EXIST';
             }
@@ -293,9 +301,9 @@
           }
           if (tag === ':') {
             s = (function() {
-              var ref2;
+              var ref;
               switch (false) {
-                case ref2 = this.tag(i - 1), indexOf.call(EXPRESSION_END, ref2) < 0:
+                case ref = this.tag(i - 1), indexOf.call(EXPRESSION_END, ref) < 0:
                   return start[1];
                 case this.tag(i - 2) !== '@':
                   return i - 2;
@@ -307,7 +315,7 @@
               s -= 2;
             }
             this.insideForDeclaration = nextTag === 'FOR';
-            startsLine = s === 0 || (ref2 = this.tag(s - 1), indexOf.call(LINEBREAKS, ref2) >= 0) || tokens[s - 1].newLine;
+            startsLine = s === 0 || (ref = this.tag(s - 1), indexOf.call(LINEBREAKS, ref) >= 0) || tokens[s - 1].newLine;
             if (stackTop()) {
               [stackTag, stackIdx] = stackTop();
               if ((stackTag === '{' || stackTag === 'INDENT' && this.tag(stackIdx - 1) === '{') && (startsLine || this.tag(s - 1) === ',' || this.tag(s - 1) === '{')) {
@@ -331,7 +339,7 @@
               [stackTag, stackIdx, {sameLine, startsLine}] = stackTop();
               if (inImplicitCall() && prevTag !== ',') {
                 endImplicitCall();
-              } else if (inImplicitObject() && !this.insideForDeclaration && sameLine && tag !== 'TERMINATOR' && prevTag !== ':') {
+              } else if (inImplicitObject() && !this.insideForDeclaration && sameLine && tag !== 'TERMINATOR' && prevTag !== ':' && !(tag === 'POST_IF' && startsLine && implicitObjectContinues(i + 1))) {
                 endImplicitObject();
               } else if (inImplicitObject() && tag === 'TERMINATOR' && prevTag !== ',' && !(startsLine && this.looksObjectish(i + 1))) {
                 if (nextTag === 'HERECOMMENT') {

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -549,7 +549,8 @@ exports.Lexer = class Lexer
     stack = []
     {tokens} = this
     i = tokens.length
-    tokens[--i][0] = 'PARAM_END'
+    paramEndToken = tokens[--i]
+    paramEndToken[0] = 'PARAM_END'
     while tok = tokens[--i]
       switch tok[0]
         when ')'
@@ -559,7 +560,9 @@ exports.Lexer = class Lexer
           else if tok[0] is '('
             tok[0] = 'PARAM_START'
             return this
-          else return this
+          else
+            paramEndToken[0] = 'CALL_END'
+            return this
     this
 
   # Close up all remaining open blocks at the end of the file.

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -45,16 +45,18 @@ exports.Rewriter = class Rewriter
     i += block.call this, token, i, tokens while token = tokens[i]
     true
 
-  detectEnd: (i, condition, action) ->
+  detectEnd: (i, condition, action, opts = {}) ->
     {tokens} = this
     levels = 0
     while token = tokens[i]
-      return action.call this, token, i     if levels is 0 and condition.call this, token, i
-      return action.call this, token, i - 1 if not token or levels < 0
+      return action.call this, token, i if levels is 0 and condition.call this, token, i
       if token[0] in EXPRESSION_START
         levels += 1
       else if token[0] in EXPRESSION_END
         levels -= 1
+      if levels < 0
+        return if opts.returnOnNegativeLevel
+        return action.call this, token, i
       i += 1
     i - 1
 
@@ -65,25 +67,23 @@ exports.Rewriter = class Rewriter
     @tokens.splice 0, i if i
 
   # The lexer has tagged the opening parenthesis of a method call. Match it with
-  # its paired close. We have the mis-nested outdent case included here for
-  # calls that close on the same line, just before their outdent.
+  # its paired close.
   closeOpenCalls: ->
     condition = (token, i) ->
-      token[0] in [')', 'CALL_END'] or
-      token[0] is 'OUTDENT' and @tag(i - 1) is ')'
+      token[0] in [')', 'CALL_END']
 
     action = (token, i) ->
-      @tokens[if token[0] is 'OUTDENT' then i - 1 else i][0] = 'CALL_END'
+      token[0] = 'CALL_END'
 
     @scanTokens (token, i) ->
       @detectEnd i + 1, condition, action if token[0] is 'CALL_START'
       1
 
-  # The lexer has tagged the opening parenthesis of an indexing operation call.
+  # The lexer has tagged the opening bracket of an indexing operation call.
   # Match it with its paired close.
   closeOpenIndexes: ->
     condition = (token, i) ->
-      token[0] in [']', 'INDEX_END']
+      token[0] is [']', 'INDEX_END']
 
     action = (token, i) ->
       token[0] = 'INDEX_END'
@@ -140,7 +140,7 @@ exports.Rewriter = class Rewriter
     @scanTokens (token, i, tokens) ->
       [tag]     = token
       [prevTag] = prevToken = if i > 0 then tokens[i - 1] else []
-      [nextTag] = if i < tokens.length - 1 then tokens[i + 1] else []
+      [nextTag] = nextToken = if i < tokens.length - 1 then tokens[i + 1] else []
       stackTop  = -> stack[stack.length - 1]
       startIdx  = i
 
@@ -159,30 +159,35 @@ exports.Rewriter = class Rewriter
       # class declaration or if-conditionals)
       inImplicitControl = -> inImplicit() and stackTop()?[0] is 'CONTROL'
 
-      startImplicitCall = (j) ->
-        idx = j ? i
+      startImplicitCall = (idx) ->
         stack.push ['(', idx, ours: yes]
         tokens.splice idx, 0, generate 'CALL_START', '('
-        i += 1 if not j?
 
       endImplicitCall = ->
         stack.pop()
         tokens.splice i, 0, generate 'CALL_END', ')', ['', 'end of input', token[2]]
         i += 1
 
-      startImplicitObject = (j, startsLine = yes) ->
-        idx = j ? i
+      startImplicitObject = (idx, startsLine = yes) ->
         stack.push ['{', idx, sameLine: yes, startsLine: startsLine, ours: yes]
         val = new String '{'
         val.generated = yes
         tokens.splice idx, 0, generate '{', val, token
-        i += 1 if not j?
 
       endImplicitObject = (j) ->
         j = j ? i
         stack.pop()
         tokens.splice j, 0, generate '}', '}', token
         i += 1
+
+      implicitObjectContinues = (j) =>
+        nextTerminatorIdx = null
+        @detectEnd j,
+          (token) -> token[0] is 'TERMINATOR'
+          (token, i) -> nextTerminatorIdx = i
+          returnOnNegativeLevel: yes
+        return no unless nextTerminatorIdx?
+        @looksObjectish nextTerminatorIdx + 1
 
       # Don't end an implicit call on next indent if any of these are in an argument
       if inImplicitCall() and tag in ['IF', 'TRY', 'FINALLY', 'CATCH',
@@ -197,7 +202,7 @@ exports.Rewriter = class Rewriter
         #  1. We have seen a `CONTROL` argument on the line.
         #  2. The last token before the indent is part of the list below
         #
-        if prevTag not in ['=>', '->', '[', '(', ',', '{', 'TRY', 'ELSE', '=']
+        if prevTag not in ['=>', '->', '[', '(', ',', '{', 'ELSE', '=']
           endImplicitCall() while inImplicitCall()
         stack.pop() if inImplicitControl()
         stack.push [tag, i]
@@ -225,7 +230,7 @@ exports.Rewriter = class Rewriter
           tag is '?' and i > 0 and not tokens[i - 1].spaced) and
          (nextTag in IMPLICIT_CALL or
           nextTag in IMPLICIT_UNSPACED_CALL and
-          not tokens[i + 1]?.spaced and not tokens[i + 1]?.newLine)
+          not nextToken.spaced and not nextToken.newLine)
         tag = token[0] = 'FUNC_EXIST' if tag is '?'
         startImplicitCall i + 1
         return forward(2)
@@ -235,13 +240,6 @@ exports.Rewriter = class Rewriter
       #     f
       #       a: b
       #       c: d
-      #
-      # and
-      #
-      #     f
-      #       1
-      #       a: b
-      #       b: c
       #
       # Don't accept implicit calls of this type, when on the same line
       # as the control structures below as that may misinterpret constructs like:
@@ -316,7 +314,8 @@ exports.Rewriter = class Rewriter
           # Close implicit objects such as:
           # return a: 1, b: 2 unless true
           else if inImplicitObject() and not @insideForDeclaration and sameLine and
-                  tag isnt 'TERMINATOR' and prevTag isnt ':'
+                  tag isnt 'TERMINATOR' and prevTag isnt ':' and
+                  not (tag is 'POST_IF' and startsLine and implicitObjectContinues(i + 1))
             endImplicitObject()
           # Close implicit objects when at end of line, line didn't end with a comma
           # and the implicit object didn't start the line or the next line doesn't look like

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -83,7 +83,7 @@ exports.Rewriter = class Rewriter
   # Match it with its paired close.
   closeOpenIndexes: ->
     condition = (token, i) ->
-      token[0] is [']', 'INDEX_END']
+      token[0] in [']', 'INDEX_END']
 
     action = (token, i) ->
       token[0] = 'INDEX_END'

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -622,3 +622,12 @@ test "#4544: Postfix conditionals in first line of implicit object literals", ->
   x = bar: 42 if no
   baz: 1337
   ok not x?
+
+  # Example from #2051
+  a = null
+  _alert = (arg) -> a = arg
+  _alert
+    val3: "works" if true
+    val: "hello"
+    val2: "all good"
+  eq a.val2, "all good"

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -439,6 +439,12 @@ test "#3216: For loop declaration as a value of an implicit object", ->
   arrayEq ob.b, test
   arrayEq ob.c, test
   arrayEq ob.d, test
+  byFirstKey =
+    a: for v in test by 1 then v
+  arrayEq byFirstKey.a, test
+  whenFirstKey =
+    a: for v in test when true then v
+  arrayEq whenFirstKey.a, test
 
 test 'inline implicit object literals within multiline implicit object literals', ->
   x =
@@ -587,3 +593,32 @@ test "#1263: Braceless object return", ->
   eq 1, obj.a
   eq 2, obj.b
   eq 3, obj.c()
+
+test "#4544: Postfix conditionals in first line of implicit object literals", ->
+  two =
+    foo:
+      bar: 42 if yes
+      baz: 1337
+  eq 42, two.foo.bar
+  eq 1337, two.foo.baz
+
+  f = (x) -> x
+
+  three =
+    foo: f
+      bar: 42 if yes
+      baz: 1337
+  eq 42, three.foo.bar
+  eq 1337, three.foo.baz
+
+  four =
+    f
+      foo:
+        bar: 42 if yes
+      baz: 1337
+  eq 42, four.foo.bar
+  eq 1337, four.baz
+
+  x = bar: 42 if no
+  baz: 1337
+  ok not x?


### PR DESCRIPTION
Fixes #4544. Also includes some little `rewriter.coffee` cleanups

The reason for the behavior @couchand describes in #4544 is that postfix `if`s are currently treated as implicit-object-literal-closing if they're on the first line of the object literal so that things like `x = a: b if c` work correctly. But it's assuming that it's a single-line object literal, so if the expected compilation described by @couchand is desired (which I think it is, ie you should be able to swap two lines of an object literal without anything weird happening) then this fixes it by sniffing ahead to see if we appear to be on the first line of a multi-line object literal

Added the examples given by @couchand as well as a few more cases to `test/objects.coffee`

@GeoffreyBooth I figured you'd want this targeted against `2`?

@GeoffreyBooth @lydell let me know if I should justify the correctness of any/all of the little cleanup refactorings