### PR TITLE
[CS2] Fix #2998: Object literal with inconsistent indentation should throw an error

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -280,7 +280,7 @@
         stack = [];
         start = null;
         return this.scanTokens(function(token, i, tokens) {
-          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
+          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, ref1, ref2, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
           [tag] = token;
           [prevTag] = prevToken = i > 0 ? tokens[i - 1] : [];
           [nextTag] = nextToken = i < tokens.length - 1 ? tokens[i + 1] : [];
@@ -473,8 +473,11 @@
               if ((stackTag === '{' || stackTag === 'INDENT' && this.tag(stackIdx - 1) === '{') && (startsLine || this.tag(s - 1) === ',' || this.tag(s - 1) === '{')) {
                 return forward(1);
               }
+            // Is this an indentation error within what was intended to be one object?
+            } else if (s > 3 && (ref1 = this.tag(s - 1), indexOf.call(LINEBREAKS, ref1) >= 0) && (ref2 = this.tag(s - 2), indexOf.call(LINEBREAKS, ref2) >= 0) && this.tag(s - 3) === '}' && this.tokens[s - 3].generated) {
+              throwSyntaxError('unexpected indentation', this.tokens[s - 1][2]);
             }
-            startImplicitObject(s, !!startsLine);
+            startImplicitObject(s, startsLine != null);
             return forward(2);
           }
           // End implicit calls when chaining method calls

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -315,8 +315,12 @@ exports.Rewriter = class Rewriter
           if (stackTag is '{' or stackTag is 'INDENT' and @tag(stackIdx - 1) is '{') and
              (startsLine or @tag(s - 1) is ',' or @tag(s - 1) is '{')
             return forward(1)
+        # Is this an indentation error within what was intended to be one object?
+        else if s > 3 and @tag(s - 1) in LINEBREAKS and @tag(s - 2) in LINEBREAKS and
+           @tag(s - 3) is '}' and @tokens[s - 3].generated
+          throwSyntaxError 'unexpected indentation', @tokens[s - 1][2]
 
-        startImplicitObject(s, !!startsLine)
+        startImplicitObject s, startsLine?
         return forward(2)
 
       # End implicit calls when chaining method calls

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1756,14 +1756,3 @@ test "#2998: Indentation mismatch in object shouldn’t produce two objects", ->
       ^
   '''
 
-  # Former object test that is now invalid because it looks too much like a mistake.
-  # It used to test that string-keyed objects shouldn’t suppress newlines.
-  assertErrorFormat '''
-    one =
-      '>!': 3
-    six: -> 10
-  ''', '''
-    [stdin]:3:1: error: unexpected indentation
-    six: -> 10
-    ^
-  '''

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1742,3 +1742,28 @@ test "#3199: error message for throw indented comprehension", ->
       x for x in [1, 2, 3]
       ^
   '''
+
+test "#2998: Indentation mismatch in object shouldn’t produce two objects", ->
+  assertErrorFormat '''
+  colors =
+     45: 'cyan'
+     52: 'sepia'
+    100: 'olive'
+    124: 'red'
+  ''', '''
+    [stdin]:4:3: error: unexpected indentation
+      100: 'olive'
+      ^
+  '''
+
+  # Former object test that is now invalid because it looks too much like a mistake.
+  # It used to test that string-keyed objects shouldn’t suppress newlines.
+  assertErrorFormat '''
+    one =
+      '>!': 3
+    six: -> 10
+  ''', '''
+    [stdin]:3:1: error: unexpected indentation
+    six: -> 10
+    ^
+  '''

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -113,12 +113,6 @@ ok obj.misdent.toString() is ',,,'
 #542: Objects leading expression statement should be parenthesized.
 {f: -> ok yes }.f() + 1
 
-# String-keyed objects shouldn't suppress newlines.
-one =
-  '>!': 3
-six: -> 10
-ok not one.six
-
 # Shorthand objects with property references.
 obj =
   ### comment one ###
@@ -696,4 +690,3 @@ test "#4579: Postfix for/while/until in first line of implicit object literals",
       baz: 1337
   arrayEq [4, 3, 2, 1, 0], six.foo.bar
   eq 1337, six.foo.baz
-

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -113,6 +113,12 @@ ok obj.misdent.toString() is ',,,'
 #542: Objects leading expression statement should be parenthesized.
 {f: -> ok yes }.f() + 1
 
+# String-keyed objects shouldn't suppress newlines.
+one =
+  '>!': 3
+  six: -> 10
+eq one.six(), 10
+
 # Shorthand objects with property references.
 obj =
   ### comment one ###


### PR DESCRIPTION
Closes #2998. Now code like its example:

```coffee
known_colors =
   45:              'cyan'
   52:              'sepia'
  100:              'olive'
  124:              'red'
```

will throw an `unexpected indentation` error. Not sure if my error check is too specific, but it catches this case at least.