### PR TITLE
[CS2] Refine #4666: add parens to chained do IIFE with params

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -757,9 +757,7 @@
             return 1;
           }
           doIndex = i;
-          this.detectEnd(i + 2, condition, action, {
-            log: true
-          });
+          this.detectEnd(i + 2, condition, action);
           return 2;
         });
       }

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -744,11 +744,12 @@
           return this.tag(i - 1) === 'OUTDENT';
         };
         action = function(token, i) {
-          if (token[0] !== '.') {
+          var ref;
+          if (ref = token[0], indexOf.call(CALL_CLOSERS, ref) < 0) {
             return;
           }
-          this.tokens.splice(doIndex, 0, generate('(', '(', this.tokens[doIndex][2]));
-          return this.tokens.splice(i + 1, 0, generate(')', ')', ['', 'implicit parentheses', token[2]]));
+          this.tokens.splice(doIndex, 0, generate('(', '(', this.tokens[doIndex]));
+          return this.tokens.splice(i + 1, 0, generate(')', ')', this.tokens[i]));
         };
         doIndex = null;
         return this.scanTokens(function(token, i, tokens) {

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -753,12 +753,24 @@
         };
         doIndex = null;
         return this.scanTokens(function(token, i, tokens) {
-          var ref;
-          if (!(token[1] === 'do' && ((ref = this.tag(i + 1)) === '->' || ref === '=>') && this.tag(i + 2) === 'INDENT')) {
+          var glyphIndex, ref;
+          if (token[1] !== 'do') {
             return 1;
           }
           doIndex = i;
-          this.detectEnd(i + 2, condition, action);
+          glyphIndex = i + 1;
+          if (this.tag(i + 1) === 'PARAM_START') {
+            glyphIndex = null;
+            this.detectEnd(i + 1, function(token, i) {
+              return this.tag(i - 1) === 'PARAM_END';
+            }, function(token, i) {
+              return glyphIndex = i;
+            });
+          }
+          if (!((glyphIndex != null) && ((ref = this.tag(glyphIndex)) === '->' || ref === '=>') && this.tag(glyphIndex + 1) === 'INDENT')) {
+            return 1;
+          }
+          this.detectEnd(glyphIndex + 1, condition, action);
           return 2;
         });
       }

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -86,6 +86,7 @@
         this.normalizeLines();
         this.tagPostfixConditionals();
         this.addImplicitBracesAndParens();
+        this.addParensToChainedDoIife();
         this.rescueStowawayComments();
         this.addLocationDataToGeneratedTokens();
         this.enforceValidCSXAttributes();
@@ -731,6 +732,35 @@
             last_column: prevLocationData.last_column
           };
           return 1;
+        });
+      }
+
+      // Add parens around a `do` IIFE followed by a chained `.` so that the
+      // chaining applies to the executed function rather than the function
+      // object (see #3736)
+      addParensToChainedDoIife() {
+        var action, condition, doIndex;
+        condition = function(token, i) {
+          return this.tag(i - 1) === 'OUTDENT';
+        };
+        action = function(token, i) {
+          if (token[0] !== '.') {
+            return;
+          }
+          this.tokens.splice(doIndex, 0, generate('(', '(', this.tokens[doIndex][2]));
+          return this.tokens.splice(i + 1, 0, generate(')', ')', ['', 'implicit parentheses', token[2]]));
+        };
+        doIndex = null;
+        return this.scanTokens(function(token, i, tokens) {
+          var ref;
+          if (!(token[1] === 'do' && ((ref = this.tag(i + 1)) === '->' || ref === '=>') && this.tag(i + 2) === 'INDENT')) {
+            return 1;
+          }
+          doIndex = i;
+          this.detectEnd(i + 2, condition, action, {
+            log: true
+          });
+          return 2;
         });
       }
 

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -53,6 +53,7 @@ exports.Rewriter = class Rewriter
     @normalizeLines()
     @tagPostfixConditionals()
     @addImplicitBracesAndParens()
+    @addParensToChainedDoIife()
     @rescueStowawayComments()
     @addLocationDataToGeneratedTokens()
     @enforceValidCSXAttributes()
@@ -511,6 +512,23 @@ exports.Rewriter = class Rewriter
         last_line:    prevLocationData.last_line
         last_column:  prevLocationData.last_column
       return 1
+
+  # Add parens around a `do` IIFE followed by a chained `.` so that the
+  # chaining applies to the executed function rather than the function
+  # object (see #3736)
+  addParensToChainedDoIife: ->
+    condition = (token, i) ->
+      @tag(i - 1) is 'OUTDENT'
+    action = (token, i) ->
+      return unless token[0] is '.'
+      @tokens.splice doIndex, 0, generate '(', '(', @tokens[doIndex][2]
+      @tokens.splice i + 1, 0, generate ')', ')', ['', 'implicit parentheses', token[2]]
+    doIndex = null
+    @scanTokens (token, i, tokens) ->
+      return 1 unless token[1] is 'do' and @tag(i + 1) in ['->', '=>'] and @tag(i + 2) is 'INDENT'
+      doIndex = i
+      @detectEnd i + 2, condition, action, log: yes
+      return 2
 
   # Because our grammar is LALR(1), it can’t handle some single-line
   # expressions that lack ending delimiters. The **Rewriter** adds the implicit

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -525,9 +525,16 @@ exports.Rewriter = class Rewriter
       @tokens.splice i + 1, 0, generate ')', ')', @tokens[i]
     doIndex = null
     @scanTokens (token, i, tokens) ->
-      return 1 unless token[1] is 'do' and @tag(i + 1) in ['->', '=>'] and @tag(i + 2) is 'INDENT'
+      return 1 unless token[1] is 'do'
       doIndex = i
-      @detectEnd i + 2, condition, action
+      glyphIndex = i + 1
+      if @tag(i + 1) is 'PARAM_START'
+        glyphIndex = null
+        @detectEnd i + 1,
+          (token, i) -> @tag(i - 1) is 'PARAM_END'
+          (token, i) -> glyphIndex = i
+      return 1 unless glyphIndex? and @tag(glyphIndex) in ['->', '=>'] and @tag(glyphIndex + 1) is 'INDENT'
+      @detectEnd glyphIndex + 1, condition, action
       return 2
 
   # Because our grammar is LALR(1), it can’t handle some single-line

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -520,9 +520,9 @@ exports.Rewriter = class Rewriter
     condition = (token, i) ->
       @tag(i - 1) is 'OUTDENT'
     action = (token, i) ->
-      return unless token[0] is '.'
-      @tokens.splice doIndex, 0, generate '(', '(', @tokens[doIndex][2]
-      @tokens.splice i + 1, 0, generate ')', ')', ['', 'implicit parentheses', token[2]]
+      return unless token[0] in CALL_CLOSERS
+      @tokens.splice doIndex, 0, generate '(', '(', @tokens[doIndex]
+      @tokens.splice i + 1, 0, generate ')', ')', @tokens[i]
     doIndex = null
     @scanTokens (token, i, tokens) ->
       return 1 unless token[1] is 'do' and @tag(i + 1) in ['->', '=>'] and @tag(i + 2) is 'INDENT'

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -527,7 +527,7 @@ exports.Rewriter = class Rewriter
     @scanTokens (token, i, tokens) ->
       return 1 unless token[1] is 'do' and @tag(i + 1) in ['->', '=>'] and @tag(i + 2) is 'INDENT'
       doIndex = i
-      @detectEnd i + 2, condition, action, log: yes
+      @detectEnd i + 2, condition, action
       return 2
 
   # Because our grammar is LALR(1), it can’t handle some single-line

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -420,3 +420,19 @@ test "#4576: function chaining on separate rows", ->
     .then ->
       yes
     .then ok
+
+test "#3736: chaining after do IIFE", ->
+  eq 3,
+    do ->
+      a: 3
+    .a
+
+  eq 3,
+    do -> a: 3
+    .a
+
+  # preserve existing chaining behavior for non-IIFE `do`
+  b = c: -> 4
+  eq 4,
+    do b
+    .c

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -428,8 +428,16 @@ test "#3736: chaining after do IIFE", ->
     .a
 
   eq 3,
-    do -> a: 3
+    do (b = (c) -> c) -> a: 3
     ?.a
+
+  b = 3
+  eq 3,
+    do (
+      b
+    ) ->
+      a: b
+    .a
 
   # preserve existing chaining behavior for non-IIFE `do`
   b = c: -> 4

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -429,7 +429,7 @@ test "#3736: chaining after do IIFE", ->
 
   eq 3,
     do -> a: 3
-    .a
+    ?.a
 
   # preserve existing chaining behavior for non-IIFE `do`
   b = c: -> 4

--- a/test/formatting.coffee
+++ b/test/formatting.coffee
@@ -435,6 +435,7 @@ test "#3736: chaining after do IIFE", ->
   eq 3,
     do (
       b
+      {d} = {}
     ) ->
       a: b
     .a


### PR DESCRIPTION
@connec pointed out that #4666 didn't handle `do <IIFE>` with arguments

So this extends #4666 to handle arguments. Added tests where the arguments are on separate lines and contain nested `PARAM_END` token