### PR TITLE
[CS2] Fix #1768: Ignore space after `::`

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -902,13 +902,13 @@
         tag = 'SHIFT';
       } else if (value === '?' && (prev != null ? prev.spaced : void 0)) {
         tag = 'BIN?';
-      } else if (prev && !prev.spaced) {
-        if (value === '(' && (ref2 = prev[0], indexOf.call(CALLABLE, ref2) >= 0)) {
+      } else if (prev) {
+        if (value === '(' && !prev.spaced && (ref2 = prev[0], indexOf.call(CALLABLE, ref2) >= 0)) {
           if (prev[0] === '?') {
             prev[0] = 'FUNC_EXIST';
           }
           tag = 'CALL_START';
-        } else if (value === '[' && (ref3 = prev[0], indexOf.call(INDEXABLE, ref3) >= 0)) {
+        } else if (value === '[' && (((ref3 = prev[0], indexOf.call(INDEXABLE, ref3) >= 0) && !prev.spaced) || (prev[0] === '::'))) { // `.prototype` can’t be a method you can call.
           tag = 'INDEX_START';
           switch (prev[0]) {
             case '?':

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -673,11 +673,12 @@ exports.Lexer = class Lexer
     else if value in UNARY_MATH      then tag = 'UNARY_MATH'
     else if value in SHIFT           then tag = 'SHIFT'
     else if value is '?' and prev?.spaced then tag = 'BIN?'
-    else if prev and not prev.spaced
-      if value is '(' and prev[0] in CALLABLE
+    else if prev
+      if value is '(' and not prev.spaced and prev[0] in CALLABLE
         prev[0] = 'FUNC_EXIST' if prev[0] is '?'
         tag = 'CALL_START'
-      else if value is '[' and prev[0] in INDEXABLE
+      else if value is '[' and ((prev[0] in INDEXABLE and not prev.spaced) or
+         (prev[0] is '::')) # `.prototype` can’t be a method you can call.
         tag = 'INDEX_START'
         switch prev[0]
           when '?'  then prev[0] = 'INDEX_SOAK'

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -87,6 +87,9 @@ doesNotThrow -> CoffeeScript.compile """
   a?[b..c]
   """
 
+test "#1768: space between `::` and index is ignored", ->
+  eq 'function', typeof String:: ['toString']
+
 # Array Literals
 
 test "indented array literals don't trigger whitespace rewriting", ->


### PR DESCRIPTION
Fixes #1768. So as `Array:: isArray` becomes `Array.protoype.isArray`, now `Array:: ["isArray"]` becomes `Array.prototype["isArray"]`.