### PR TITLE
Fix #4568: refine sameLine implicit object tagging

### DIFF
--- a/lib/coffee-script/rewriter.js
+++ b/lib/coffee-script/rewriter.js
@@ -326,6 +326,9 @@
         if (indexOf.call(LINEBREAKS, tag) >= 0) {
           for (k = stack.length - 1; k >= 0; k += -1) {
             stackItem = stack[k];
+            if (!isImplicit(stackItem)) {
+              break;
+            }
             if (isImplicitObject(stackItem)) {
               stackItem[2].sameLine = false;
             }

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -303,8 +303,9 @@ exports.Rewriter = class Rewriter
 
       # Mark all enclosing objects as not sameLine
       if tag in LINEBREAKS
-        for stackItem in stack by -1 when isImplicitObject stackItem
-          stackItem[2].sameLine = no
+        for stackItem in stack by -1
+          break unless isImplicit stackItem
+          stackItem[2].sameLine = no if isImplicitObject stackItem
 
       newLine = prevTag is 'OUTDENT' or prevToken.newLine
       if tag in IMPLICIT_END or tag in CALL_CLOSERS and newLine

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -232,6 +232,16 @@ test "method call chaining inside objects", ->
       .c
   eq 42, result.b
 
+test "#4568: refine sameLine implicit object tagging", ->
+  condition = yes
+  fn = -> yes
+
+  x =
+    fn bar: {
+      foo: 123
+    } if not condition
+  eq x, undefined
+
 # Nested blocks caused by paren unwrapping
 test "#1492: Nested blocks don't cause double semicolons", ->
   js = CoffeeScript.compile '(0;0)'


### PR DESCRIPTION
@GeoffreyBooth this fixes #4568 but still preserves @xixixao's fix for #4533 

Refines #4534 by stopping the traversal up the `stack` (looking for implicit objects to tag as no longer being `sameLine`) once we see something non-implicit (eg an `EXPRESSION_START`)

This fixes @jo-soft's reported regression in #4568 (simplified):
```
fn bar: {
  foo: 123
} if not condition
```
Basically what was happening post-#4534 was that when it hit the `OUTDENT` after `123`, it was tagging the `bar: ...` implicit object as no longer being `sameLine`. The correct (and pre-#4534) behavior is that it should treat the `OUTDENT` as being contained to within the literal `{...}` (represented by the literal `{` being at the top of the `stack`). So we should stop traversing the stack tagging implicit objects as `sameLine: no` once we hit that literal `{`. But for cases like #4533, we can still preserve this approach of traversing the stack tagging `sameLine: no` as long as we're only traversing through implicit objects/calls