### PR TITLE
[CS2] CLI: Propagate SIGINT and SIGTERM signals when node is forked

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -462,6 +462,9 @@ forkNode = ->
     cwd:        process.cwd()
     env:        process.env
     stdio:      [0, 1, 2]
+  ['SIGINT', 'SIGTERM'].forEach (signal) ->
+    process.on signal, ->
+      p.kill signal
   p.on 'exit', (code) -> process.exit code
 
 # Print the `--help` usage message and exit. Deprecated switches are not

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -462,9 +462,9 @@ forkNode = ->
     cwd:        process.cwd()
     env:        process.env
     stdio:      [0, 1, 2]
-  ['SIGINT', 'SIGTERM'].forEach (signal) ->
-    process.on signal, ->
-      p.kill signal
+  for signal in ['SIGINT', 'SIGTERM']
+    process.on signal, do (signal) ->
+      -> p.kill signal
   p.on 'exit', (code) -> process.exit code
 
 # Print the `--help` usage message and exit. Deprecated switches are not


### PR DESCRIPTION
When running commands like `coffee --nodejs --max_old_space_size=128 index.coffee` the coffee process doesn't forward signals to node process, which was already discussed in #4185.

Problem is that tools that use flow SIGTERM, delay, SIGKILL leave zombie processes.

This fixes #4185.