### PR TITLE
[CS2] Fix #3709, #3789: ‘throw’ an ‘if’, ‘for’, ‘switch’, ‘while’

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4774,7 +4774,11 @@
 
       compileNode(o) {
         var fragments;
-        fragments = this.expression.compileToFragments(o);
+        if (this.expression instanceof For || this.expression instanceof If || this.expression instanceof Switch || this.expression instanceof While) {
+          fragments = this.expression.compileClosure(o);
+        } else {
+          fragments = this.expression.compileToFragments(o);
+        }
         unshiftAfterComments(fragments, this.makeCode('throw '));
         fragments.unshift(this.makeCode(this.tab));
         fragments.push(this.makeCode(';'));

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4774,7 +4774,7 @@
 
       compileNode(o) {
         var fragments;
-        if (this.expression instanceof For || this.expression instanceof If || this.expression instanceof Switch || this.expression instanceof While) {
+        if (this.expression instanceof For || this.expression instanceof If || this.expression instanceof Switch || this.expression instanceof Throw || this.expression instanceof While) {
           fragments = this.expression.compileClosure(o);
         } else {
           fragments = this.expression.compileToFragments(o);

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4774,11 +4774,7 @@
 
       compileNode(o) {
         var fragments;
-        if (this.expression instanceof For || this.expression instanceof If || this.expression instanceof Switch || this.expression instanceof Throw || this.expression instanceof While) {
-          fragments = this.expression.compileClosure(o);
-        } else {
-          fragments = this.expression.compileToFragments(o);
-        }
+        fragments = this.expression.compileToFragments(o, LEVEL_LIST);
         unshiftAfterComments(fragments, this.makeCode('throw '));
         fragments.unshift(this.makeCode(this.tab));
         fragments.push(this.makeCode(';'));

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3258,6 +3258,7 @@ exports.Throw = class Throw extends Base
     if @expression instanceof For or
        @expression instanceof If or
        @expression instanceof Switch or
+       @expression instanceof Throw or
        @expression instanceof While
       fragments = @expression.compileClosure o
     else

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3255,7 +3255,14 @@ exports.Throw = class Throw extends Base
   makeReturn: THIS
 
   compileNode: (o) ->
-    fragments = @expression.compileToFragments o
+    if @expression instanceof For or
+       @expression instanceof If or
+       @expression instanceof Switch or
+       @expression instanceof While
+      fragments = @expression.compileClosure o
+    else
+      fragments = @expression.compileToFragments o
+
     unshiftAfterComments fragments, @makeCode 'throw '
     fragments.unshift @makeCode @tab
     fragments.push @makeCode ';'

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3255,15 +3255,7 @@ exports.Throw = class Throw extends Base
   makeReturn: THIS
 
   compileNode: (o) ->
-    if @expression instanceof For or
-       @expression instanceof If or
-       @expression instanceof Switch or
-       @expression instanceof Throw or
-       @expression instanceof While
-      fragments = @expression.compileClosure o
-    else
-      fragments = @expression.compileToFragments o
-
+    fragments = @expression.compileToFragments o, LEVEL_LIST
     unshiftAfterComments fragments, @makeCode 'throw '
     fragments.unshift @makeCode @tab
     fragments.push @makeCode ';'

--- a/test/exception_handling.coffee
+++ b/test/exception_handling.coffee
@@ -176,3 +176,9 @@ test "#3709: throwing a while loop", ->
       i++
   catch err
     eq i, 3
+
+test "#3789: throwing a throw", ->
+  try
+    throw throw throw new Error 'whoa!'
+  catch err
+    eq err.message, 'whoa!'

--- a/test/exception_handling.coffee
+++ b/test/exception_handling.coffee
@@ -89,10 +89,8 @@ test "try/catch with empty catch as last statement in a function body", ->
     catch err
   eq nonce, fn()
 
-
-# Catch leads to broken scoping: #1595
-
-test "try/catch with a reused variable name.", ->
+test "#1595: try/catch with a reused variable name", ->
+  # `catch` shouldn’t lead to broken scoping.
   do ->
     try
       inner = 5
@@ -100,19 +98,13 @@ test "try/catch with a reused variable name.", ->
       # nothing
   eq typeof inner, 'undefined'
 
-
-# Allowed to destructure exceptions: #2580
-
-test "try/catch with destructuring the exception object", ->
-
+test "#2580: try/catch with destructuring the exception object", ->
   result = try
     missing.object
   catch {message}
     message
 
   eq message, 'missing is not defined'
-
-
 
 test "Try catch finally as implicit arguments", ->
   first = (x) -> x
@@ -130,8 +122,8 @@ test "Try catch finally as implicit arguments", ->
   catch e
   eq bar, yes
 
-# Catch Should Not Require Param: #2900
-test "parameter-less catch clause", ->
+test "#2900: parameter-less catch clause", ->
+  # `catch` should not require a parameter.
   try
     throw new Error 'failed'
   catch
@@ -140,3 +132,47 @@ test "parameter-less catch clause", ->
   try throw new Error 'failed' catch finally ok true
 
   ok try throw new Error 'failed' catch then true
+
+test "#3709: throwing an if statement", ->
+  # `throw if` should return a closure around the `if` block, so that the
+  # output is valid JavaScript.
+  try
+    throw if no
+        new Error 'drat!'
+      else
+        new Error 'no escape!'
+  catch err
+    eq err.message, 'no escape!'
+
+  try
+    throw if yes then new Error 'huh?' else null
+  catch err
+    eq err.message, 'huh?'
+
+test "#3709: throwing a switch statement", ->
+  i = 3
+  try
+    throw switch i
+      when 2
+        new Error 'not this one'
+      when 3
+        new Error 'oh no!'
+  catch err
+    eq err.message, 'oh no!'
+
+test "#3709: throwing a for loop", ->
+  # `throw for` should return a closure around the `for` block, so that the
+  # output is valid JavaScript.
+  try
+    throw for i in [0..3]
+      i * 2
+  catch err
+    arrayEq err, [0, 2, 4, 6]
+
+test "#3709: throwing a while loop", ->
+  i = 0
+  try
+    throw while i < 3
+      i++
+  catch err
+    eq i, 3


### PR DESCRIPTION
Fixes #3709 and #3789. If the expression to be thrown is of certain types (`If`, `For`, `Switch`, `While` or a nested `Throw`) wrap it in a closure, so that it becomes valid JavaScript.

I’m sure there are probably other expression types that should get wrapped, so please suggest any you can think of and I’ll add them to the list. But these should be the most likely ones that people would think to put after `throw`, (other than another `throw`, which is so unlikely it feels silly to even cover the case). And now we have a way to handle all similar cases.

I tried to find a way to deduce whether the expression should get wrapped in a closure, by looking at `shouldCache` or `isStatement` or the like, but I didn’t find a helper that was consistent. Ultimately I don’t think there are too many node types that make sense to put after `throw`, so just listing every possibility should hopefully be good enough.