### PR TITLE
[CS2] Fix #4575: Leading asterisk

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -886,7 +886,7 @@
       if (value === ';') {
         this.seenFor = this.seenImport = this.seenExport = false;
         tag = 'TERMINATOR';
-      } else if (value === '*' && prev[0] === 'EXPORT') {
+      } else if (value === '*' && (prev != null ? prev[0] : void 0) === 'EXPORT') {
         tag = 'EXPORT_ALL';
       } else if (indexOf.call(MATH, value) >= 0) {
         tag = 'MATH';

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -664,7 +664,7 @@ exports.Lexer = class Lexer
     if value is ';'
       @seenFor = @seenImport = @seenExport = no
       tag = 'TERMINATOR'
-    else if value is '*' and prev[0] is 'EXPORT'
+    else if value is '*' and prev?[0] is 'EXPORT'
       tag = 'EXPORT_ALL'
     else if value in MATH            then tag = 'MATH'
     else if value in COMPARE         then tag = 'COMPARE'


### PR DESCRIPTION
Fixes #4575. Before:

```
coffee -bpe '*'
TypeError: Cannot read property '0' of undefined
    at Lexer.literalToken (./coffeescript/lib/coffeescript/lexer.js:889:39)
```
After:
```
./bin/coffee -bpe '*'
[stdin]:1:1: error: unexpected *
*
^
```