### PR TITLE
Fix #4283: error message for implicit call

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -213,7 +213,7 @@
               ours: true
             }
           ]);
-          tokens.splice(idx, 0, generate('CALL_START', '('));
+          tokens.splice(idx, 0, generate('CALL_START', '(', ['', 'implicit function call', token[2]]));
           if (j == null) {
             return i += 1;
           }

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -162,7 +162,7 @@ exports.Rewriter = class Rewriter
       startImplicitCall = (j) ->
         idx = j ? i
         stack.push ['(', idx, ours: yes]
-        tokens.splice idx, 0, generate 'CALL_START', '('
+        tokens.splice idx, 0, generate 'CALL_START', '(', ['', 'implicit function call', token[2]]
         i += 1 if not j?
 
       endImplicitCall = ->

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1319,3 +1319,12 @@ test "#4248: Unicode code point escapes", ->
     '\\u{a}\\u{1111110000}'
       \    ^\^^^^^^^^^^^^^
   '''
+
+test "#4283: error message for implicit call", ->
+  assertErrorFormat '''
+    console.log {search, users, contacts users_to_display}
+  ''', '''
+    [stdin]:1:29: error: unexpected implicit function call
+    console.log {search, users, contacts users_to_display}
+                                ^^^^^^^^
+  '''


### PR DESCRIPTION
Fixes #4283

@lydell is this what you had in mind? I made the error message `unexpected implicit function call`, and it points to the identifier that was being implicitly called (almost seems like it should point to the space between the implicit function and its first arg, but this probably clarifies the error sufficiently?)