### PR TITLE
Fix #4763: Comments at beginning or end of REPL input shouldn’t throw errors

### DIFF
--- a/lib/coffeescript/repl.js
+++ b/lib/coffeescript/repl.js
@@ -29,7 +29,7 @@
     })(),
     historyMaxInputSize: 10240,
     eval: function(input, context, filename, cb) {
-      var Assign, Block, Call, Code, Literal, Value, ast, err, isAsync, js, referencedVars, result, token, tokens;
+      var Assign, Block, Call, Code, Literal, Value, ast, err, isAsync, js, ref, ref1, referencedVars, result, token, tokens;
       // XXX: multiline hack.
       input = input.replace(/\uFF00/g, '\n');
       // Node's REPL sends the input ending with a newline and then wrapped in
@@ -43,6 +43,13 @@
       try {
         // Tokenize the clean input.
         tokens = CoffeeScript.tokens(input);
+        // Filter out tokens generated just to hold comments.
+        if (tokens.length >= 2 && tokens[0].generated && ((ref = tokens[0].comments) != null ? ref.length : void 0) !== 0 && tokens[0][1] === '' && tokens[1][0] === 'TERMINATOR') {
+          tokens = tokens.slice(2);
+        }
+        if (tokens.length >= 1 && tokens[tokens.length - 1].generated && ((ref1 = tokens[tokens.length - 1].comments) != null ? ref1.length : void 0) !== 0 && tokens[tokens.length - 1][1] === '') {
+          tokens.pop();
+        }
         // Collect referenced variable names just like in `CoffeeScript.compile`.
         referencedVars = (function() {
           var i, len, results;

--- a/src/repl.coffee
+++ b/src/repl.coffee
@@ -30,6 +30,14 @@ replDefaults =
     try
       # Tokenize the clean input.
       tokens = CoffeeScript.tokens input
+      # Filter out tokens generated just to hold comments.
+      if tokens.length >= 2 and tokens[0].generated and
+         tokens[0].comments?.length isnt 0 and tokens[0][1] is '' and
+         tokens[1][0] is 'TERMINATOR'
+        tokens = tokens[2...]
+      if tokens.length >= 1 and tokens[tokens.length - 1].generated and
+         tokens[tokens.length - 1].comments?.length isnt 0 and tokens[tokens.length - 1][1] is ''
+        tokens.pop()
       # Collect referenced variable names just like in `CoffeeScript.compile`.
       referencedVars = (token[1] for token in tokens when token[0] is 'IDENTIFIER')
       # Generate the AST of the tokens.

--- a/test/repl.coffee
+++ b/test/repl.coffee
@@ -77,6 +77,14 @@ testRepl "empty command evaluates to undefined", (input, output) ->
   input.emitLine ''
   eq 'undefined', output.lastWrite()
 
+testRepl "#4763: comment evaluates to undefined", (input, output) ->
+  input.emitLine '# comment'
+  eq 'undefined', output.lastWrite()
+
+testRepl "#4763: multiple comments evaluate to undefined", (input, output) ->
+  input.emitLine '### a ### ### b ### # c'
+  eq 'undefined', output.lastWrite()
+
 testRepl "ctrl-v toggles multiline prompt", (input, output) ->
   input.emit 'keypress', null, ctrlV
   eq '------> ', output.lastWrite(0)


### PR DESCRIPTION
Fixes #4763. Now if you type `# comment` in the REPL, when it evaluates the line the REPL evaluates it to `undefined`.

Nitty-gritty explanation: Comments are “attached” to tokens, and added to the output JavaScript at the end of compilation when tokens are converted into the final JS code. When there’s no nearby token to attach to, for example if your entire code string was just `# comment` or `### first comment ### # second comment`, the rewriter creates a placeholder PassthroughLiteral token that’s a zero-length string—``` `` ```, essentially—to attach the tokens to. This placeholder is only ever needed at the beginning or end the tokens array. When such a placeholder is added, a newline `TERMINATOR` token is also added, if necessary, after or the placeholder (if it starts the stream) or before it (if it ends the stream). The REPL doesn’t care about comments, so when we see these placeholder tokens at the beginning or end of the `tokens` array, we remove them before we assign the REPL result to `__`.