### PR TITLE
[CS1] fix #4260 and #1349: splat error with soak properties or expressions

### DIFF
--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2741,10 +2741,20 @@
     };
 
     Splat.prototype.compileToFragments = function(o) {
+      var fragment, fragments, ix, j, len1;
       if (!(this.name instanceof Value) || (!(this.name.base instanceof Parens) && this.propHasSoak())) {
         this.name = new Value(new Parens(this.name));
+        fragments = this.name.compileToFragments(o);
+        for (ix = j = 0, len1 = fragments.length; j < len1; ix = ++j) {
+          fragment = fragments[ix];
+          if (fragment.code === "void 0" && fragment.type === "If") {
+            fragments[ix].code = "[]";
+          }
+        }
+        return fragments;
+      } else {
+        return this.name.compileToFragments(o);
       }
-      return this.name.compileToFragments(o);
     };
 
     Splat.prototype.unwrap = function() {

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -535,7 +535,7 @@
     };
 
     Literal.prototype.toString = function() {
-      return " " + (this.isStatement() ? Literal.__super__.toString.apply(this, arguments) : this.constructor.name) + ": " + this.value;
+      return " " + (this.isStatement() ? Literal.__super__.toString.apply(this, (arguments)) : this.constructor.name) + ": " + this.value;
     };
 
     return Literal;
@@ -781,7 +781,7 @@
       if (o.scope.parent == null) {
         this.error('yield can only occur inside functions');
       }
-      return YieldReturn.__super__.compileNode.apply(this, arguments);
+      return YieldReturn.__super__.compileNode.apply(this, (arguments));
     };
 
     return YieldReturn;
@@ -1037,7 +1037,7 @@
         }
         delete this.needsUpdatedStartLocation;
       }
-      return Call.__super__.updateLocationDataIfMissing.apply(this, arguments);
+      return Call.__super__.updateLocationDataIfMissing.apply(this, (arguments));
     };
 
     Call.prototype.newInstance = function() {
@@ -2725,7 +2725,25 @@
       return this.name.assigns(name);
     };
 
+    Splat.prototype.propHasSoak = function() {
+      var isSoak, j, len1, prop, ref3;
+      if (!this.name.properties) {
+        return false;
+      }
+      ref3 = this.name.properties;
+      for (j = 0, len1 = ref3.length; j < len1; j++) {
+        prop = ref3[j];
+        if (prop.soak) {
+          isSoak = true;
+        }
+      }
+      return isSoak != null ? isSoak : false;
+    };
+
     Splat.prototype.compileToFragments = function(o) {
+      if (!(this.name instanceof Value) || (!(this.name.base instanceof Parens) && this.propHasSoak())) {
+        this.name = new Value(new Parens(this.name));
+      }
       return this.name.compileToFragments(o);
     };
 
@@ -2818,7 +2836,7 @@
 
     While.prototype.makeReturn = function(res) {
       if (res) {
-        return While.__super__.makeReturn.apply(this, arguments);
+        return While.__super__.makeReturn.apply(this, (arguments));
       } else {
         this.returns = !this.jumps({
           loop: true
@@ -3371,7 +3389,7 @@
     StringWithInterpolations.prototype.compileNode = function(o) {
       var element, elements, expr, fragments, j, len1, value;
       if (!o.inTaggedTemplateCall) {
-        return StringWithInterpolations.__super__.compileNode.apply(this, arguments);
+        return StringWithInterpolations.__super__.compileNode.apply(this, (arguments));
       }
       expr = this.body.unwrap();
       elements = [];

--- a/lib/coffee-script/nodes.js
+++ b/lib/coffee-script/nodes.js
@@ -2725,36 +2725,8 @@
       return this.name.assigns(name);
     };
 
-    Splat.prototype.propHasSoak = function() {
-      var isSoak, j, len1, prop, ref3;
-      if (!this.name.properties) {
-        return false;
-      }
-      ref3 = this.name.properties;
-      for (j = 0, len1 = ref3.length; j < len1; j++) {
-        prop = ref3[j];
-        if (prop.soak) {
-          isSoak = true;
-        }
-      }
-      return isSoak != null ? isSoak : false;
-    };
-
-    Splat.prototype.compileToFragments = function(o) {
-      var fragment, fragments, ix, j, len1;
-      if (!(this.name instanceof Value) || (!(this.name.base instanceof Parens) && this.propHasSoak())) {
-        this.name = new Value(new Parens(this.name));
-        fragments = this.name.compileToFragments(o);
-        for (ix = j = 0, len1 = fragments.length; j < len1; ix = ++j) {
-          fragment = fragments[ix];
-          if (fragment.code === "void 0" && fragment.type === "If") {
-            fragments[ix].code = "[]";
-          }
-        }
-        return fragments;
-      } else {
-        return this.name.compileToFragments(o);
-      }
+    Splat.prototype.compileNode = function(o) {
+      return this.name.compileToFragments(o);
     };
 
     Splat.prototype.unwrap = function() {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1827,7 +1827,15 @@ exports.Splat = class Splat extends Base
     if not (@name instanceof Value) or
         (not (@name.base instanceof Parens) and @propHasSoak())
       @name = new Value new Parens @name
-    @name.compileToFragments o
+      # We need to replace `void 0` with `[]` in compiled fragments.
+      # Example: [a?.b...]
+      # slice.call((typeof a !== "undefined" && a !== null ? a.b : []));
+      fragments = @name.compileToFragments o
+      for fragment, ix in fragments
+        fragments[ix].code = "[]" if fragment.code == "void 0" and fragment.type == "If"
+      fragments
+    else
+      @name.compileToFragments o
 
   unwrap: -> @name
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1812,30 +1812,8 @@ exports.Splat = class Splat extends Base
   assigns: (name) ->
     @name.assigns name
 
-  propHasSoak: ->
-    return no unless @name.properties
-    isSoak = yes for prop in @name.properties when prop.soak
-    isSoak ? no
-
-  compileToFragments: (o) ->
-    # Check if @name is not an instance of `Value` or @name properties contains soak accessor, e.g. ?.b,
-    # and ensure correct compilation by wrapping the @name in `Parens`.
-    # Examples:
-    # [a?.b...]    => [(a?.b)...]
-    # f(a.b?.c...) => f((a.b?.c)...)
-    # [a if b...]  => [(a if b)...]
-    if not (@name instanceof Value) or
-        (not (@name.base instanceof Parens) and @propHasSoak())
-      @name = new Value new Parens @name
-      # We need to replace `void 0` with `[]` in compiled fragments.
-      # Example: [a?.b...]
-      # slice.call((typeof a !== "undefined" && a !== null ? a.b : []));
-      fragments = @name.compileToFragments o
-      for fragment, ix in fragments
-        fragments[ix].code = "[]" if fragment.code == "void 0" and fragment.type == "If"
-      fragments
-    else
-      @name.compileToFragments o
+  compileNode: (o) ->
+    @name.compileToFragments o
 
   unwrap: -> @name
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1812,7 +1812,21 @@ exports.Splat = class Splat extends Base
   assigns: (name) ->
     @name.assigns name
 
+  propHasSoak: ->
+    return no unless @name.properties
+    isSoak = yes for prop in @name.properties when prop.soak
+    isSoak ? no
+
   compileToFragments: (o) ->
+    # Check if @name is not an instance of `Value` or @name properties contains soak accessor, e.g. ?.b,
+    # and ensure correct compilation by wrapping the @name in `Parens`.
+    # Examples:
+    # [a?.b...]    => [(a?.b)...]
+    # f(a.b?.c...) => f((a.b?.c)...)
+    # [a if b...]  => [(a if b)...]
+    if not (@name instanceof Value) or
+        (not (@name.base instanceof Parens) and @propHasSoak())
+      @name = new Value new Parens @name
     @name.compileToFragments o
 
   unwrap: -> @name

--- a/test/arrays.coffee
+++ b/test/arrays.coffee
@@ -72,6 +72,13 @@ test "#4260: splat after existential operator soak", ->
   arrayEq [a?.b...], [3]
   arrayEq [c?.b...], []
 
+test "#1349: trailing if after splat", ->
+  a = [3]
+  b = yes
+  c = null
+  arrayEq [a if b...], [3]
+  arrayEq [a if c...], []
+
 test "#1274: `[] = a()` compiles to `false` instead of `a()`", ->
   a = false
   fn = -> a = true

--- a/test/arrays.coffee
+++ b/test/arrays.coffee
@@ -36,9 +36,7 @@ test "array splat expansions with assignments", ->
   eq 4, b
   arrayEq [0,1,2,3,4], list
 
-
 test "mixed shorthand objects in array lists", ->
-
   arr = [
     a:1
     'b'
@@ -58,7 +56,6 @@ test "mixed shorthand objects in array lists", ->
   eq arr[2].b, 1
   eq arr[3], 'b'
 
-
 test "array splats with nested arrays", ->
   nonce = {}
   a = [nonce]
@@ -69,6 +66,11 @@ test "array splats with nested arrays", ->
   a = [[nonce]]
   list = [1, 2, a...]
   arrayEq list, [1, 2, [nonce]]
+
+test "#4260: splat after existential operator soak", ->
+  a = {b: [3]}
+  arrayEq [a?.b...], [3]
+  arrayEq [c?.b...], []
 
 test "#1274: `[] = a()` compiles to `false` instead of `a()`", ->
   a = false

--- a/test/arrays.coffee
+++ b/test/arrays.coffee
@@ -69,15 +69,27 @@ test "array splats with nested arrays", ->
 
 test "#4260: splat after existential operator soak", ->
   a = {b: [3]}
+  foo = (a) -> [a]
   arrayEq [a?.b...], [3]
-  arrayEq [c?.b...], []
+  arrayEq [c?.b ? []...], []
+  arrayEq foo(a?.b...), [3]
+  arrayEq foo(c?.b ? []...), [undefined]
+  e = yes
+  f = null
+  arrayEq [(a if e)?.b...], [3]
+  arrayEq [(a if f)?.b ? []...], []
+  arrayEq foo((a if e)?.b...), [3]
+  arrayEq foo((a if f)?.b ? []...), [undefined]
 
 test "#1349: trailing if after splat", ->
   a = [3]
   b = yes
   c = null
+  foo = (a) -> [a]
   arrayEq [a if b...], [3]
-  arrayEq [a if c...], []
+  arrayEq [(a if c) ? []...], []
+  arrayEq foo((a if b)...), [3]
+  arrayEq foo((a if c) ? []...), [undefined]
 
 test "#1274: `[] = a()` compiles to `false` instead of `a()`", ->
   a = false


### PR DESCRIPTION
This is a fix for #4260 and #1349 when invalid JS is compiled if `Splat` contains soak accessor  (`?.`), or `if` statement.

Before:
```javascript
// [a if b...]
slice.call(  if (b) {
    a;
  });

// [a?.b...]
slice.call(  if (typeof a !== "undefined" && a !== null) {
    a.b;
  });

// arr.push(error.data?.errors...)
arr.push.apply(arr, if ((ref = error.data) != null) {
  ref.errors;
});
```


After:
```javascript
// [a if b...]
slice.call((b ? a : void 0));

// [a?.b...]
slice.call((typeof a !== "undefined" && a !== null ? a.b : void 0));

// arr.push(error.data?.errors...)
arr.push.apply(arr, ((ref = error.data) != null ? ref.errors : void 0));
```