### PR TITLE
Fix #4790: Double-check that we’re not creating a bound generator function

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3729,7 +3729,7 @@
       // parameters after the splat, they are declared via expressions in the
       // function body.
       compileNode(o) {
-        var answer, body, boundMethodCheck, comment, condition, exprs, generatedVariables, haveBodyParam, haveSplatParam, i, ifTrue, j, k, l, len1, len2, len3, m, methodScope, modifiers, name, param, paramNames, paramToAddToScope, params, paramsAfterSplat, ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, scopeVariablesCount, signature, splatParamName, thisAssignments, wasEmpty;
+        var answer, body, boundMethodCheck, comment, condition, exprs, generatedVariables, haveBodyParam, haveSplatParam, i, ifTrue, j, k, l, len1, len2, len3, m, methodScope, modifiers, name, param, paramNames, paramToAddToScope, params, paramsAfterSplat, ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, scopeVariablesCount, signature, splatParamName, thisAssignments, wasEmpty, yieldNode;
         if (this.ctor) {
           if (this.isAsync) {
             this.name.error('Class constructor may not be async');
@@ -3938,6 +3938,14 @@
         }
         if (!(wasEmpty || this.noReturn)) {
           this.body.makeReturn();
+        }
+        // JavaScript doesn’t allow bound (`=>`) functions to also be generators.
+        // This is usually caught via `Op::compileContinuation`, but double-check:
+        if (this.bound && this.isGenerator) {
+          yieldNode = this.body.contains(function(node) {
+            return node instanceof Op && node.operator === 'yield';
+          });
+          (yieldNode || this).error('yield cannot occur inside bound (fat arrow) functions');
         }
         // Assemble the output
         modifiers = [];

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2697,6 +2697,12 @@ exports.Code = class Code extends Base
       @body.expressions.unshift new Call(boundMethodCheck, [new Value(new ThisLiteral), @classVariable])
     @body.makeReturn() unless wasEmpty or @noReturn
 
+    # JavaScript doesn’t allow bound (`=>`) functions to also be generators.
+    # This is usually caught via `Op::compileContinuation`, but double-check:
+    if @bound and @isGenerator
+      yieldNode = @body.contains (node) -> node instanceof Op and node.operator is 'yield'
+      (yieldNode or @).error 'yield cannot occur inside bound (fat arrow) functions'
+
     # Assemble the output
     modifiers = []
     modifiers.push 'static' if @isMethod and @isStatic

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1197,6 +1197,18 @@ test "bound functions cannot be generators", ->
            ^^^^^^^^^^
   '''
 
+test "#4790: bound functions cannot be generators, even when we’re creating IIFEs", ->
+  assertErrorFormat '''
+  =>
+    for x in []
+      for y in []
+        yield z
+  ''', '''
+    [stdin]:4:7: error: yield cannot occur inside bound (fat arrow) functions
+          yield z
+          ^^^^^^^
+  '''
+
 test "CoffeeScript keywords cannot be used as unaliased names in import lists", ->
   assertErrorFormat """
     import { unless, baz as bar } from 'lib'


### PR DESCRIPTION
Fixes #4790. So that case was interesting:

```coffee
=>
  for x in []
    for y in []
      yield z
```

This compiled, even though it should’ve thrown an error about `yield` not being allowed in `=>` functions (ES2015 just doesn’t allow bound generator functions, for whatever reason). The reason our usual check for `yield`s inside `=>` functions missed this case was because one of the `for` loops here compiled into an immediately-invoked function expression (IIFE), which created a new function scope around the `yield`; and that new function was a normal one, not bound:

```js
(*() => {
  var i, len, ref, results, x, y;
  ref = [];
  results = [];
  for (i = 0, len = ref.length; i < len; i++) {
    x = ref[i];
    results.push((yield* (function*() {
      var j, len1, ref1, results1;
      ref1 = [];
      results1 = [];
      for (j = 0, len1 = ref1.length; j < len1; j++) {
        y = ref1[j];
        results1.push((yield z));
      }
      return results1;
    })()));
  }
  return results;
});
```

And all this happened because of all the contortions involved with returning the results of these `for` loops. Throw a `return` after the `yield` and the expected error message appears.

It looked hopelessly complicated to try to amend the code where the current check is (when compiling `yield`, we check that the function it’s inside isn’t bound) to try to know when to look up a level or two because its parent function might’ve been generated by the compiler. A simpler solution to this case was to add an extra error check at the source, the compilation of the function itself, so that’s what this PR does. Either we catch the bound generator-ness when compiling `yield` or when compiling `=>`.