### PR TITLE
Fix #4724

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -701,6 +701,12 @@
         ref1 = this.expressions;
         for (index = j = 0, len1 = ref1.length; j < len1; index = ++j) {
           node = ref1[index];
+          if (node.hoisted) {
+            // This is a hoisted expression.
+            // We want to compile this and ignore the result.
+            node.compileToFragments(o);
+            continue;
+          }
           node = node.unwrapAll();
           node = node.unfoldSoak(o) || node;
           if (node instanceof Block) {
@@ -708,10 +714,6 @@
             // enclose it in a new scope; we just compile the statements in this
             // block along with our own.
             compiledNodes.push(node.compileNode(o));
-          } else if (node.hoisted) {
-            // This is a hoisted expression.
-            // We want to compile this and ignore the result.
-            node.compileToFragments(o);
           } else if (top) {
             node.front = true;
             fragments = node.compileToFragments(o);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -497,6 +497,12 @@ exports.Block = class Block extends Base
     compiledNodes = []
 
     for node, index in @expressions
+      if node.hoisted
+        # This is a hoisted expression.
+        # We want to compile this and ignore the result.
+        node.compileToFragments o
+        continue
+
       node = node.unwrapAll()
       node = (node.unfoldSoak(o) or node)
       if node instanceof Block
@@ -504,10 +510,6 @@ exports.Block = class Block extends Base
         # enclose it in a new scope; we just compile the statements in this
         # block along with our own.
         compiledNodes.push node.compileNode o
-      else if node.hoisted
-        # This is a hoisted expression.
-        # We want to compile this and ignore the result.
-        node.compileToFragments o
       else if top
         node.front = yes
         fragments = node.compileToFragments o

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -1848,3 +1848,12 @@ test "#4464: backticked expressions in class body", ->
   b = new B
   eq 42, b.x
   eq 84, b.y
+
+test "#4724: backticked expression in a class body with hoisted member", ->
+  class A
+    `get x() { return 42; }`
+    hoisted: 84
+
+  a = new A
+  eq 42, a.x
+  eq 84, a.hoisted


### PR DESCRIPTION
The handling of hoisted nodes in class bodies was incorrect, as the node was being unwrapped *before* checking if it was hoisted, meaning nodes that should have been hoisted would be output normally.

This affected `PassthroughLiteral`s as they were wrapped in a `Value`.

Fixes #4724.