### PR TITLE
Fix #4756: Comments lost when an Existence has grandchildren

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3908,7 +3908,9 @@
           exprs.unshift(new Assign(new Value(new Arr([
             new Splat(new IdentifierLiteral(splatParamName)),
             ...((function() {
-              var k, len2, results;
+              var k,
+            len2,
+            results;
               results = [];
               for (k = 0, len2 = paramsAfterSplat.length; k < len2; k++) {
                 param = paramsAfterSplat[k];
@@ -4867,8 +4869,8 @@
         this.expression = expression1;
         this.comparisonTarget = onlyNotUndefined ? 'undefined' : 'null';
         salvagedComments = [];
-        this.expression.eachChild(function(child) {
-          var comment, j, k, len1, len2, ref1, ref2, ref3;
+        this.expression.traverseChildren(true, function(child) {
+          var comment, j, len1, ref1;
           if (child.comments) {
             ref1 = child.comments;
             for (j = 0, len1 = ref1.length; j < len1; j++) {
@@ -4877,17 +4879,7 @@
                 salvagedComments.push(comment);
               }
             }
-            delete child.comments;
-          }
-          if ((ref2 = child.name) != null ? ref2.comments : void 0) {
-            ref3 = child.name.comments;
-            for (k = 0, len2 = ref3.length; k < len2; k++) {
-              comment = ref3[k];
-              if (indexOf.call(salvagedComments, comment) < 0) {
-                salvagedComments.push(comment);
-              }
-            }
-            return delete child.name.comments;
+            return delete child.comments;
           }
         });
         attachCommentsToNode(salvagedComments, this);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3309,15 +3309,11 @@ exports.Existence = class Existence extends Base
     super()
     @comparisonTarget = if onlyNotUndefined then 'undefined' else 'null'
     salvagedComments = []
-    @expression.eachChild (child) ->
+    @expression.traverseChildren yes, (child) ->
       if child.comments
         for comment in child.comments
           salvagedComments.push comment unless comment in salvagedComments
         delete child.comments
-      if child.name?.comments
-        for comment in child.name.comments
-          salvagedComments.push comment unless comment in salvagedComments
-        delete child.name.comments
     attachCommentsToNode salvagedComments, @
     moveComments @expression, @
 

--- a/test/comments.coffee
+++ b/test/comments.coffee
@@ -1107,3 +1107,16 @@ test "#4747: Flow comments for local variable declarations with reassignment", -
 
   a/* some other comment */ = 2;
   '''
+
+test "#4756: Comment before ? operation", ->
+  eqJS '''
+  do ->
+    ### Comment ###
+    @foo ? 42
+  ''', '''
+  (function() {
+    var ref;
+    /* Comment */
+    return (ref = this.foo) != null ? ref : 42;
+  })();
+  '''


### PR DESCRIPTION
Fixes #4756, where comments where lost before `return @foo ? 42`. This is because the “salvage comments” code in the `Existence` class was using `eachChild`, which only looks at the immediate children of the expression, rather than `traverseChildren`, which drills down to all descendant children. When the expression contains `@`, as in `@foo` instead of just `foo`, the comments are one level deeper than where they would be on just `foo`.

Previously I was covering accessors via a second check for `child.name`, but that just masked the real issue (that I wasn’t drilling down far enough) by selectively diving down just in the case of the `name` property. Now that we’re searching the entire tree, there’s no need for a special check for a `name` grandchild node.