### PR TITLE
Fix #4765: .map filenames should correspond to .js filenames

### DIFF
--- a/lib/coffeescript/command.js
+++ b/lib/coffeescript/command.js
@@ -534,7 +534,7 @@
   // same directory as the `.js` file.
   writeJs = function(base, sourcePath, js, jsPath, generatedSourceMap = null) {
     var compile, jsDir, sourceMapPath;
-    sourceMapPath = outputPath(sourcePath, base, ".js.map");
+    sourceMapPath = `${jsPath}.map`;
     jsDir = path.dirname(jsPath);
     compile = function() {
       if (opts.compile) {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -401,7 +401,7 @@ mkdirp = (dir, fn) ->
 # If `generatedSourceMap` is provided, this will write a `.js.map` file into the
 # same directory as the `.js` file.
 writeJs = (base, sourcePath, js, jsPath, generatedSourceMap = null) ->
-  sourceMapPath = outputPath sourcePath, base, ".js.map"
+  sourceMapPath = "#{jsPath}.map"
   jsDir  = path.dirname jsPath
   compile = ->
     if opts.compile


### PR DESCRIPTION
Fixes #4765: When `--output` is used to compile one `.coffee` file into a `.js` file with an unrelated filename, the generated .map file should have a corresponding filename. In other words:

```bash
coffee --map --output foo.js test.coffee
```

Should generate `foo.js` and `foo.js.map`. Prior to this PR, the files generated were `foo.js` and `test.js.map`.