### PR TITLE
Allow applying 'foo.get'/'foo.set' to a bracketless object literal

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -190,7 +190,7 @@
       // what CoffeeScript would normally interpret as calls to functions named
       // `get` or `set`, i.e. `get({foo: function () {}})`.
       } else if (tag === 'PROPERTY' && prev) {
-        if (prev.spaced && (ref6 = prev[0], indexOf.call(CALLABLE, ref6) >= 0) && /^[gs]et$/.test(prev[1])) {
+        if (prev.spaced && (ref6 = prev[0], indexOf.call(CALLABLE, ref6) >= 0) && /^[gs]et$/.test(prev[1]) && this.tokens[this.tokens.length - 2][0] !== '.') {
           this.error(`'${prev[1]}' cannot be used as a keyword, or as a function call without parentheses`, prev[2]);
         } else {
           prevprev = this.tokens[this.tokens.length - 2];

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -186,7 +186,7 @@ exports.Lexer = class Lexer
     # what CoffeeScript would normally interpret as calls to functions named
     # `get` or `set`, i.e. `get({foo: function () {}})`.
     else if tag is 'PROPERTY' and prev
-      if prev.spaced and prev[0] in CALLABLE and /^[gs]et$/.test(prev[1])
+      if prev.spaced and prev[0] in CALLABLE and /^[gs]et$/.test(prev[1]) and @tokens[@tokens.length - 2][0] isnt '.'
         @error "'#{prev[1]}' cannot be used as a keyword, or as a function call without parentheses", prev[2]
       else
         prevprev = @tokens[@tokens.length - 2]

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -806,6 +806,12 @@ test "functions named get or set can be used without parentheses when attached t
 
   a = new A()
 
+  class B
+    get: (x) -> x.value + 6
+    set: (x) -> x.value + 7
+
+  b = new B()
+
   eq 12, obj.get 10
   eq 13, obj.set 10
 
@@ -825,3 +831,8 @@ test "functions named get or set can be used without parentheses when attached t
   eq 12, obj.obj.get @ten
   eq 13, obj.obj.set @ten
 
+  eq 16, b.get value: 10
+  eq 17, b.set value: 10
+
+  eq 16, b.get value: @ten
+  eq 17, b.set value: @ten


### PR DESCRIPTION
This is a logical extension of #4525, adding support for `obj.set propertyName: propertyValue` etc.

(Real-world example [here](https://github.com/philc/vimium/blob/abb32e2f2974832df08395ef7664561bb57c7324/background_scripts/commands.coffee#L43).)