### PR TITLE
[CS2] Fix #4577; renamed destructured parameters with same default value

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3282,9 +3282,11 @@
           }
           if (obj instanceof Assign) {
             if (obj.value instanceof Assign) {
+              obj = obj.value.variable;
+            } else {
               obj = obj.value;
             }
-            this.eachName(iterator, obj.value.unwrap());
+            this.eachName(iterator, obj.unwrap());
           } else if (obj instanceof Splat) {
             node = obj.name.unwrap();
             iterator(node.value, node, this);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2492,8 +2492,10 @@ exports.Param = class Param extends Base
       if obj instanceof Assign
         # ... possibly with a default value
         if obj.value instanceof Assign
+          obj = obj.value.variable
+        else
           obj = obj.value
-        @eachName iterator, obj.value.unwrap()
+        @eachName iterator, obj.unwrap()
       # * splats within destructured parameters `[xs...]`
       else if obj instanceof Splat
         node = obj.name.unwrap()

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -245,6 +245,12 @@ test "rest element destructuring in function definition", ->
   deepEqual [1, {b:2}], f()
   deepEqual [2, {}], f {a:2}
   deepEqual [3, {c:5}], f {a:3, c:5}
+  
+  f = ({ a: aa = 0, b: bb = 0 }) -> [aa, bb]
+  deepEqual [0, 0], f {}
+  deepEqual [0, 42], f {b:42}
+  deepEqual [42, 0], f {a:42}
+  deepEqual [42, 43], f {a:42, b:43}
 
 test "#4005: `([a = {}]..., b) ->` weirdness", ->
   fn = ([a = {}]..., b) -> [a, b]


### PR DESCRIPTION
This PR fixes issue #4577. 
Renamed destructured parameters with the same default value produced a compilation error: 
`multiple parameters named 0`.

```
({ a: aa = 0, b: bb = 0 }) ->
  "#{aa}, #{bb}"
```