### PR TITLE
Fix #3906: safe missing end token error

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -12,7 +12,7 @@
     function Lexer() {}
 
     Lexer.prototype.tokenize = function(code, opts) {
-      var consumed, end, i, ref2;
+      var consumed, end, i, ref2, ref3;
       if (opts == null) {
         opts = {};
       }
@@ -46,7 +46,7 @@
       }
       this.closeIndentation();
       if (end = this.ends.pop()) {
-        this.error("missing " + end.tag, end.origin[2]);
+        this.error("missing " + end.tag, ((ref3 = end.origin) != null ? ref3 : end)[2]);
       }
       if (opts.rewrite === false) {
         return this.tokens;

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -78,7 +78,7 @@ exports.Lexer = class Lexer
       return {@tokens, index: i} if opts.untilBalanced and @ends.length is 0
 
     @closeIndentation()
-    @error "missing #{end.tag}", end.origin[2] if end = @ends.pop()
+    @error "missing #{end.tag}", (end.origin ? end)[2] if end = @ends.pop()
     return @tokens if opts.rewrite is off
     (new Rewriter).rewrite @tokens
 

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1319,3 +1319,37 @@ test "#4248: Unicode code point escapes", ->
     '\\u{a}\\u{1111110000}'
       \    ^\^^^^^^^^^^^^^
   '''
+
+test "#3906: error for unusual indentation", ->
+  assertErrorFormat '''
+    a('b')
+      .c 'a',
+        {b: 'a'}
+      .c()
+    a(
+      'b'
+    )
+    1
+  ''', '''
+    [stdin]:8:2: error: missing OUTDENT
+    1
+     ^
+  '''
+
+test "#3906: error for unusual indentation", ->
+  assertErrorFormat '''
+    a
+        .b ->
+            c
+        .d
+
+    e(
+        f
+    )
+
+    g
+  ''', '''
+    [stdin]:10:2: error: missing OUTDENT
+    g
+     ^
+  '''


### PR DESCRIPTION
Fixes #3906 

This fixes the TypeError thrown by the compiler when trying to compile the examples from #3906. All of the examples from that issue except @GeoffreyBooth's should really successfully compile though - I fixed that as well, but figure that the compiler-throwing-an-error part should be merged into `master` while the fix-wonky-indentation-behavior part should be merged into `2`? So I'll open a second pull request against `2` that makes those examples compile successfully