### PR TITLE
[CS2] Fix #4578: Leading colon shouldn’t throw exception

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -466,7 +466,7 @@
                   return i - 1;
               }
             }).call(this);
-            startsLine = s === 0 || (ref1 = this.tag(s - 1), indexOf.call(LINEBREAKS, ref1) >= 0) || tokens[s - 1].newLine;
+            startsLine = s <= 0 || (ref1 = this.tag(s - 1), indexOf.call(LINEBREAKS, ref1) >= 0) || tokens[s - 1].newLine;
             // Are we just continuing an already declared object?
             if (stackTop()) {
               [stackTag, stackIdx] = stackTop();

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -309,7 +309,7 @@ exports.Rewriter = class Rewriter
           when @tag(i - 2) is '@' then i - 2
           else i - 1
 
-        startsLine = s is 0 or @tag(s - 1) in LINEBREAKS or tokens[s - 1].newLine
+        startsLine = s <= 0 or @tag(s - 1) in LINEBREAKS or tokens[s - 1].newLine
         # Are we just continuing an already declared object?
         if stackTop()
           [stackTag, stackIdx] = stackTop()


### PR DESCRIPTION
Fixes #4578. Before:

```
coffee -bpe ':'
TypeError: Cannot read property 'newLine' of undefined
    at Rewriter.<anonymous> (/usr/local/lib/node_modules/coffeescript/lib/coffee-script/rewriter.js:316:113)
```
After:
```
./bin/coffee -bpe ':'
[stdin]:1:1: error: unexpected :
:
^
```