### PR TITLE
Refine #4588: disallow inline chained call after function glyph

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -441,7 +441,7 @@
           return this.tokens.splice((this.tag(i - 1) === ',' ? i - 1 : i), 0, outdent);
         };
         return this.scanTokens(function(token, i, tokens) {
-          var j, k, ref, ref1, ref2, tag;
+          var j, k, ref, ref1, tag;
           [tag] = token;
           if (tag === 'TERMINATOR') {
             if (this.tag(i + 1) === 'ELSE' && this.tag(i - 1) !== 'OUTDENT') {
@@ -462,7 +462,7 @@
               return 2 + j;
             }
           }
-          if ((tag === '->' || tag === '=>') && ((ref2 = this.tag(i + 1)) === ',' || ref2 === '.')) {
+          if ((tag === '->' || tag === '=>') && (this.tag(i + 1) === ',' || this.tag(i + 1) === '.' && token.newLine)) {
             [indent, outdent] = this.indentation(tokens[i]);
             tokens.splice(i + 1, 0, indent, outdent);
             return 1;

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -434,7 +434,7 @@ exports.Rewriter = class Rewriter
         for j in [1..2] when @tag(i + j) in ['OUTDENT', 'TERMINATOR', 'FINALLY']
           tokens.splice i + j, 0, @indentation()...
           return 2 + j
-      if tag in ['->', '=>'] and @tag(i + 1) in [',', '.']
+      if tag in ['->', '=>'] and (@tag(i + 1) is ',' or @tag(i + 1) is '.' and token.newLine)
         [indent, outdent] = @indentation tokens[i]
         tokens.splice i + 1, 0, indent, outdent
         return 1

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1600,3 +1600,13 @@ test 'Bound method called as callback before binding throws runtime error', ->
     derivedBound: =>
       ok no
   d = new Derived
+
+test "#3845/#3446: chain after function glyph (but not inline)", ->
+  assertErrorFormat '''
+    a -> .b
+  ''',
+  '''
+    [stdin]:1:6: error: unexpected .
+    a -> .b
+         ^
+  '''


### PR DESCRIPTION
Per @connec's comment in #4588, distinguish between "inline" and line-break chaining when interpreting `->` followed by `.` in the token stream as `(->).`

So `a -> .b` will error (added test) while
```
a ->
.b
```
is still interpreted as `a(->).b` via #4588 