### PR TITLE
Fix #4558: Stack trace line numbers for scripts that compile CoffeeScript

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -341,11 +341,15 @@ task 'doc:source:watch', 'watch and continually rebuild the annotated source doc
 
 
 task 'release', 'build and test the CoffeeScript source, and build the documentation', ->
-  invoke 'build:full'
-  invoke 'build:browser:full'
-  invoke 'doc:site'
-  invoke 'doc:test'
-  invoke 'doc:source'
+  execSync '''
+    cake build:full
+    cake build:browser
+    cake test:browser
+    cake test:integrations
+    cake doc:site
+    cake doc:test
+    cake doc:source''', stdio: 'inherit'
+
 
 task 'bench', 'quick benchmark of compilation time', ->
   {Rewriter} = require './lib/coffeescript/rewriter'

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -4682,7 +4682,7 @@ $(document).ready ->
     else
       initializeScrollspyFromHash window.location.hash
       # Initializing the code editors might’ve thrown off our vertical scroll position
-      document.getElementById(window.location.hash.slice(1)).scrollIntoView()
+      document.getElementById(window.location.hash.slice(1).replace(/try:.*/, '')).scrollIntoView()
 
 </script>
 

--- a/documentation/v2/docs.coffee
+++ b/documentation/v2/docs.coffee
@@ -125,4 +125,4 @@ $(document).ready ->
     else
       initializeScrollspyFromHash window.location.hash
       # Initializing the code editors might’ve thrown off our vertical scroll position
-      document.getElementById(window.location.hash.slice(1)).scrollIntoView()
+      document.getElementById(window.location.hash.slice(1).replace(/try:.*/, '')).scrollIntoView()

--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -4,7 +4,8 @@
   // on Node.js/V8, or to run CoffeeScript directly in the browser. This module
   // contains the main entry functions for tokenizing, parsing, and compiling
   // source CoffeeScript into JavaScript.
-  var Lexer, SourceMap, base64encode, checkShebangLine, compile, formatSourcePosition, getSourceMap, helpers, lexer, packageJson, parser, sourceMaps, sources, withPrettyErrors;
+  var FILE_EXTENSIONS, Lexer, SourceMap, base64encode, checkShebangLine, compile, formatSourcePosition, getSourceMap, helpers, lexer, packageJson, parser, sourceMaps, sources, withPrettyErrors,
+    indexOf = [].indexOf;
 
   ({Lexer} = require('./lexer'));
 
@@ -21,7 +22,7 @@
   // The current CoffeeScript version number.
   exports.VERSION = packageJson.version;
 
-  exports.FILE_EXTENSIONS = ['.coffee', '.litcoffee', '.coffee.md'];
+  exports.FILE_EXTENSIONS = FILE_EXTENSIONS = ['.coffee', '.litcoffee', '.coffee.md'];
 
   // Expose helpers for testing.
   exports.helpers = helpers;
@@ -67,10 +68,10 @@
   // a stack trace. Assuming that most of the time, code isn’t throwing
   // exceptions, it’s probably more efficient to compile twice only when we
   // need a stack trace, rather than always generating a source map even when
-  // it’s not likely to be used. Save in form of `filename`: `(source)`
+  // it’s not likely to be used. Save in form of `filename`: [`(source)`]
   sources = {};
 
-  // Also save source maps if generated, in form of `filename`: `(source map)`.
+  // Also save source maps if generated, in form of `(source)`: [`(source map)`].
   sourceMaps = {};
 
   // Compile CoffeeScript code to JavaScript, using the Coffee/Jison compiler.
@@ -93,7 +94,10 @@
     generateSourceMap = options.sourceMap || options.inlineMap || (options.filename == null);
     filename = options.filename || '<anonymous>';
     checkShebangLine(filename, code);
-    sources[filename] = code;
+    if (sources[filename] == null) {
+      sources[filename] = [];
+    }
+    sources[filename].push(code);
     if (generateSourceMap) {
       map = new SourceMap;
     }
@@ -158,7 +162,10 @@
     }
     if (generateSourceMap) {
       v3SourceMap = map.generate(options, code);
-      sourceMaps[filename] = map;
+      if (sourceMaps[filename] == null) {
+        sourceMaps[filename] = [];
+      }
+      sourceMaps[filename].push(map);
     }
     if (options.inlineMap) {
       encoded = base64encode(JSON.stringify(v3SourceMap));
@@ -311,17 +318,43 @@
     }
   };
 
-  getSourceMap = function(filename) {
-    var answer;
-    if (sourceMaps[filename] != null) {
-      return sourceMaps[filename];
-    // CoffeeScript compiled in a browser may get compiled with `options.filename`
-    // of `<anonymous>`, but the browser may request the stack trace with the
-    // filename of the script file.
+  getSourceMap = function(filename, line, column) {
+    var answer, i, map, ref, ref1, sourceLocation;
+    if (!(filename === '<anonymous>' || (ref = filename.slice(filename.lastIndexOf('.')), indexOf.call(FILE_EXTENSIONS, ref) >= 0))) {
+      // Skip files that we didn’t compile, like Node system files that appear in
+      // the stack trace, as they never have source maps.
+      return null;
+    }
+    if (filename !== '<anonymous>' && (sourceMaps[filename] != null)) {
+      return sourceMaps[filename][sourceMaps[filename].length - 1];
+    // CoffeeScript compiled in a browser or via `CoffeeScript.compile` or `.run`
+    // may get compiled with `options.filename` that’s missing, which becomes
+    // `<anonymous>`; but the runtime might request the stack trace with the
+    // filename of the script file. See if we have a source map cached under
+    // `<anonymous>` that matches the error.
     } else if (sourceMaps['<anonymous>'] != null) {
-      return sourceMaps['<anonymous>'];
-    } else if (sources[filename] != null) {
-      answer = compile(sources[filename], {
+      ref1 = sourceMaps['<anonymous>'];
+      // Work backwards from the most recent anonymous source maps, until we find
+      // one that works. This isn’t foolproof; there is a chance that multiple
+      // source maps will have line/column pairs that match. But we have no other
+      // way to match them. `frame.getFunction().toString()` doesn’t always work,
+      // and it’s not foolproof either.
+      for (i = ref1.length - 1; i >= 0; i += -1) {
+        map = ref1[i];
+        sourceLocation = map.sourceLocation([line - 1, column - 1]);
+        if (((sourceLocation != null ? sourceLocation[0] : void 0) != null) && (sourceLocation[1] != null)) {
+          return map;
+        }
+      }
+    }
+    // If all else fails, recompile this source to get a source map. We need the
+    // previous section (for `<anonymous>`) despite this option, because after it
+    // gets compiled we will still need to look it up from
+    // `sourceMaps['<anonymous>']` in order to find and return it. That’s why we
+    // start searching from the end in the previous block, because most of the
+    // time the source map we want is the last one.
+    if (sources[filename] != null) {
+      answer = compile(sources[filename][sources[filename].length - 1], {
         filename: filename,
         sourceMap: true,
         literate: helpers.isLiterate(filename)
@@ -340,7 +373,7 @@
     var frame, frames, getSourceMapping;
     getSourceMapping = function(filename, line, column) {
       var answer, sourceMap;
-      sourceMap = getSourceMap(filename);
+      sourceMap = getSourceMap(filename, line, column);
       if (sourceMap != null) {
         answer = sourceMap.sourceLocation([line - 1, column - 1]);
       }

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -14,7 +14,7 @@ packageJson   = require '../../package.json'
 # The current CoffeeScript version number.
 exports.VERSION = packageJson.version
 
-exports.FILE_EXTENSIONS = ['.coffee', '.litcoffee', '.coffee.md']
+exports.FILE_EXTENSIONS = FILE_EXTENSIONS = ['.coffee', '.litcoffee', '.coffee.md']
 
 # Expose helpers for testing.
 exports.helpers = helpers
@@ -266,15 +266,35 @@ formatSourcePosition = (frame, getSourceMapping) ->
   else
     fileLocation
 
-getSourceMap = (filename) ->
-  if sourceMaps[filename]?
-    sourceMaps[filename][sourceMaps[filename].length - 1]
+getSourceMap = (filename, line, column) ->
+  # Skip files that we didn’t compile, like Node system files that appear in
+  # the stack trace, as they never have source maps.
+  return null unless filename is '<anonymous>' or filename.slice(filename.lastIndexOf('.')) in FILE_EXTENSIONS
+
+  if filename isnt '<anonymous>' and sourceMaps[filename]?
+    return sourceMaps[filename][sourceMaps[filename].length - 1]
+  # CoffeeScript compiled in a browser or via `CoffeeScript.compile` or `.run`
+  # may get compiled with `options.filename` that’s missing, which becomes
+  # `<anonymous>`; but the runtime might request the stack trace with the
+  # filename of the script file. See if we have a source map cached under
+  # `<anonymous>` that matches the error.
   else if sourceMaps['<anonymous>']?
-    # CoffeeScript compiled in a browser may get compiled with `options.filename`
-    # of `<anonymous>`, but the browser may request the stack trace with the
-    # filename of the script file.
-    sourceMaps['<anonymous>'][sourceMaps['<anonymous>'].length - 1]
-  else if sources[filename]?
+    # Work backwards from the most recent anonymous source maps, until we find
+    # one that works. This isn’t foolproof; there is a chance that multiple
+    # source maps will have line/column pairs that match. But we have no other
+    # way to match them. `frame.getFunction().toString()` doesn’t always work,
+    # and it’s not foolproof either.
+    for map in sourceMaps['<anonymous>'] by -1
+      sourceLocation = map.sourceLocation [line - 1, column - 1]
+      return map if sourceLocation?[0]? and sourceLocation[1]?
+
+  # If all else fails, recompile this source to get a source map. We need the
+  # previous section (for `<anonymous>`) despite this option, because after it
+  # gets compiled we will still need to look it up from
+  # `sourceMaps['<anonymous>']` in order to find and return it. That’s why we
+  # start searching from the end in the previous block, because most of the
+  # time the source map we want is the last one.
+  if sources[filename]?
     answer = compile sources[filename][sources[filename].length - 1],
       filename: filename
       sourceMap: yes
@@ -289,7 +309,7 @@ getSourceMap = (filename) ->
 # positions.
 Error.prepareStackTrace = (err, stack) ->
   getSourceMapping = (filename, line, column) ->
-    sourceMap = getSourceMap filename
+    sourceMap = getSourceMap filename, line, column
     answer = sourceMap.sourceLocation [line - 1, column - 1] if sourceMap?
     if answer? then [answer[0] + 1, answer[1] + 1] else null
 


### PR DESCRIPTION
Fixes #4558. Also fixes the `cake release` command, which broke somewhere around when Node 8 came out.

Feedback welcome. So basically the issue in #4558 is that when you have a CoffeeScript file that itself has `CoffeeScript = require 'coffeescript'` and then something like `CoffeeScript.compile`, there’s basically a script within a script here and we need to preserve the source maps within the source maps, so that stack trace line numbers work correctly. Unfortunately the child scripts are all cached as `<anonymous>`, and the runtime always throws errors referencing the filename of the top-level script, so there’s some dark arts involved in picking which source map to use for patching the error stack trace. The method I’ve chosen isn’t foolproof, if you have multiple source maps that happen to have identical code or mappings, but it should work most of the time. I don’t see how to get a foolproof method without the runtime providing the full source of the “file” throwing the error, which it doesn’t (as far as I can tell). There’s more gory detail in the comments of the PR.