### PR TITLE
[CS2] Fix #4631: Expansion that becomes rest parameter causes runtime error

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -280,7 +280,7 @@
         stack = [];
         start = null;
         return this.scanTokens(function(token, i, tokens) {
-          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
+          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, ref1, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
           [tag] = token;
           [prevTag] = prevToken = i > 0 ? tokens[i - 1] : [];
           [nextTag] = nextToken = i < tokens.length - 1 ? tokens[i + 1] : [];
@@ -422,7 +422,7 @@
           // Recognize standard implicit calls like
           // f a, f() b, f? c, h[0] d etc.
           // Added support for spread dots on the left side: f ...a
-          if ((indexOf.call(IMPLICIT_FUNC, tag) >= 0 && token.spaced || tag === '?' && i > 0 && !tokens[i - 1].spaced) && (indexOf.call(IMPLICIT_CALL, nextTag) >= 0 || (nextTag === '...' && !this.findTagsBackwards(i, ['INDEX_START', '['])) || indexOf.call(IMPLICIT_UNSPACED_CALL, nextTag) >= 0 && !nextToken.spaced && !nextToken.newLine)) {
+          if ((indexOf.call(IMPLICIT_FUNC, tag) >= 0 && token.spaced || tag === '?' && i > 0 && !tokens[i - 1].spaced) && (indexOf.call(IMPLICIT_CALL, nextTag) >= 0 || (nextTag === '...' && (ref = this.tag(i + 2), indexOf.call(IMPLICIT_CALL, ref) >= 0) && !this.findTagsBackwards(i, ['INDEX_START', '['])) || indexOf.call(IMPLICIT_UNSPACED_CALL, nextTag) >= 0 && !nextToken.spaced && !nextToken.newLine)) {
             if (tag === '?') {
               tag = token[0] = 'FUNC_EXIST';
             }
@@ -456,9 +456,9 @@
           if (tag === ':') {
             // Go back to the (implicit) start of the object.
             s = (function() {
-              var ref;
+              var ref1;
               switch (false) {
-                case ref = this.tag(i - 1), indexOf.call(EXPRESSION_END, ref) < 0:
+                case ref1 = this.tag(i - 1), indexOf.call(EXPRESSION_END, ref1) < 0:
                   return start[1];
                 case this.tag(i - 2) !== '@':
                   return i - 2;
@@ -466,7 +466,7 @@
                   return i - 1;
               }
             }).call(this);
-            startsLine = s === 0 || (ref = this.tag(s - 1), indexOf.call(LINEBREAKS, ref) >= 0) || tokens[s - 1].newLine;
+            startsLine = s === 0 || (ref1 = this.tag(s - 1), indexOf.call(LINEBREAKS, ref1) >= 0) || tokens[s - 1].newLine;
             // Are we just continuing an already declared object?
             if (stackTop()) {
               [stackTag, stackIdx] = stackTop();

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -422,7 +422,7 @@
           // Recognize standard implicit calls like
           // f a, f() b, f? c, h[0] d etc.
           // Added support for spread dots on the left side: f ...a
-          if ((indexOf.call(IMPLICIT_FUNC, tag) >= 0 && token.spaced || tag === '?' && i > 0 && !tokens[i - 1].spaced) && (indexOf.call(IMPLICIT_CALL, nextTag) >= 0 || nextTag === '...' || indexOf.call(IMPLICIT_UNSPACED_CALL, nextTag) >= 0 && !nextToken.spaced && !nextToken.newLine)) {
+          if ((indexOf.call(IMPLICIT_FUNC, tag) >= 0 && token.spaced || tag === '?' && i > 0 && !tokens[i - 1].spaced) && (indexOf.call(IMPLICIT_CALL, nextTag) >= 0 || (nextTag === '...' && !this.findTagsBackwards(i, ['INDEX_START', '['])) || indexOf.call(IMPLICIT_UNSPACED_CALL, nextTag) >= 0 && !nextToken.spaced && !nextToken.newLine)) {
             if (tag === '?') {
               tag = token[0] = 'FUNC_EXIST';
             }

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -268,7 +268,7 @@ exports.Rewriter = class Rewriter
       if (tag in IMPLICIT_FUNC and token.spaced or
           tag is '?' and i > 0 and not tokens[i - 1].spaced) and
          (nextTag in IMPLICIT_CALL or 
-         (nextTag is '...' and not @findTagsBackwards(i, ['INDEX_START', '['])) or
+         (nextTag is '...' and @tag(i + 2) in IMPLICIT_CALL and not @findTagsBackwards(i, ['INDEX_START', '['])) or
           nextTag in IMPLICIT_UNSPACED_CALL and
           not nextToken.spaced and not nextToken.newLine)
         tag = token[0] = 'FUNC_EXIST' if tag is '?'

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -267,7 +267,8 @@ exports.Rewriter = class Rewriter
       # Added support for spread dots on the left side: f ...a
       if (tag in IMPLICIT_FUNC and token.spaced or
           tag is '?' and i > 0 and not tokens[i - 1].spaced) and
-         (nextTag in IMPLICIT_CALL or nextTag is '...' or
+         (nextTag in IMPLICIT_CALL or 
+         (nextTag is '...' and not @findTagsBackwards(i, ['INDEX_START', '['])) or
           nextTag in IMPLICIT_UNSPACED_CALL and
           not nextToken.spaced and not nextToken.newLine)
         tag = token[0] = 'FUNC_EXIST' if tag is '?'

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -267,7 +267,7 @@ exports.Rewriter = class Rewriter
       # Added support for spread dots on the left side: f ...a
       if (tag in IMPLICIT_FUNC and token.spaced or
           tag is '?' and i > 0 and not tokens[i - 1].spaced) and
-         (nextTag in IMPLICIT_CALL or 
+         (nextTag in IMPLICIT_CALL or
          (nextTag is '...' and @tag(i + 2) in IMPLICIT_CALL and not @findTagsBackwards(i, ['INDEX_START', '['])) or
           nextTag in IMPLICIT_UNSPACED_CALL and
           not nextToken.spaced and not nextToken.newLine)

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -185,6 +185,12 @@ test "destructuring assignment with splats", ->
   arrayEq [b,c,d], y
   eq e, z
 
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  [x,y ...,z] = [a,b,c,d,e]
+  eq a, x
+  arrayEq [b,c,d], y
+  eq e, z
+
 test "deep destructuring assignment with splats", ->
   a={}; b={}; c={}; d={}; e={}; f={}; g={}; h={}; i={}
   [u, [v, w..., x], y..., z] = [a, [b, c, d, e], f, g, h, i]
@@ -229,6 +235,11 @@ test "destructuring assignment with objects and splats", ->
   eq a, y
   arrayEq [b,c,d], z
 
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  {a: b: [y, z ...]} = obj
+  eq a, y
+  arrayEq [b,c,d], z
+
 test "destructuring assignment against an expression", ->
   a={}; b={}
   [y, z] = if true then [a, b] else [b, a]
@@ -263,6 +274,15 @@ test "destructuring assignment with splats and default values", ->
   eq b, 1
   deepEqual d, {}
 
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  {
+    a: {b} = c
+    d ...
+  } = obj
+
+  eq b, 1
+  deepEqual d, {}
+
 test "destructuring assignment with splat with default value", ->
   obj = {}
   c = {val: 1}
@@ -273,6 +293,18 @@ test "destructuring assignment with splat with default value", ->
 test "destructuring assignment with multiple splats in different objects", ->
   obj = { a: {val: 1}, b: {val: 2} }
   { a: {a...}, b: {b...} } = obj
+  deepEqual a, val: 1
+  deepEqual b, val: 2
+
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  {
+    a: {
+      a ...
+    }
+    b: {
+      b ...
+    }
+  } = obj
   deepEqual a, val: 1
   deepEqual b, val: 2
 
@@ -299,6 +331,15 @@ test "destructuring assignment with objects and splats: Babel tests", ->
   n = { x, y, z... }
   deepEqual n, { x: 1, y: 2, a: 3, b: 4 }
 
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  { x, y, z ... } = { x: 1, y: 2, a: 3, b: 4 }
+  eq x, 1
+  eq y, 2
+  deepEqual z, { a: 3, b: 4 }
+
+  n = { x, y, z ... }
+  deepEqual n, { x: 1, y: 2, a: 3, b: 4 }
+
 test "deep destructuring assignment with objects: ES2015", ->
   a1={}; b1={}; c1={}; d1={}
   obj = {
@@ -315,6 +356,13 @@ test "deep destructuring assignment with objects: ES2015", ->
     b2: {b1, c1}
   }
   {a: w, b: {c: {d: {b1: bb, r1...}}}, r2...} = obj
+  eq r1.e, c1
+  eq r2.b, undefined
+  eq bb, b1
+  eq r2.b2, obj.b2
+
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  {a: w, b: {c: {d: {b1: bb, r1 ...}}}, r2 ...} = obj
   eq r1.e, c1
   eq r2.b, undefined
   eq bb, b1
@@ -343,13 +391,52 @@ test "deep destructuring assignment with defaults: ES2015", ->
   eq hello, 'world'
   deepEqual h, some: 'prop'
 
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  {
+    a ...
+    b: {
+      c,
+      d ...
+    }
+    e: {
+      f: hello
+      g: {
+        h ...
+      } = i
+    } = j
+  } = obj
+
+  deepEqual a, foo: 'bar'
+  eq c, 1
+  deepEqual d, baz: 'qux'
+  eq hello, 'world'
+  deepEqual h, some: 'prop'
+
 test "object spread properties: ES2015", ->
   obj = {a: 1, b: 2, c: 3, d: 4, e: 5}
   obj2 = {obj..., c:9}
   eq obj2.c, 9
   eq obj.a, obj2.a
 
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  obj2 = {
+    obj ...
+    c:9
+  }
+  eq obj2.c, 9
+  eq obj.a, obj2.a
+
   obj2 = {obj..., a: 8, c: 9, obj...}
+  eq obj2.c, 3
+  eq obj.a, obj2.a
+
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  obj2 = {
+    obj ...
+    a: 8
+    c: 9
+    obj ...
+  }
   eq obj2.c, 3
   eq obj.a, obj2.a
 
@@ -370,7 +457,39 @@ test "object spread properties: ES2015", ->
   eq obj4.f.g, 5
   deepEqual obj4.f, obj.c.f
 
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  (({
+    a
+    b
+    r ...
+    }) ->
+    eq 1, a
+    deepEqual r, {c: 3, d: 44, e: 55}
+  ) {
+    obj2 ...
+    d: 44
+    e: 55
+  }
+
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  obj4 = {
+    a: 10
+    obj.c ...
+  }
+  eq obj4.a, 10
+  eq obj4.d, 3
+  eq obj4.f.g, 5
+  deepEqual obj4.f, obj.c.f
+
   obj5 = {obj..., ((k) -> {b: k})(99)...}
+  eq obj5.b, 99
+  deepEqual obj5.c, obj.c
+
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  obj5 = {
+    obj ...
+    ((k) -> {b: k})(99) ...
+  }
   eq obj5.b, 99
   deepEqual obj5.c, obj.c
 
@@ -382,7 +501,16 @@ test "object spread properties: ES2015", ->
   obj7 = {obj..., fn()..., {c: {d: 55, e: 66, f: {77}}}...}
   eq obj7.c.d, 55
   deepEqual obj6.c, {d: 33, e: 44, f: {g: 55}}
-  
+
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  obj7 = {
+    obj ...
+    fn() ...
+    {c: {d: 55, e: 66, f: {77}}} ...
+  }
+  eq obj7.c.d, 55
+  deepEqual obj6.c, {d: 33, e: 44, f: {g: 55}}
+
   obj =
     a:
       b:

--- a/test/ranges.coffee
+++ b/test/ranges.coffee
@@ -28,6 +28,19 @@ test "basic exclusive ranges", ->
   arrayEq [], [0...0]
   arrayEq [], [-1...-1]
 
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  arrayEq [1, 2, 3] , [1 ... 4]
+  arrayEq [0, 1, 2] , [0 ... 3]
+  arrayEq [0, 1]    , [0 ... 2]
+  arrayEq [0]       , [0 ... 1]
+  arrayEq [-1]      , [-1 ... 0]
+  arrayEq [-1, 0]   , [-1 ... 1]
+  arrayEq [-1, 0, 1], [-1 ... 2]
+
+  arrayEq [], [1 ... 1]
+  arrayEq [], [0 ... 0]
+  arrayEq [], [-1 ... -1]
+
 test "downward ranges", ->
   arrayEq shared, [9..0].reverse()
   arrayEq [5, 4, 3, 2] , [5..2]
@@ -65,6 +78,9 @@ test "ranges with expressions as endpoints", ->
   [a, b] = [1, 3]
   arrayEq [2, 3, 4, 5, 6], [(a+1)..2*b]
   arrayEq [2, 3, 4, 5]   , [(a+1)...2*b]
+
+  # Should not trigger implicit call, e.g. rest ... => rest(...)
+  arrayEq [2, 3, 4, 5]   , [(a+1) ... 2*b]
 
 test "large ranges are generated with looping constructs", ->
   down = [99..0]

--- a/test/slicing_and_splicing.coffee
+++ b/test/slicing_and_splicing.coffee
@@ -64,6 +64,18 @@ test "#1722: operator precedence in unbounded slice compilation", ->
 test "#2349: inclusive slicing to numeric strings", ->
   arrayEq [0, 1], [0..10][.."1"]
 
+test "#4631: slicing with space before and/or after the dots", ->
+  a = (s) -> s
+  b = [4, 5, 6]
+  c = [7, 8, 9]
+  arrayEq [2, 3, 4], shared[2 ... 5]
+  arrayEq [3, 4, 5], shared[3... 6]
+  arrayEq [4, 5, 6], shared[4 ...7]
+  arrayEq shared[(a b...)...(a c...)]  , shared[(a ...b)...(a ...c)]
+  arrayEq shared[(a b...) ... (a c...)], shared[(a ...b) ... (a ...c)]
+  arrayEq shared[(a b...)... (a c...)] , shared[(a ...b)... (a ...c)]
+  arrayEq shared[(a b...) ...(a c...)] , shared[(a ...b) ...(a ...c)]
+
 
 # Splicing
 


### PR DESCRIPTION
Closes #4631. 
After added support for the spread dots on the left side, dots in array slice, e.g. (`[a...b]`) were misinterpreted and the code was compiled to an implicit call. The error occurred when there was a space around the dots.

Example:
```coffeescript
# wrong
arr[a ... b] => arr[a(...b)]
```

```coffeescript
# correct
arr[a ... b] => arr.slice(a, b)
```





