### PR TITLE
[CS2] Fix for comma after function glyph [#1043]

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -441,7 +441,7 @@
           return this.tokens.splice((this.tag(i - 1) === ',' ? i - 1 : i), 0, outdent);
         };
         return this.scanTokens(function(token, i, tokens) {
-          var j, k, ref, ref1, tag;
+          var j, k, ref, ref1, ref2, tag;
           [tag] = token;
           if (tag === 'TERMINATOR') {
             if (this.tag(i + 1) === 'ELSE' && this.tag(i - 1) !== 'OUTDENT') {
@@ -462,7 +462,7 @@
               return 2 + j;
             }
           }
-          if ((tag === '->' || tag === '=>') && this.tag(i + 1) === ',') {
+          if ((tag === '->' || tag === '=>') && ((ref2 = this.tag(i + 1)) === ',' || ref2 === '.')) {
             [indent, outdent] = this.indentation(tokens[i]);
             tokens.splice(i + 1, 0, indent, outdent);
             return 1;

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -462,6 +462,11 @@
               return 2 + j;
             }
           }
+          if ((tag === '->' || tag === '=>') && this.tag(i + 1) === ',') {
+            [indent, outdent] = this.indentation(tokens[i]);
+            tokens.splice(i + 1, 0, indent, outdent);
+            return 1;
+          }
           if (indexOf.call(SINGLE_LINERS, tag) >= 0 && this.tag(i + 1) !== 'INDENT' && !(tag === 'ELSE' && this.tag(i + 1) === 'IF')) {
             starter = tag;
             [indent, outdent] = this.indentation(tokens[i]);

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -434,7 +434,7 @@ exports.Rewriter = class Rewriter
         for j in [1..2] when @tag(i + j) in ['OUTDENT', 'TERMINATOR', 'FINALLY']
           tokens.splice i + j, 0, @indentation()...
           return 2 + j
-      if tag in ['->', '=>'] and @tag(i + 1) is ','
+      if tag in ['->', '=>'] and @tag(i + 1) in [',', '.']
         [indent, outdent] = @indentation tokens[i]
         tokens.splice i + 1, 0, indent, outdent
         return 1

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -434,6 +434,10 @@ exports.Rewriter = class Rewriter
         for j in [1..2] when @tag(i + j) in ['OUTDENT', 'TERMINATOR', 'FINALLY']
           tokens.splice i + j, 0, @indentation()...
           return 2 + j
+      if tag in ['->', '=>'] and @tag(i + 1) is ','
+        [indent, outdent] = @indentation tokens[i]
+        tokens.splice i + 1, 0, indent, outdent
+        return 1
       if tag in SINGLE_LINERS and @tag(i + 1) isnt 'INDENT' and
          not (tag is 'ELSE' and @tag(i + 1) is 'IF')
         starter = tag

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -378,3 +378,27 @@ test "#1043: comma after function glyph", ->
   eq g, undefined
   h = f(=>, 2)
   eq h, undefined
+
+test "#3845/#3446: chain after function glyph", ->
+  angular = module: -> controller: -> controller: ->
+
+  eq undefined,
+    angular.module 'foo'
+    .controller 'EmailLoginCtrl', ->
+    .controller 'EmailSignupCtrl', ->
+
+  beforeEach = (f) -> f()
+  getPromise = -> then: -> catch: ->
+
+  eq undefined,
+    beforeEach ->
+      getPromise()
+      .then (@result) =>
+      .catch (@error) =>
+
+  doThing = -> then: -> catch: (f) -> f()
+  handleError = -> 3
+  eq 3,
+    doThing()
+    .then (@result) =>
+    .catch handleError

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -367,3 +367,14 @@ test "#4566: destructuring with nested default values", ->
   f = ({a: {b = 1}}) ->
     b
   eq 2, f a: b: 2
+
+test "#1043: comma after function glyph", ->
+  x = (a=->, b=2) ->
+    a()
+  eq x(), undefined
+
+  f = (a) -> a()
+  g = f ->, 2
+  eq g, undefined
+  h = f(->, 2)
+  eq h, undefined

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -376,5 +376,5 @@ test "#1043: comma after function glyph", ->
   f = (a) -> a()
   g = f ->, 2
   eq g, undefined
-  h = f(->, 2)
+  h = f(=>, 2)
   eq h, undefined


### PR DESCRIPTION
The one "unambiguous" thing I saw in #1043 was that a `,` immediately following `->` or `=>` can indicate an empty function body, since otherwise it seems to be a syntax error (ie a function body can't start with a comma). So this uses the rewriter to interpret `-> ,` and `=> ,` that way

@GeoffreyBooth I targeted `2`, I guess this could safely go on `master` since the previous meaning was a syntax error, but you seem to prefer only targeting `master` if really necessary?