### PR TITLE
[CS2] fix for “`do super` in constructor” bug

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -66,7 +66,7 @@
     }
 
     identifierToken() {
-      var alias, colon, colonOffset, colonToken, id, idLength, inCSXTag, input, match, poppedToken, prev, prevprev, ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, regex, tag, tagToken;
+      var alias, colon, colonOffset, colonToken, id, idLength, inCSXTag, input, match, poppedToken, prev, prevprev, ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, regExSuper, regex, sup, tag, tagToken;
       inCSXTag = this.atCSXTag();
       regex = inCSXTag ? CSX_ATTRIBUTE : IDENTIFIER;
       if (!(match = regex.exec(this.chunk))) {
@@ -102,11 +102,12 @@
         this.token('DEFAULT', id);
         return id.length;
       }
-      if (id === 'do' && /^super(?:\s+?)?(?!\(\))/.exec(this.chunk.slice(3))) {
+      if (id === 'do' && (regExSuper = /^(\s*super)(?!\(\))/.exec(this.chunk.slice(3)))) {
         this.token('SUPER', 'super');
         this.token('CALL_START', '(');
         this.token('CALL_END', ')');
-        return 8;
+        [input, sup] = regExSuper;
+        return sup.length + 3;
       }
       prev = this.prev();
       tag = colon || (prev != null) && (((ref4 = prev[0]) === '.' || ref4 === '?.' || ref4 === '::' || ref4 === '?::') || !prev.spaced && prev[0] === '@') ? 'PROPERTY' : 'IDENTIFIER';

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -102,6 +102,12 @@
         this.token('DEFAULT', id);
         return id.length;
       }
+      if (id === 'do' && /^super(?:\s+?)?(?!\(\))/.exec(this.chunk.slice(3))) {
+        this.token('SUPER', 'super');
+        this.token('CALL_START', '(');
+        this.token('CALL_END', ')');
+        return 8;
+      }
       prev = this.prev();
       tag = colon || (prev != null) && (((ref4 = prev[0]) === '.' || ref4 === '?.' || ref4 === '::' || ref4 === '?::') || !prev.spaced && prev[0] === '@') ? 'PROPERTY' : 'IDENTIFIER';
       if (tag === 'IDENTIFIER' && (indexOf.call(JS_KEYWORDS, id) >= 0 || indexOf.call(COFFEE_KEYWORDS, id) >= 0) && !(this.exportSpecifierList && indexOf.call(COFFEE_KEYWORDS, id) >= 0)) {

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -136,6 +136,11 @@ exports.Lexer = class Lexer
     if id is 'default' and @seenExport and @tag() in ['EXPORT', 'AS']
       @token 'DEFAULT', id
       return id.length
+    if id is 'do' and /^super(?:\s+?)?(?!\(\))/.exec @chunk[3...]
+      @token 'SUPER', 'super'
+      @token 'CALL_START', '('      
+      @token 'CALL_END', ')'
+      return 8
 
     prev = @prev()
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -136,11 +136,12 @@ exports.Lexer = class Lexer
     if id is 'default' and @seenExport and @tag() in ['EXPORT', 'AS']
       @token 'DEFAULT', id
       return id.length
-    if id is 'do' and /^super(?:\s+?)?(?!\(\))/.exec @chunk[3...]
+    if id is 'do' and regExSuper = /^(\s*super)(?!\(\))/.exec @chunk[3...]
       @token 'SUPER', 'super'
       @token 'CALL_START', '('      
       @token 'CALL_END', ')'
-      return 8
+      [input, sup] = regExSuper
+      return sup.length + 3
 
     prev = @prev()
 


### PR DESCRIPTION
A small fix for the #4623 (`do super` in constructor)

```coffeescript
class b extends a
  constructor: ->
    do super
```

```javascript
b = class b extends a {
    constructor() {
      super();
    }
}
```