### PR TITLE
Fix #3440: --stdio and --map don’t make sense to use together

### DIFF
--- a/lib/coffeescript/command.js
+++ b/lib/coffeescript/command.js
@@ -303,6 +303,10 @@
   // and write them back to **stdout**.
   compileStdio = function() {
     var buffers, stdin;
+    if (opts.map) {
+      console.error('--stdio and --map cannot be used together');
+      process.exit(1);
+    }
     buffers = [];
     stdin = process.openStdin();
     stdin.on('data', function(buffer) {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -243,6 +243,9 @@ compileScript = (file, input, base = null) ->
 # Attach the appropriate listeners to compile scripts incoming over **stdin**,
 # and write them back to **stdout**.
 compileStdio = ->
+  if opts.map
+    console.error '--stdio and --map cannot be used together'
+    process.exit 1
   buffers = []
   stdin = process.openStdin()
   stdin.on 'data', (buffer) ->


### PR DESCRIPTION
Fixes #3440. Currently `echo 'console.log "hello, world!"' | coffee --map --stdio` throws an exception, which isn’t good. This PR makes it print an error message instead.