### PR TITLE
Fix REPL assignment

### DIFF
--- a/lib/coffee-script/repl.js
+++ b/lib/coffee-script/repl.js
@@ -38,7 +38,7 @@
           return results;
         })();
         ast = CoffeeScript.nodes(tokens);
-        ast = new Block([new Assign(new Value(new Literal('_')), ast, '=')]);
+        ast = new Block([new Assign(new Value(new Literal('__')), ast, '=')]);
         js = ast.compile({
           bare: true,
           locals: Object.keys(context),

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -33,7 +33,7 @@ replDefaults =
       ast = CoffeeScript.nodes tokens
       # Add assignment to `_` variable to force the input to be an expression.
       ast = new Block [
-        new Assign (new Value new Literal '_'), ast, '='
+        new Assign (new Value new Literal '__'), ast, '='
       ]
       js = ast.compile {bare: yes, locals: Object.keys(context), referencedVars}
       cb null, runInContext js, context, filename


### PR DESCRIPTION
Is no one ever using the REPL? The variable was never documented, but Node does this on its own, so you can access the last expression with both `_` and `__`. No more annoying messages!!!