### PR TITLE
Build and test with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+
+node_js:
+  - 6
+  - 8
+
+cache:
+  directories:
+    - node_modules
+
+script:
+  - node ./bin/cake build:except-parser
+  - node ./bin/cake build:parser
+  - node ./bin/cake build:full
+  - node ./bin/cake build:browser
+  - node ./bin/cake test
+  - node ./bin/cake test:browser
+  - node ./bin/cake test:integrations


### PR DESCRIPTION
Adds a `.travis.yml` to build and test using Travis CI. This tests in both Node 6 and 8, using _all_ the tests (Node, browser compiler, integrations). This should help prevent future PRs that break the compiler in Node 6; PRs where the submitter forgets to commit the files in `lib` or to compile twice; and PRs that break the browser tests. See https://travis-ci.org/GeoffreyBooth/coffeescript/builds/273166849

Task for future improvement: [integrate headless Chrome](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-Chrome-addon-in-the-headless-mode) to load `test.html` and see if the tests all pass in a real browser, as opposed to Node masquerading as one.