### PR TITLE
[CS2] Object spread syntax in multiline objects without braces or commas

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -133,8 +133,96 @@
         return i + j + fuzz - 1;
       }
 
+      detectObjectSpreadStart(j) {
+        var expEnd, expStart, levels, ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, s, spreadStarters, startIdx, tag;
+        spreadStarters = ['IDENTIFIER', 'SUPER', '@', 'THIS'];
+        expStart = ['(', '{', 'CALL_START', 'PARAM_START'];
+        expEnd = [')', '}', 'CALL_END', 'PARAM_END'];
+        if (this.tag(j) === '...' && (ref = this.tag(j + 1), indexOf.call([...spreadStarters, '(', '{', 'CALL_START'], ref) >= 0)) {
+          return j;
+        }
+        startIdx = j - 1;
+        if (!(startIdx > -1)) {
+          return -1;
+        }
+        if (ref1 = this.tag(startIdx), indexOf.call(spreadStarters, ref1) >= 0) {
+          return startIdx;
+        }
+        if (this.tag(startIdx) === 'PROPERTY' || (ref2 = this.tag(startIdx), indexOf.call(expEnd, ref2) >= 0)) {
+          s = startIdx - 1;
+          levels = (ref3 = this.tag(startIdx), indexOf.call(expEnd, ref3) >= 0) ? 1 : 0;
+          while (tag = this.tag(s)) {
+            if ((tag === '[' || tag === 'INDEX_START' || tag === 'PARAM_START') && levels <= 0) {
+              return -1;
+            }
+            if (indexOf.call(expStart, tag) >= 0 && levels === 0 || (ref4 = this.tag(s - 1), indexOf.call(expStart, ref4) >= 0) && levels < 0) {
+              if ((ref5 = this.tag(s - 1), indexOf.call(spreadStarters, ref5) >= 0) && (ref6 = this.tag(s - 2), indexOf.call(expStart, ref6) >= 0)) {
+                return s - 2;
+              }
+              if (ref7 = this.tag(s - 1), indexOf.call(spreadStarters, ref7) >= 0) {
+                return s - 1;
+              }
+              if (!(ref8 = this.tag(s - 1), indexOf.call(expEnd, ref8) >= 0) && this.tag(s - 1) !== '.') {
+                return s;
+              }
+              levels = 0;
+            }
+            if (indexOf.call(spreadStarters, tag) >= 0 && levels <= 0) {
+              return s;
+            }
+            if (indexOf.call(expEnd, tag) >= 0) {
+              levels += 1;
+            } else if (indexOf.call(expStart, tag) >= 0) {
+              levels -= 1;
+            }
+            s -= 1;
+          }
+        }
+        return -1;
+      }
+
+      detectObjectSpread(j) {
+        var action, condition, end, index, ref, spreadStart;
+        spreadStart = ['IDENTIFIER', 'SUPER', '@', 'THIS', '(', '[', '{', 'CALL_START'];
+        if (this.tag(j) === '...' && (ref = this.tag(j + 1), indexOf.call(spreadStart, ref) >= 0)) {
+          return true;
+        }
+        if (this.indexOfTag(j, 'IDENTIFIER', '...') > -1 || this.indexOfTag(j, '@', null, '...') > -1) {
+          return true;
+        }
+        index = this.indexOfTag(j, [...EXPRESSION_START, ...spreadStart]);
+        if (!(index > -1)) {
+          return false;
+        }
+        end = null;
+        condition = function(token, i) {
+          var cond1, cond2, ref1, ref2;
+          cond1 = this.tag(i) === '...' && ((ref1 = this.tag(i - 1)) === 'IDENTIFIER' || ref1 === 'PROPERTY' || ref1 === ')' || ref1 === ']' || ref1 === '}' || ref1 === 'CALL_END');
+          cond2 = this.tag(i + 1) === '...' && ((ref2 = this.tag(i)) === 'IDENTIFIER' || ref2 === 'PROPERTY' || ref2 === ')' || ref2 === ']' || ref2 === '}' || ref2 === 'CALL_END');
+          return cond1 || cond2;
+        };
+        action = function(token, i) {
+          var ref1, ref2;
+          if (((ref1 = this.tokens[i]) != null ? ref1[0] : void 0) === '...') {
+            end = i;
+          }
+          if (((ref2 = this.tokens[i + 1]) != null ? ref2[0] : void 0) === '...') {
+            end = i + 1;
+          }
+          return end;
+        };
+        this.detectEnd(index + 1, condition, action);
+        if (this.tag(end) === '...') {
+          return true;
+        }
+        return false;
+      }
+
       looksObjectish(j) {
         var end, index;
+        if (!this.processingImplicitCall && this.detectObjectSpread(j)) {
+          return true;
+        }
         if (this.indexOfTag(j, '@', null, ':') > -1 || this.indexOfTag(j, null, ':') > -1) {
           return true;
         }
@@ -174,7 +262,7 @@
         stack = [];
         start = null;
         return this.scanTokens(function(token, i, tokens) {
-          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
+          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, inParamOrArray, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, s, sameLine, self, spreadTag, spreadTagStart, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
           [tag] = token;
           [prevTag] = prevToken = i > 0 ? tokens[i - 1] : [];
           [nextTag] = nextToken = i < tokens.length - 1 ? tokens[i + 1] : [];
@@ -182,6 +270,7 @@
             return stack[stack.length - 1];
           };
           startIdx = i;
+          self = this;
           forward = function(n) {
             return i - startIdx + n;
           };
@@ -209,6 +298,7 @@
             return inImplicit() && ((ref = stackTop()) != null ? ref[0] : void 0) === 'CONTROL';
           };
           startImplicitCall = function(idx) {
+            self.processingImplicitCall = true;
             stack.push([
               '(', idx, {
                 ours: true
@@ -217,6 +307,7 @@
             return tokens.splice(idx, 0, generate('CALL_START', '(', ['', 'implicit function call', token[2]]));
           };
           endImplicitCall = function() {
+            self.processingImplicitCall = false;
             stack.pop();
             tokens.splice(i, 0, generate('CALL_END', ')', ['', 'end of input', token[2]]));
             return i += 1;
@@ -254,6 +345,28 @@
               return false;
             }
             return this.looksObjectish(nextTerminatorIdx + 1);
+          };
+          inParamOrArray = (j) => {
+            var end, ref;
+            end = null;
+            this.detectEnd(j, (function(token) {
+              var ref;
+              return (ref = token[0]) === ']' || ref === 'INDEX_END';
+            }), (function(token, i) {
+              return end = i;
+            }));
+            if ((ref = this.tag(end)) === ']' || ref === 'INDEX_END') {
+              return true;
+            }
+            this.detectEnd(j, (function(token) {
+              return token[0] === 'PARAM_END';
+            }), (function(token, i) {
+              return end = i;
+            }));
+            if (this.tag(end) === 'PARAM_END') {
+              return true;
+            }
+            return false;
           };
           if ((inImplicitCall() || inImplicitObject()) && indexOf.call(CONTROL_IN_IMPLICIT, tag) >= 0 || inImplicitObject() && prevTag === ':' && tag === 'FOR') {
             stack.push([
@@ -307,10 +420,17 @@
             stack.push(['INDENT', i + 2]);
             return forward(3);
           }
-          if (tag === ':') {
+          spreadTag = false;
+          if (tag === '...' && !(this.processingImplicitCall || inParamOrArray(i))) {
+            spreadTagStart = this.detectObjectSpreadStart(i);
+            spreadTag = spreadTagStart > -1;
+          }
+          if (tag === ':' || spreadTag) {
             s = (function() {
               var ref;
               switch (false) {
+                case !spreadTag:
+                  return spreadTagStart;
                 case ref = this.tag(i - 1), indexOf.call(EXPRESSION_END, ref) < 0:
                   return start[1];
                 case this.tag(i - 2) !== '@':
@@ -325,7 +445,7 @@
             startsLine = s === 0 || (ref = this.tag(s - 1), indexOf.call(LINEBREAKS, ref) >= 0) || tokens[s - 1].newLine;
             if (stackTop()) {
               [stackTag, stackIdx] = stackTop();
-              if ((stackTag === '{' || stackTag === 'INDENT' && this.tag(stackIdx - 1) === '{') && (startsLine || this.tag(s - 1) === ',' || this.tag(s - 1) === '{')) {
+              if ((stackTag === '{' || stackTag === 'INDENT' && this.tag(stackIdx - 1) === '{') && (startsLine || this.tag(s - 1) === ',' || this.tag(s - 1) === '{' || this.tag(s - 1) === '...')) {
                 return forward(1);
               }
             }
@@ -527,6 +647,8 @@
       }
 
     };
+
+    Rewriter.prototype.processingImplicitCall = false;
 
     Rewriter.prototype.generate = generate;
 

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -413,7 +413,7 @@ exports.Rewriter = class Rewriter
           # Close implicit objects when at end of line, line didn't end with a comma
           # and the implicit object didn't start the line or the next line doesn't look like
           # the continuation of an object.
-          else if inImplicitObject() and tag is 'TERMINATOR' and prevTag isnt ',' and 
+          else if inImplicitObject() and tag is 'TERMINATOR' and prevTag isnt ',' and
                   not (startsLine and @looksObjectish(i + 1))
             return forward 1 if nextTag is 'HERECOMMENT'
             endImplicitObject()
@@ -434,7 +434,8 @@ exports.Rewriter = class Rewriter
       #     f a, b: c, d: e, f, g: h: i, j
       #
 
-      if tag is ',' and not @looksObjectish(i + 1) and inImplicitObject() and (nextTag isnt 'TERMINATOR' or not @looksObjectish(i + 2))
+      if tag is ',' and not @looksObjectish(i + 1) and inImplicitObject() and 
+          (nextTag isnt 'TERMINATOR' or not @looksObjectish(i + 2))
         # When nextTag is OUTDENT the comma is insignificant and
         # should just be ignored so embed it in the implicit object.
         #

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -107,10 +107,74 @@ exports.Rewriter = class Rewriter
       return -1 if @tag(i + j + fuzz) not in pattern[j]
     i + j + fuzz - 1
 
+  # Return starting position of the object spread when used without braces and commas.
+  detectObjectSpreadStart: (j) ->
+    spreadStarters = ['IDENTIFIER', 'SUPER', '@', 'THIS']
+    expStart = ['(', '{', 'CALL_START', 'PARAM_START']
+    expEnd = [')', '}', 'CALL_END', 'PARAM_END']
+    # left side spread, e.g. ...obj
+    return j if @tag(j) is '...' and @tag(j + 1) in [spreadStarters..., '(', '{', 'CALL_START']
+    startIdx = j - 1
+    return -1 unless startIdx > -1 
+    # right side spread, e.g, obj...
+    return startIdx if @tag(startIdx) in spreadStarters
+    if @tag(startIdx) is 'PROPERTY' or @tag(startIdx) in expEnd
+      s = startIdx - 1
+      levels = if @tag(startIdx) in expEnd then 1 else 0
+      while tag = @tag(s)
+        # Stop if spread is directly in array or argument.
+        return -1 if tag in ['[', 'INDEX_START', 'PARAM_START'] and levels <= 0
+        # Spread is wrapped in '()', '{}'
+        if tag in expStart and levels == 0 or @tag(s - 1) in expStart and levels < 0
+          # foo({})...
+          return s - 2 if @tag(s - 1) in spreadStarters and @tag(s - 2) in expStart
+          # foo()...
+          return s - 1 if @tag(s - 1) in spreadStarters
+          # ()...
+          return s if not (@tag(s - 1) in expEnd) and @tag(s - 1) isnt '.'
+          levels = 0
+        # foo...  
+        return s if tag in spreadStarters and levels <= 0
+        if tag in expEnd
+          levels += 1
+        else if tag in expStart
+          levels -= 1
+        s -= 1
+    -1
+
+  # Return yes if standing in front of the spread.
+  # foo.., foo()..., {}..., ()...
+  # ...foo, ...foo(), ...(), ...{}
+  detectObjectSpread: (j) ->
+    spreadStart = ['IDENTIFIER', 'SUPER', '@', 'THIS', '(', '[', '{', 'CALL_START']
+    # left side spread
+    return yes if @tag(j) is '...' and @tag(j + 1) in spreadStart
+    #right side spread
+    return yes if @indexOfTag(j, 'IDENTIFIER', '...') > -1 or @indexOfTag(j, '@', null, '...') > -1
+    index = @indexOfTag(j, [EXPRESSION_START..., spreadStart...])
+    return no unless index > -1
+    end = null
+    condition = (token, i) ->
+      cond1 = @tag(i) is '...' and @tag(i - 1) in ['IDENTIFIER', 'PROPERTY', ')', ']', '}', 'CALL_END']
+      cond2 = @tag(i + 1) is '...' and @tag(i) in ['IDENTIFIER', 'PROPERTY', ')', ']', '}', 'CALL_END']      
+      cond1 or cond2
+    action = (token, i) ->
+      end = i if @tokens[i]?[0] is '...'  
+      end = i + 1 if @tokens[i + 1]?[0] is '...'  
+      end
+    @detectEnd index + 1, condition, action
+    return yes if @tag(end) is '...'
+    no
+  
+  # Helper property when dealing with an implicit call, (e.g. f a:1, obj...)
+  # which is used to avoid processing spreads.
+  processingImplicitCall: no
+
   # Returns `yes` if standing in front of something looking like
   # `@<x>:`, `<x>:` or `<EXPRESSION_START><x>...<EXPRESSION_END>:`,
   # skipping over 'HERECOMMENT's.
   looksObjectish: (j) ->
+    return yes if not @processingImplicitCall and @detectObjectSpread(j)
     return yes if @indexOfTag(j, '@', null, ':') > -1 or @indexOfTag(j, null, ':') > -1
     index = @indexOfTag(j, EXPRESSION_START)
     if index > -1
@@ -146,6 +210,7 @@ exports.Rewriter = class Rewriter
       [nextTag] = nextToken = if i < tokens.length - 1 then tokens[i + 1] else []
       stackTop  = -> stack[stack.length - 1]
       startIdx  = i
+      self = @
 
       # Helper function, used for keeping track of the number of tokens consumed
       # and spliced, when returning for getting a new token.
@@ -163,10 +228,12 @@ exports.Rewriter = class Rewriter
       inImplicitControl = -> inImplicit() and stackTop()?[0] is 'CONTROL'
 
       startImplicitCall = (idx) ->
+        self.processingImplicitCall = yes
         stack.push ['(', idx, ours: yes]
         tokens.splice idx, 0, generate 'CALL_START', '(', ['', 'implicit function call', token[2]]
 
       endImplicitCall = ->
+        self.processingImplicitCall = no
         stack.pop()
         tokens.splice i, 0, generate 'CALL_END', ')', ['', 'end of input', token[2]]
         i += 1
@@ -191,6 +258,16 @@ exports.Rewriter = class Rewriter
           returnOnNegativeLevel: yes
         return no unless nextTerminatorIdx?
         @looksObjectish nextTerminatorIdx + 1
+      
+      # Helper function returns yes if spread is directly in the argument or array
+      # [a, b..., c], f a:1, obj...
+      inParamOrArray = (j) =>
+        end = null
+        @detectEnd j, ((token) -> token[0] in [']', 'INDEX_END']), ((token, i) -> end = i)
+        return yes if @tag(end) in [']', 'INDEX_END']
+        @detectEnd j, ((token) -> token[0] is 'PARAM_END'), ((token, i) -> end = i)
+        return yes if @tag(end) is 'PARAM_END'
+        no
 
       # Don't end an implicit call/object on next indent if any of these are in an argument/value
       if (
@@ -234,7 +311,7 @@ exports.Rewriter = class Rewriter
         start = stack.pop()
 
       # Recognize standard implicit calls like
-      # f a, f() b, f? c, h[0] d etc.
+      # f a, f ...a, f() b, f? c, h[0] d etc.
       # Added support for spread dots on the left side: f ...a
       if (tag in IMPLICIT_FUNC and token.spaced or
           tag is '?' and i > 0 and not tokens[i - 1].spaced) and
@@ -271,10 +348,19 @@ exports.Rewriter = class Rewriter
         stack.push ['INDENT', i + 2]
         return forward(3)
 
-      # Implicit objects start here
-      if tag is ':'
+      # Check if tag is object spread.
+      spreadTag = no
+      if tag is '...' and not (@processingImplicitCall or inParamOrArray(i))
+        # Find the staring position of the spread. 
+        # Spread can be positioned on the left or the right side.
+        spreadTagStart = @detectObjectSpreadStart i
+        spreadTag = spreadTagStart > -1
+      
+      # Implicit objects start here, e.g. a:1 or a...
+      if tag is ':' or spreadTag
         # Go back to the (implicit) start of the object
         s = switch
+          when spreadTag then spreadTagStart
           when @tag(i - 1) in EXPRESSION_END then start[1]
           when @tag(i - 2) is '@' then i - 2
           else i - 1
@@ -285,7 +371,7 @@ exports.Rewriter = class Rewriter
         if stackTop()
           [stackTag, stackIdx] = stackTop()
           if (stackTag is '{' or stackTag is 'INDENT' and @tag(stackIdx - 1) is '{') and
-             (startsLine or @tag(s - 1) is ',' or @tag(s - 1) is '{')
+             (startsLine or @tag(s - 1) is ',' or @tag(s - 1) is '{' or @tag(s - 1) is '...')
             return forward(1)
 
         startImplicitObject(s, !!startsLine)
@@ -327,7 +413,7 @@ exports.Rewriter = class Rewriter
           # Close implicit objects when at end of line, line didn't end with a comma
           # and the implicit object didn't start the line or the next line doesn't look like
           # the continuation of an object.
-          else if inImplicitObject() and tag is 'TERMINATOR' and prevTag isnt ',' and
+          else if inImplicitObject() and tag is 'TERMINATOR' and prevTag isnt ',' and 
                   not (startsLine and @looksObjectish(i + 1))
             return forward 1 if nextTag is 'HERECOMMENT'
             endImplicitObject()
@@ -347,8 +433,8 @@ exports.Rewriter = class Rewriter
       #
       #     f a, b: c, d: e, f, g: h: i, j
       #
-      if tag is ',' and not @looksObjectish(i + 1) and inImplicitObject() and
-         (nextTag isnt 'TERMINATOR' or not @looksObjectish(i + 2))
+
+      if tag is ',' and not @looksObjectish(i + 1) and inImplicitObject() and (nextTag isnt 'TERMINATOR' or not @looksObjectish(i + 2))
         # When nextTag is OUTDENT the comma is insignificant and
         # should just be ignored so embed it in the implicit object.
         #

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -433,7 +433,6 @@ exports.Rewriter = class Rewriter
       #
       #     f a, b: c, d: e, f, g: h: i, j
       #
-
       if tag is ',' and not @looksObjectish(i + 1) and inImplicitObject() and 
           (nextTag isnt 'TERMINATOR' or not @looksObjectish(i + 2))
         # When nextTag is OUTDENT the comma is insignificant and


### PR DESCRIPTION
This is initial commit for object spread syntax in multiline objects without braces or commas (#4600).
Left and right position of spread dots are supported. 
It's still rough around the edges and needs refinements. The trickiest part was detecting the starting position of the spread and detecting if next token is spread. 

Examples:

```coffeescript
# bar =
#   foo...
#   c: 3
bar = Object.assign({}, foo, {
    c: 3
  });
  
# bar = a:1, foo...
bar = Object.assign({a:1}, 
    foo);

# bar = a:1, ...foo
bar = Object.assign({a:1}, 
    foo);
```

Function parameters compiles as usual.

```coffeescript
# f a:1, obj...
f({
    a: 1
  }, ...obj);

# f ...obj, a:1
f(...obj, {
   a: 1
 });

# f {a:1, obj...}
f(Object.assign({
    a: 1
  }, obj));
```