### PR TITLE
Fix #4342: Always output `sourcesContent` property as part of source map

### DIFF
--- a/lib/coffeescript/sourcemap.js
+++ b/lib/coffeescript/sourcemap.js
@@ -150,7 +150,7 @@
           names: [],
           mappings: buffer
         };
-        if (options.inlineMap) {
+        if (options.sourceMap || options.inlineMap) {
           v3.sourcesContent = [code];
         }
         return v3;

--- a/src/sourcemap.litcoffee
+++ b/src/sourcemap.litcoffee
@@ -133,7 +133,7 @@ Produce the canonical JSON object format for a "v3" source map.
           names:      []
           mappings:   buffer
 
-        v3.sourcesContent = [code] if options.inlineMap
+        v3.sourcesContent = [code] if options.sourceMap or options.inlineMap
 
         v3
 


### PR DESCRIPTION
Fixes #4342. This PR always outputs the `sourcesContent` property as part of the source map, whether inline map or written-to-disk map.

Currently we output `sourcesContent` only for inline maps, which doesn’t make much sense, as it’s really more useful to save in `.map` files. Babel outputs this property for both inline and saved-to-disk source maps, and I think we should do the same.