### PR TITLE
Fix #4798: Incorrect output for object rest destructuring inside array destructuring 

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3184,7 +3184,7 @@
       // we've been assigned to, for correct internal references. If the variable
       // has not been seen yet within the current scope, declare it.
       compileNode(o) {
-        var answer, compiledName, isValue, j, name, objDestructAnswer, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
+        var answer, compiledName, hasSplat, isValue, j, name, objDestructAnswer, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
         isValue = this.variable instanceof Value;
         if (isValue) {
           // When compiling `@variable`, remember if it is part of a function parameter.
@@ -3198,12 +3198,14 @@
             // know that, so that those nodes know that they’re assignable as
             // destructured variables.
             this.variable.base.lhs = true;
-            if (!this.variable.isAssignable()) {
+            // Check if @variable contains Obj with splats.
+            hasSplat = this.variable.contains(function(node) {
+              return node instanceof Obj && node.hasSplat();
+            });
+            if (!this.variable.isAssignable() || this.variable.isArray() && hasSplat) {
               return this.compileDestructuring(o);
             }
-            if (this.variable.isObject() && this.variable.contains(function(node) {
-              return node instanceof Obj && node.hasSplat();
-            })) {
+            if (this.variable.isObject() && hasSplat) {
               // Object destructuring. Can be removed once ES proposal hits Stage 4.
               objDestructAnswer = this.compileObjectDestruct(o);
             }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2141,10 +2141,11 @@ exports.Assign = class Assign extends Base
         # know that, so that those nodes know that they’re assignable as
         # destructured variables.
         @variable.base.lhs = yes
-        return @compileDestructuring o unless @variable.isAssignable()
+        # Check if @variable contains Obj with splats.
+        hasSplat = @variable.contains (node) -> node instanceof Obj and node.hasSplat()
+        return @compileDestructuring o if not @variable.isAssignable() or @variable.isArray() and hasSplat
         # Object destructuring. Can be removed once ES proposal hits Stage 4.
-        objDestructAnswer = @compileObjectDestruct(o) if @variable.isObject() and @variable.contains (node) ->
-          node instanceof Obj and node.hasSplat()
+        objDestructAnswer = @compileObjectDestruct(o) if @variable.isObject() and hasSplat
         return objDestructAnswer if objDestructAnswer
 
       return @compileSplice       o if @variable.isSplice()

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -185,6 +185,12 @@ test "#4787 destructuring of objects within arrays", ->
   eq b, arr[1].b
   deepEqual {a, b}, arr[1]
 
+test "#4798 destructuring of objects with splat within arrays", ->
+  arr = [1, {a:1, b:2}]
+  [...,{a, r...}] = arr
+  eq a, 1
+  deepEqual r, {b:2}
+
 test "destructuring assignment with splats", ->
   a = {}; b = {}; c = {}; d = {}; e = {}
   [x,y...,z] = [a,b,c,d,e]

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -190,6 +190,11 @@ test "#4798 destructuring of objects with splat within arrays", ->
   [...,{a, r...}] = arr
   eq a, 1
   deepEqual r, {b:2}
+  [b, {q...}] = arr
+  eq b, 1
+  deepEqual q, arr[1]
+  eq q.b, r.b
+  eq q.a, a
 
 test "destructuring assignment with splats", ->
   a = {}; b = {}; c = {}; d = {}; e = {}


### PR DESCRIPTION
Fixes #4798
```javascript
// [{a, rest...}] = arr
({a} = ref = arr[0]);
rest = objectWithoutKeys(ref, ['a']);

// [b,{a, rest...},c] = arr
b = arr[0], (({a} = ref = arr[1]), rest = objectWithoutKeys(ref, ['a'])), c = arr[2];
```
