### PR TITLE
Fix #4780: Babel should get correct options

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -85,7 +85,7 @@
   // object, where sourceMap is a sourcemap.coffee#SourceMap object, handy for
   // doing programmatic lookups.
   exports.compile = compile = withPrettyErrors(function(code, options = {}) {
-    var currentColumn, currentLine, encoded, filename, fragment, fragments, generateSourceMap, header, i, j, js, len, len1, map, newLines, ref, ref1, sourceMapDataURI, sourceURL, token, tokens, transpiler, transpilerOutput, v3SourceMap;
+    var currentColumn, currentLine, encoded, filename, fragment, fragments, generateSourceMap, header, i, j, js, len, len1, map, newLines, ref, ref1, sourceMapDataURI, sourceURL, token, tokens, transpiler, transpilerOptions, transpilerOutput, v3SourceMap;
     // Clone `options`, to avoid mutating the `options` object passed in.
     options = Object.assign({}, options);
     // Always generate a source map if no filename is passed in, since without a
@@ -177,13 +177,14 @@
       // is run via the CLI or Node API.
       transpiler = options.transpile.transpile;
       delete options.transpile.transpile;
+      transpilerOptions = Object.assign({}, options.transpile);
       // See https://github.com/babel/babel/issues/827#issuecomment-77573107:
       // Babel can take a v3 source map object as input in `inputSourceMap`
       // and it will return an *updated* v3 source map object in its output.
-      if (v3SourceMap && (options.transpile.inputSourceMap == null)) {
-        options.transpile.inputSourceMap = v3SourceMap;
+      if (v3SourceMap && (transpilerOptions.inputSourceMap == null)) {
+        transpilerOptions.inputSourceMap = v3SourceMap;
       }
-      transpilerOutput = transpiler(js, options.transpile);
+      transpilerOutput = transpiler(js, transpilerOptions);
       js = transpilerOutput.code;
       if (v3SourceMap && transpilerOutput.map) {
         v3SourceMap = transpilerOutput.map;

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -140,12 +140,14 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
     transpiler = options.transpile.transpile
     delete options.transpile.transpile
 
+    transpilerOptions = Object.assign {}, options.transpile
+
     # See https://github.com/babel/babel/issues/827#issuecomment-77573107:
     # Babel can take a v3 source map object as input in `inputSourceMap`
     # and it will return an *updated* v3 source map object in its output.
-    if v3SourceMap and not options.transpile.inputSourceMap?
-      options.transpile.inputSourceMap = v3SourceMap
-    transpilerOutput = transpiler js, options.transpile
+    if v3SourceMap and not transpilerOptions.inputSourceMap?
+      transpilerOptions.inputSourceMap = v3SourceMap
+    transpilerOutput = transpiler js, transpilerOptions
     js = transpilerOutput.code
     if v3SourceMap and transpilerOutput.map
       v3SourceMap = transpilerOutput.map


### PR DESCRIPTION
Fixes #4780. Currently when compiling with `--transpile`, the options object being sent to Babel isn’t “clean”—it’s a mutated version of the same options object for each iteration of the loop of each file that’s being compiled. So in #4780 the result of this was that some of the fields of source maps `.map` files were the same values for all files, when they shouldn’t be. This PR fixes things so that the `options` object is never mutated, but rather if we need to make adjustments to the options we pass to Babel, those adjustments happen in a copy.

@lydell you would be proud.