### PR TITLE
[CS2] Don’t require async/await support to run `coffee`

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -413,7 +413,7 @@ runTests = (CoffeeScript) ->
     try
       new Function('async () => {}')()
       yes
-    catch exception
+    catch
       no
   else
     [major, minor, build] = process.versions.node.split('.').map (version) ->

--- a/Cakefile
+++ b/Cakefile
@@ -409,6 +409,17 @@ runTests = (CoffeeScript) ->
         description: description if description?
         source: fn.toString() if fn.toString?
 
+  global.supportsAsync = if global.testingBrowser
+    try
+      new Function('async () => {}')()
+      yes
+    catch exception
+      no
+  else
+    [major, minor, build] = process.versions.node.split('.').map (version) ->
+      parseInt version, 10
+    major >= 8 or (major is 7 and minor >= 6)
+
   helpers.extend global, require './test/support/helpers'
 
   # When all the tests have run, collect and print errors.
@@ -428,6 +439,8 @@ runTests = (CoffeeScript) ->
 
   # Run every test in the `test` folder, recording failures.
   files = fs.readdirSync 'test'
+  unless global.supportsAsync # Except for async tests, if async isn’t supported.
+    files = files.filter (filename) -> filename isnt 'async.coffee'
 
   for file in files when helpers.isCoffee file
     literate = helpers.isLiterate file

--- a/lib/coffeescript/repl.js
+++ b/lib/coffeescript/repl.js
@@ -26,7 +26,7 @@
       }
     })(),
     historyMaxInputSize: 10240,
-    eval: async function(input, context, filename, cb) {
+    eval: function(input, context, filename, cb) {
       var Assign, Block, Call, Code, Literal, Value, ast, err, isAsync, js, referencedVars, result, token, tokens;
       // XXX: multiline hack.
       input = input.replace(/\uFF00/g, '\n');
@@ -71,10 +71,11 @@
         result = runInContext(js, context, filename);
         // Await an async result, if necessary
         if (isAsync) {
-          result = (await result);
-          if (!sawSIGINT) {
-            cb(null, result);
-          }
+          result.then(function(resolvedResult) {
+            if (!sawSIGINT) {
+              return cb(null, resolvedResult);
+            }
+          });
           return sawSIGINT = false;
         } else {
           return cb(null, result);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "2.0.0-beta4",
   "license": "MIT",
   "engines": {
-    "node": ">=7.6.0"
+    "node": ">=6"
   },
   "directories": {
     "lib": "./lib/coffeescript"

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -44,9 +44,9 @@ replDefaults =
       result = runInContext js, context, filename
       # Await an async result, if necessary
       if isAsync
-        result = await result
-        cb null, result unless sawSIGINT
-        sawSIGINT = false
+        result.then (resolvedResult) ->
+          cb null, resolvedResult unless sawSIGINT
+        sawSIGINT = no
       else
         cb null, result
     catch err

--- a/test/repl.coffee
+++ b/test/repl.coffee
@@ -115,6 +115,13 @@ testRepl "keeps running after runtime error", (input, output) ->
   input.emitLine 'a'
   eq 'undefined', output.lastWrite()
 
+testRepl "#4604: wraps an async function", (input, output) ->
+  return unless global.supportsAsync
+  input.emitLine 'await new Promise (resolve) -> setTimeout (-> resolve 33), 10'
+  setTimeout ->
+    eq '33', output.lastWrite()
+  , 20
+
 process.on 'exit', ->
   try
     fs.unlinkSync historyFile


### PR DESCRIPTION
Aside from #4604, the `coffee` command runs in Node 6 (though the tests don’t). See #4676. I feel like we might as well support Node 6 if we can, and it seems that all we need to do so is convert one `await` into a `Promise`.

I also added a test for the functionality added in #4604, plus a guard so that the tests (other than the async ones) can also run in Node 6.

I noticed that `cake test` is returning before the async tests have completed; see #4680.