### PR TITLE
Fix #4580:  two-value postfix for in implicit object

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -281,7 +281,7 @@
         stack = [];
         start = null;
         return this.scanTokens(function(token, i, tokens) {
-          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, ref1, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
+          var endImplicitCall, endImplicitObject, forward, implicitObjectContinues, inImplicit, inImplicitCall, inImplicitControl, inImplicitObject, isImplicit, isImplicitCall, isImplicitObject, k, newLine, nextTag, nextToken, offset, prevTag, prevToken, ref, ref1, ref2, s, sameLine, stackIdx, stackItem, stackTag, stackTop, startIdx, startImplicitCall, startImplicitObject, startsLine, tag;
           [tag] = token;
           [prevTag] = prevToken = i > 0 ? tokens[i - 1] : [];
           [nextTag] = nextToken = i < tokens.length - 1 ? tokens[i + 1] : [];
@@ -539,7 +539,7 @@
 
           //     f a, b: c, d: e, f, g: h: i, j
 
-          if (tag === ',' && !this.looksObjectish(i + 1) && inImplicitObject() && (nextTag !== 'TERMINATOR' || !this.looksObjectish(i + 2))) {
+          if (tag === ',' && !this.looksObjectish(i + 1) && inImplicitObject() && !((ref2 = this.tag(i + 2)) === 'FOROF' || ref2 === 'FORIN') && (nextTag !== 'TERMINATOR' || !this.looksObjectish(i + 2))) {
             // When nextTag is OUTDENT the comma is insignificant and
             // should just be ignored so embed it in the implicit object.
 

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -377,7 +377,7 @@ exports.Rewriter = class Rewriter
       #
       #     f a, b: c, d: e, f, g: h: i, j
       #
-      if tag is ',' and not @looksObjectish(i + 1) and inImplicitObject() and
+      if tag is ',' and not @looksObjectish(i + 1) and inImplicitObject() and not (@tag(i + 2) in ['FOROF', 'FORIN']) and
          (nextTag isnt 'TERMINATOR' or not @looksObjectish(i + 2))
         # When nextTag is OUTDENT the comma is insignificant and
         # should just be ignored so embed it in the implicit object.

--- a/test/objects.coffee
+++ b/test/objects.coffee
@@ -652,20 +652,22 @@ test "#4544: Postfix conditionals in first line of implicit object literals", ->
 test "#4579: Postfix for/while/until in first line of implicit object literals", ->
   two =
     foo:
-      bar: x for x in [1, 2, 3]
+      bar1: x for x in [1, 2, 3]
+      bar2: x + y for x, y in [1, 2, 3]
       baz: 1337
-  arrayEq [1, 2, 3], two.foo.bar
+  arrayEq [1, 2, 3], two.foo.bar1
+  arrayEq [1, 3, 5], two.foo.bar2
   eq 1337, two.foo.baz
 
   f = (x) -> x
 
   three =
     foo: f
-      # Uncomment when #4580 is fixed
-      # bar: x + y for x, y of a: 'b', c: 'd'
-      bar: x + 'c' for x of a: 1, b: 2
+      bar1: x + y for x, y of a: 'b', c: 'd'
+      bar2: x + 'c' for x of a: 1, b: 2
       baz: 1337
-  arrayEq ['ac', 'bc'], three.foo.bar
+  arrayEq ['ab', 'cd'], three.foo.bar1
+  arrayEq ['ac', 'bc'], three.foo.bar2
   eq 1337, three.foo.baz
 
   four =
@@ -696,4 +698,3 @@ test "#4579: Postfix for/while/until in first line of implicit object literals",
       baz: 1337
   arrayEq [4, 3, 2, 1, 0], six.foo.bar
   eq 1337, six.foo.baz
-


### PR DESCRIPTION
Fixes #4580 where two-value postfix `for` in implicit object caused compiler error.
```coffeescript
a: b
c: d for d, e in f
```
or
```coffeescript
a: b
c: d for d, e of f
```
