### PR TITLE
[CS2] Fix #4651: object spread destructuring bug

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3234,7 +3234,7 @@
       // Check object destructuring variable for rest elements;
       // can be removed once ES proposal hits Stage 4.
       compileObjectDestruct(o) {
-        var fragments, getPropKey, getPropName, j, len1, restElement, restElements, result, setScopeVar, traverseRest, value, valueRef;
+        var fragments, getPropKey, getPropName, j, len1, restElement, restElements, result, setScopeVar, shouldCache, traverseRest, value, valueRef;
         // Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Assignment_without_declaration,
         // if we’re destructuring without declaring, the destructuring assignment
         // must be wrapped in parentheses: `({a, b} = obj)`. Helper function
@@ -3301,9 +3301,13 @@
                 [prop.value.value, nestedSourceDefault] = prop.value.value.cache(o);
               }
               if (nestedProperties) {
-                nestedSource = new Value(source.base, source.properties.concat([new Access(getPropKey(prop))]));
-                if (nestedSourceDefault) {
-                  nestedSource = new Value(new Op('?', nestedSource, nestedSourceDefault));
+                if (source.properties) {
+                  nestedSource = new Value(source.base, source.properties.concat([new Access(getPropKey(prop))]));
+                  if (nestedSourceDefault) {
+                    nestedSource = new Value(new Op('?', nestedSource, nestedSourceDefault));
+                  }
+                } else {
+                  nestedSource = source;
                 }
                 restElements.push(...traverseRest(nestedProperties, nestedSource));
               }
@@ -3335,8 +3339,18 @@
           }
           return restElements;
         };
-        // Cache the value for reuse with rest elements
-        [this.value, valueRef] = this.value.cache(o);
+        // Cache the value for reuse with rest elements.
+        // `Obj` should be always cached.
+        // Examples:
+        //   {a, r...} = {a:1, b:2, c:3}
+        //   {a, r...} = {a:1, obj...}
+        shouldCache = (value) => {
+          if (value.base instanceof Obj) {
+            return true;
+          }
+          return value.shouldCache();
+        };
+        [this.value, valueRef] = this.value.cache(o, false, shouldCache);
         // Find all rest elements.
         restElements = traverseRest(this.variable.base.properties, valueRef);
         result = new Block([this]);

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3288,8 +3288,12 @@
           var base1, index, j, len1, nestedProperties, nestedSource, nestedSourceDefault, p, prop, restElements, restIndex;
           restElements = [];
           restIndex = void 0;
+          if (source.properties == null) {
+            source = new Value(source);
+          }
           for (index = j = 0, len1 = properties.length; j < len1; index = ++j) {
             prop = properties[index];
+            nestedSourceDefault = nestedSource = nestedProperties = null;
             setScopeVar(prop.unwrap());
             if (prop instanceof Assign) {
               if (typeof (base1 = prop.value).isObject === "function" ? base1.isObject() : void 0) {
@@ -3301,13 +3305,9 @@
                 [prop.value.value, nestedSourceDefault] = prop.value.value.cache(o);
               }
               if (nestedProperties) {
-                if (source.properties) {
-                  nestedSource = new Value(source.base, source.properties.concat([new Access(getPropKey(prop))]));
-                  if (nestedSourceDefault) {
-                    nestedSource = new Value(new Op('?', nestedSource, nestedSourceDefault));
-                  }
-                } else {
-                  nestedSource = source;
+                nestedSource = new Value(source.base, source.properties.concat([new Access(getPropKey(prop))]));
+                if (nestedSourceDefault) {
+                  nestedSource = new Value(new Op('?', nestedSource, nestedSourceDefault));
                 }
                 restElements.push(...traverseRest(nestedProperties, nestedSource));
               }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3142,7 +3142,7 @@
       // we've been assigned to, for correct internal references. If the variable
       // has not been seen yet within the current scope, declare it.
       compileNode(o) {
-        var answer, compiledName, isValue, j, name, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
+        var answer, compiledName, isValue, j, name, objDestructAnswer, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
         isValue = this.variable instanceof Value;
         if (isValue) {
           // When compiling `@variable`, remember if it is part of a function parameter.
@@ -3163,7 +3163,10 @@
               return node instanceof Obj && node.hasSplat();
             })) {
               // Object destructuring. Can be removed once ES proposal hits Stage 4.
-              return this.compileObjectDestruct(o);
+              objDestructAnswer = this.compileObjectDestruct(o);
+            }
+            if (objDestructAnswer) {
+              return objDestructAnswer;
             }
           }
           if (this.variable.isSplice()) {
@@ -3297,8 +3300,14 @@
             setScopeVar(prop.unwrap());
             if (prop instanceof Assign) {
               if (typeof (base1 = prop.value).isObject === "function" ? base1.isObject() : void 0) {
-                // prop is `k: {...}`
-                nestedProperties = prop.value.base.properties;
+                if (prop.operatorToken.unwrap().value === ':') {
+                  // prop is `k: {...}`
+                  nestedProperties = prop.value.base.properties;
+                }
+                if (prop.operatorToken.unwrap().value === '=') {
+                  // prop is `k = {...} `
+                  continue;
+                }
               } else if (prop.value instanceof Assign && prop.value.variable.isObject()) {
                 // prop is `k: {...} = default`
                 nestedProperties = prop.value.variable.base.properties;
@@ -3343,6 +3352,9 @@
         [this.value, valueRef] = this.value.cache(o);
         // Find all rest elements.
         restElements = traverseRest(this.variable.base.properties, valueRef);
+        if (!(restElements && restElements.length > 0)) {
+          return false;
+        }
         result = new Block([this]);
         for (j = 0, len1 = restElements.length; j < len1; j++) {
           restElement = restElements[j];

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3300,14 +3300,12 @@
             setScopeVar(prop.unwrap());
             if (prop instanceof Assign) {
               if (typeof (base1 = prop.value).isObject === "function" ? base1.isObject() : void 0) {
-                if (prop.operatorToken.unwrap().value === ':') {
-                  // prop is `k: {...}`
-                  nestedProperties = prop.value.base.properties;
-                }
-                if (prop.operatorToken.unwrap().value === '=') {
+                if (prop.context !== 'object') {
                   // prop is `k = {...} `
                   continue;
                 }
+                // prop is `k: {...}`
+                nestedProperties = prop.value.base.properties;
               } else if (prop.value instanceof Assign && prop.value.variable.isObject()) {
                 // prop is `k: {...} = default`
                 nestedProperties = prop.value.variable.base.properties;

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3344,7 +3344,7 @@
         // Examples:
         //   {a, r...} = {a:1, b:2, c:3}
         //   {a, r...} = {a:1, obj...}
-        shouldCache = (value) => {
+        shouldCache = function(value) {
           if (value.base instanceof Obj) {
             return true;
           }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3237,7 +3237,7 @@
       // Check object destructuring variable for rest elements;
       // can be removed once ES proposal hits Stage 4.
       compileObjectDestruct(o) {
-        var fragments, getPropKey, getPropName, j, len1, restElement, restElements, result, setScopeVar, traverseRest, value, valueRef;
+        var fragments, getPropKey, getPropName, j, len1, restElement, restElements, result, setScopeVar, traverseRest, value, valueRef, valueRefTemp;
         // Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Assignment_without_declaration,
         // if we’re destructuring without declaring, the destructuring assignment
         // must be wrapped in parentheses: `({a, b} = obj)`. Helper function
@@ -3349,12 +3349,19 @@
           return restElements;
         };
         // Cache the value for reuse with rest elements.
-        [this.value, valueRef] = this.value.cache(o);
+        if (this.value.shouldCache()) {
+          valueRefTemp = new IdentifierLiteral(o.scope.freeVariable('ref', {
+            reserve: false
+          }));
+        } else {
+          valueRefTemp = this.value.base;
+        }
         // Find all rest elements.
-        restElements = traverseRest(this.variable.base.properties, valueRef);
+        restElements = traverseRest(this.variable.base.properties, valueRefTemp);
         if (!(restElements && restElements.length > 0)) {
           return false;
         }
+        [this.value, valueRef] = this.value.cache(o);
         result = new Block([this]);
         for (j = 0, len1 = restElements.length; j < len1; j++) {
           restElement = restElements[j];

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2216,8 +2216,10 @@ exports.Assign = class Assign extends Base
     traverseRest = (properties, source) =>
       restElements = []
       restIndex = undefined
+      source = new Value source unless source.properties?
 
       for prop, index in properties
+        nestedSourceDefault = nestedSource = nestedProperties = null
         setScopeVar prop.unwrap()
         if prop instanceof Assign
           # prop is `k: expr`, we need to check `expr` for nested splats
@@ -2229,11 +2231,8 @@ exports.Assign = class Assign extends Base
             nestedProperties = prop.value.variable.base.properties
             [prop.value.value, nestedSourceDefault] = prop.value.value.cache o
           if nestedProperties
-            if source.properties
-              nestedSource = new Value source.base, source.properties.concat [new Access getPropKey prop]
-              nestedSource = new Value new Op '?', nestedSource, nestedSourceDefault if nestedSourceDefault
-            else
-              nestedSource = source
+            nestedSource = new Value source.base, source.properties.concat [new Access getPropKey prop]
+            nestedSource = new Value new Op '?', nestedSource, nestedSourceDefault if nestedSourceDefault
             restElements.push traverseRest(nestedProperties, nestedSource)...
         else if prop instanceof Splat
           prop.error "multiple rest elements are disallowed in object destructuring" if restIndex?

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2255,7 +2255,7 @@ exports.Assign = class Assign extends Base
     # Examples:
     #   {a, r...} = {a:1, b:2, c:3}
     #   {a, r...} = {a:1, obj...}
-    shouldCache = (value) =>
+    shouldCache = (value) ->
       return yes if value.base instanceof Obj
       value.shouldCache()
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2225,12 +2225,10 @@ exports.Assign = class Assign extends Base
         if prop instanceof Assign
           # prop is `k: expr`, we need to check `expr` for nested splats
           if prop.value.isObject?()
-            if prop.operatorToken.unwrap().value is ':'
-              # prop is `k: {...}`
-              nestedProperties = prop.value.base.properties
-            if prop.operatorToken.unwrap().value is '='
-              # prop is `k = {...} `
-              continue
+            # prop is `k = {...} `
+            continue unless prop.context is 'object'
+            # prop is `k: {...}`
+            nestedProperties = prop.value.base.properties
           else if prop.value instanceof Assign and prop.value.variable.isObject()
             # prop is `k: {...} = default`
             nestedProperties = prop.value.variable.base.properties

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2255,12 +2255,16 @@ exports.Assign = class Assign extends Base
       restElements
 
     # Cache the value for reuse with rest elements.
-    [@value, valueRef] = @value.cache o
+    if @value.shouldCache()
+      valueRefTemp = new IdentifierLiteral o.scope.freeVariable 'ref', reserve: false
+    else
+      valueRefTemp = @value.base
 
     # Find all rest elements.
-    restElements = traverseRest @variable.base.properties, valueRef
-    return false unless restElements and restElements.length > 0
+    restElements = traverseRest @variable.base.properties, valueRefTemp
+    return no unless restElements and restElements.length > 0
 
+    [@value, valueRef] = @value.cache o
     result = new Block [@]
 
     for restElement in restElements

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -305,9 +305,11 @@ test "destructuring assignment with multiple splats in different objects", ->
       s: 6
     }
   }
-  {p: {m}, r...} = o.props
+  {p: {m, q..., t = {obj...}}, r...} = o.props
   eq m, o.props.p.m
   deepEqual r, s: 6
+  deepEqual q, n: 1
+  deepEqual t, obj
 
   @props = o.props
   {p: {m}, r...} = @props

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -296,6 +296,27 @@ test "destructuring assignment with multiple splats in different objects", ->
   deepEqual a, val: 1
   deepEqual b, val: 2
 
+  o = {
+    props: {
+      p: {
+        n: 1
+        m: 5
+      }
+      s: 6
+    }
+  }
+  {p: {m}, r...} = o.props
+  eq m, o.props.p.m
+  deepEqual r, s: 6
+
+  @props = o.props
+  {p: {m}, r...} = @props
+  eq m, @props.p.m
+  deepEqual r, s: 6
+
+  {p: {m}, r...} = {o.props..., p:{m:9}}
+  eq m, 9
+
   # Should not trigger implicit call, e.g. rest ... => rest(...)
   {
     a: {


### PR DESCRIPTION
FIxes #4651. 
Compiler was throwing an error for object spread destructuring of values with properties (e.g. `@props`, `a.b.c`) or object literals. 

```coffeescript
# {a: {b}, r...} = @props
({
  a: {b}
} = ref = this.props);
r = objectWithoutKeys(ref, ['a']);
```

Besides that, caching of the object literal value  is improved:

Before:
```coffeescript
# {a, r...} = {a:1, b:2}
({a} = {a: 1, b: 2});
r = objectWithoutKeys({a: 1, b: 2}, ['a']),
```

After:
```coffeescript
# {a, r...} = {a:1, b:2}
({a} = ref = {a: 1, b: 2});
r = objectWithoutKeys(ref, ['a']),
```