### PR TITLE
[CS2] Fix #4589: Don’t unnecessarily escape quotes in template literals

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4989,7 +4989,7 @@
         for (j = 0, len1 = elements.length; j < len1; j++) {
           element = elements[j];
           if (element instanceof StringLiteral) {
-            element.value = element.unquote(this.csx);
+            element.value = element.unquote(true);
             if (!this.csx) {
               // Backticks and `${` inside template literals must be escaped.
               element.value = element.value.replace(/(\\*)(`|\$\{)/g, function(match, backslashes, toBeEscaped) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3393,7 +3393,7 @@ exports.StringWithInterpolations = class StringWithInterpolations extends Base
     fragments.push @makeCode '`' unless @csx
     for element in elements
       if element instanceof StringLiteral
-        element.value = element.unquote @csx
+        element.value = element.unquote yes
         unless @csx
           # Backticks and `${` inside template literals must be escaped.
           element.value = element.value.replace /(\\*)(`|\$\{)/g, (match, backslashes, toBeEscaped) ->


### PR DESCRIPTION
Fixes #4589. `"a\"#{1}\"b"` now becomes `` `a"${1}"b` ``, not `` `a\"${1}\"b` ``. @greghuc @xixixao.

Yes, this PR changes only four characters.