### PR TITLE
[CS2] merge master post-#4585

### DIFF
--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -615,7 +615,7 @@ pre .xml .cdata {
 <p><strong>Latest Version:</strong> <a href="https://github.com/jashkenas/coffeescript/tarball/1.12.6">1.12.6</a></p>
 <blockquote class="uneditable-code-block"><pre><code class="language-bash">npm install -g coffeescript
 </code></pre>
-</blockquote><p><strong>CoffeeScript 2 is coming!</strong> It adds support for <a href="/v2/#classes">ES2015 classes</a>, <a href="/v2/#fat-arrow"><code>async</code>/<code>await</code></a>, and generates JavaScript using ES2015+ syntax. <a href="/v2/">Learn more</a>.</p></p>
+</blockquote><p><strong>CoffeeScript 2 is coming!</strong> It adds support for <a href="/v2/#classes">ES2015 classes</a>, <a href="/v2/#fat-arrow"><code>async</code>/<code>await</code></a>, <a href="/v2/#jsx">JSX</a>, <a href="/v2/#splats">object rest/spread syntax</a>, and generates JavaScript using ES2015+ syntax. <a href="/v2/">Learn more</a>.</p></p>
 
     <h2>Overview</h2>
 <p><em>CoffeeScript on the left, compiled JavaScript output on the right.</em></p>

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -214,7 +214,7 @@
                 ours: true
               }
             ]);
-            return tokens.splice(idx, 0, generate('CALL_START', '('));
+            return tokens.splice(idx, 0, generate('CALL_START', '(', ['', 'implicit function call', token[2]]));
           };
           endImplicitCall = function() {
             stack.pop();

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -164,7 +164,7 @@ exports.Rewriter = class Rewriter
 
       startImplicitCall = (idx) ->
         stack.push ['(', idx, ours: yes]
-        tokens.splice idx, 0, generate 'CALL_START', '('
+        tokens.splice idx, 0, generate 'CALL_START', '(', ['', 'implicit function call', token[2]]
 
       endImplicitCall = ->
         stack.pop()

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1627,3 +1627,12 @@ test "#3906: error for unusual indentation", ->
       c
     ^^
   '''
+
+test "#4283: error message for implicit call", ->
+  assertErrorFormat '''
+    (a, b c) ->
+  ''', '''
+    [stdin]:1:5: error: unexpected implicit function call
+    (a, b c) ->
+        ^
+  '''


### PR DESCRIPTION
@GeoffreyBooth here's `2` with post-#4585 `master` merged. The test case in #4585 needed to be updated due to the grammar changes introduced by #4493 (object spread)

I wasn't sure how to resolve the merge conflict in `documentation/sections/introduction.md` - I deleted the "CoffeeScript 2 is coming..." conflict line b/c we're on `2` here but not sure how documentation works (for `master` vs `2`)?