### PR TITLE
Fix #4752: Error on calling super with @params in a derived class constructor

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4078,17 +4078,22 @@
         return seenSuper;
       }
 
-      // Find all super calls in the given context node
-      // Returns `true` if `iterator` is called
+      // Find all super calls in the given context node;
+      // returns `true` if `iterator` is called.
       eachSuperCall(context, iterator) {
         var seenSuper;
         seenSuper = false;
         context.traverseChildren(true, (child) => {
           if (child instanceof SuperCall) {
-            if (!child.variable.accessor && child.args.some(function(arg) {
-              return arg.this;
-            })) {
-              child.error("Can't call super with @params in derived class constructors");
+            // `super` in a constructor (the only `super` without an accessor)
+            // cannot be given an argument with a reference to `this`, as that would
+            // be referencing `this` before calling `super`.
+            if (!child.variable.accessor) {
+              Block.wrap(child.args).traverseChildren(true, (node) => {
+                if (node.this) {
+                  return node.error("Can't call super with @params in derived class constructors");
+                }
+              });
             }
             seenSuper = true;
             iterator(child);

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3908,7 +3908,9 @@
           exprs.unshift(new Assign(new Value(new Arr([
             new Splat(new IdentifierLiteral(splatParamName)),
             ...((function() {
-              var k, len2, results;
+              var k,
+            len2,
+            results;
               results = [];
               for (k = 0, len2 = paramsAfterSplat.length; k < len2; k++) {
                 param = paramsAfterSplat[k];
@@ -4083,6 +4085,11 @@
         seenSuper = false;
         context.traverseChildren(true, (child) => {
           if (child instanceof SuperCall) {
+            if (!child.variable.accessor && child.args.some(function(arg) {
+              return arg.this;
+            })) {
+              child.error("Can't call super with @params in derived class constructors");
+            }
             seenSuper = true;
             iterator(child);
           } else if (child instanceof ThisLiteral && this.ctor === 'derived' && !seenSuper) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2790,6 +2790,8 @@ exports.Code = class Code extends Base
 
     context.traverseChildren true, (child) =>
       if child instanceof SuperCall
+        if not child.variable.accessor and child.args.some((arg) -> arg.this)
+          child.error "Can't call super with @params in derived class constructors"
         seenSuper = yes
         iterator child
       else if child instanceof ThisLiteral and @ctor is 'derived' and not seenSuper

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1341,9 +1341,16 @@ test "derived constructors can't use @params without calling super", ->
 
 test "derived constructors can't call super with @params", ->
   assertErrorFormat 'class extends A then constructor: (@a) -> super(@a)', '''
-    [stdin]:1:43: error: Can't call super with @params in derived class constructors
+    [stdin]:1:49: error: Can't call super with @params in derived class constructors
     class extends A then constructor: (@a) -> super(@a)
-                                              ^^^^^^^^^
+                                                    ^^
+  '''
+
+test "derived constructors can't call super with buried @params", ->
+  assertErrorFormat 'class extends A then constructor: (@a) -> super((=> @a)())', '''
+    [stdin]:1:53: error: Can't call super with @params in derived class constructors
+    class extends A then constructor: (@a) -> super((=> @a)())
+                                                        ^^
   '''
 
 test "'super' is not allowed in constructor parameter defaults", ->

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1339,6 +1339,13 @@ test "derived constructors can't use @params without calling super", ->
                                        ^^
   '''
 
+test "derived constructors can't call super with @params", ->
+  assertErrorFormat 'class extends A then constructor: (@a) -> super(@a)', '''
+    [stdin]:1:43: error: Can't call super with @params in derived class constructors
+    class extends A then constructor: (@a) -> super(@a)
+                                              ^^^^^^^^^
+  '''
+
 test "'super' is not allowed in constructor parameter defaults", ->
   assertErrorFormat 'class extends A then constructor: (a = super()) ->', '''
     [stdin]:1:40: error: 'super' is not allowed in constructor parameter defaults


### PR DESCRIPTION
Fixes #4752, in the sense that now we throw a compiler error rather than outputting invalid JavaScript. If we want to go further and create some placeholder variables to engage in sleight of hand to make the impossible possible, well, that can be a follow-up PR.

```coffee
class A
  constructor: (@name) ->
    alert @name, 'name'
    
class B extends A
  constructor: (@name) ->
    super @name
```
```
test.coffee:7:5: error: Can't call super with @params in derived class constructors
    super @name
    ^^^^^^^^^^^
```