### PR TITLE
Fix #4811: Heregex comments cannot contain three slashes in a row

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1607,7 +1607,7 @@
   // Match any `/` except `///`.
   // Match `#` which is not part of interpolation, e.g. `#{}`.
   // Comments consume everything until the end of the line, including `///`.
-  HEREGEX = /^(?:[^\\\/#\s]|\\[\s\S]|\/(?!\/\/)|\#(?!\{)|\s+(?:#(?!\{)[^\n]*)?)*/;
+  HEREGEX = /^(?:[^\\\/#\s]|\\[\s\S]|\/(?!\/\/)|\#(?!\{)|\s+(?:#(?!\{).*)?)*/;
 
   HEREGEX_OMIT = /((?:\\\\)+)|\\(\s)|\s+(?:#.*)?/g; // Consume (and preserve) an even number of backslashes.
   // Preserve escaped whitespace.

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1602,7 +1602,8 @@
 
   VALID_FLAGS = /^(?!.*(.).*\1)[imguy]*$/;
 
-  HEREGEX = /^(?:[^\\\/#]|\\[\s\S]|\/(?!\/\/)|\#(?!\{))*/;
+  // Comment should consume everything until the end of the line.
+  HEREGEX = /^(?:[^\\\/#]|\\[\s\S]|\#(?!\{)(?:[^\n\r]*[\n\r])|\/(?!\/\/))*/;
 
   HEREGEX_OMIT = /((?:\\\\)+)|\\(\s)|\s+(?:#.*)?/g; // Consume (and preserve) an even number of backslashes.
   // Preserve escaped whitespace.

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1602,7 +1602,7 @@
 
   VALID_FLAGS = /^(?!.*(.).*\1)[imguy]*$/;
 
-  // Skip `\`, `/`, `#` and `\s` characters.
+  // Match any character, except those that need special handling below.
   // Match `\` followed by any character.
   // Match any `/` except `///`.
   // Match `#` which is not part of interpolation, e.g. `#{}`.

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1574,11 +1574,11 @@
 
   STRING_SINGLE = /^(?:[^\\']|\\[\s\S])*/;
 
-  STRING_DOUBLE = /^(?:[^\\"\#]|\\[\s\S]|\#(?!\{))*/;
+  STRING_DOUBLE = /^(?:[^\\"#]|\\[\s\S]|\#(?!\{))*/;
 
   HEREDOC_SINGLE = /^(?:[^\\']|\\[\s\S]|'(?!''))*/;
 
-  HEREDOC_DOUBLE = /^(?:[^\\"\#]|\\[\s\S]|"(?!"")|\#(?!\{))*/;
+  HEREDOC_DOUBLE = /^(?:[^\\"#]|\\[\s\S]|"(?!"")|\#(?!\{))*/;
 
   INSIDE_CSX = /^(?:[^\{<])*/; // Start of CoffeeScript interpolation. // Similar to `HEREDOC_DOUBLE` but there is no escaping.
   // Maybe CSX tag (`<` not allowed even if bare).
@@ -1602,10 +1602,10 @@
 
   VALID_FLAGS = /^(?!.*(.).*\1)[imguy]*$/;
 
-  // The comment should consume everything until the end of the line, including the '///'.
-  HEREGEX = /^(?:[^\\\/#]|\\[\s\S]|\/(?!\/\/)|\\\#|\#(?!\{)[^\n]*\n)*/; // Escaped hash.
+  // Comments consume everything until the end of the line, including `///`.
+  HEREGEX = /^(?:(?:\s+|^)(?:#(?!\{)[^\n]*)?|[^\\\/#]|\\[\s\S]|\/(?!\/\/)|\#(?!\{))*/;
 
-  HEREGEX_OMIT = /((?:\\\\)+)|\\(\s)|\s+(?:\#.*)?/g; // Consume (and preserve) an even number of backslashes.
+  HEREGEX_OMIT = /((?:\\\\)+)|\\(\s)|\s+(?:#.*)?/g; // Consume (and preserve) an even number of backslashes.
   // Preserve escaped whitespace.
   // Remove whitespace and comments.
 

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1574,11 +1574,11 @@
 
   STRING_SINGLE = /^(?:[^\\']|\\[\s\S])*/;
 
-  STRING_DOUBLE = /^(?:[^\\"#]|\\[\s\S]|\#(?!\{))*/;
+  STRING_DOUBLE = /^(?:[^\\"\#]|\\[\s\S]|\#(?!\{))*/;
 
   HEREDOC_SINGLE = /^(?:[^\\']|\\[\s\S]|'(?!''))*/;
 
-  HEREDOC_DOUBLE = /^(?:[^\\"#]|\\[\s\S]|"(?!"")|\#(?!\{))*/;
+  HEREDOC_DOUBLE = /^(?:[^\\"\#]|\\[\s\S]|"(?!"")|\#(?!\{))*/;
 
   INSIDE_CSX = /^(?:[^\{<])*/; // Start of CoffeeScript interpolation. // Similar to `HEREDOC_DOUBLE` but there is no escaping.
   // Maybe CSX tag (`<` not allowed even if bare).
@@ -1602,10 +1602,10 @@
 
   VALID_FLAGS = /^(?!.*(.).*\1)[imguy]*$/;
 
-  // Comment should consume everything until the end of the line.
-  HEREGEX = /^(?:[^\\\/#]|\\[\s\S]|\#(?!\{)(?:[^\n\r]*[\n\r])|\/(?!\/\/))*/;
+  // The comment should consume everything until the end of the line, including the '///'.
+  HEREGEX = /^(?:[^\\\/#]|\\[\s\S]|\/(?!\/\/)|\\\#|\#(?!\{)[^\n]*\n)*/; // Escaped hash.
 
-  HEREGEX_OMIT = /((?:\\\\)+)|\\(\s)|\s+(?:#.*)?/g; // Consume (and preserve) an even number of backslashes.
+  HEREGEX_OMIT = /((?:\\\\)+)|\\(\s)|\s+(?:\#.*)?/g; // Consume (and preserve) an even number of backslashes.
   // Preserve escaped whitespace.
   // Remove whitespace and comments.
 

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1602,8 +1602,12 @@
 
   VALID_FLAGS = /^(?!.*(.).*\1)[imguy]*$/;
 
+  // Skip `\`, `/`, `#` and `\s` characters.
+  // Match `\` followed by any character.
+  // Match any `/` except `///`.
+  // Match `#` which is not part of interpolation, e.g. `#{}`.
   // Comments consume everything until the end of the line, including `///`.
-  HEREGEX = /^(?:(?:\s+|^)(?:#(?!\{)[^\n]*)?|[^\\\/#]|\\[\s\S]|\/(?!\/\/)|\#(?!\{))*/;
+  HEREGEX = /^(?:[^\\\/#\s]|\\[\s\S]|\/(?!\/\/)|\#(?!\{)|\s+(?:#(?!\{)[^\n]*)?)*/;
 
   HEREGEX_OMIT = /((?:\\\\)+)|\\(\s)|\s+(?:#.*)?/g; // Consume (and preserve) an even number of backslashes.
   // Preserve escaped whitespace.

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1254,7 +1254,7 @@ VALID_FLAGS  = /^(?!.*(.).*\1)[imguy]*$/
 
 HEREGEX      = /// ^
   (?:
-      # Skip `\`, `/`, `#` and `\s` characters.
+      # Match any character, except those that need special handling below.
       [^\\/#\s]
       # Match `\` followed by any character.
     | \\[\s\S]

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1256,9 +1256,9 @@ HEREGEX      = /// ^
       (?:
         [^\\/#]   |
         \\[\s\S]  |
+        /(?!//)   |
         # The comment should consume everything until the end of the line, including the '///'
-        \#(?!\{)(?:[^\n\r]*[\n\r])  |
-        /(?!//)
+        \#(?!\{)(?:[^\n]*[\n])
       )*
 ///
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1216,9 +1216,9 @@ HERE_JSTOKEN = ///^ ```     ((?: [^`\\] | \\[\s\S] | `(?!``) )*) ``` ///
 STRING_START   = /^(?:'''|"""|'|")/
 
 STRING_SINGLE  = /// ^(?: [^\\']  | \\[\s\S]                      )* ///
-STRING_DOUBLE  = /// ^(?: [^\\"#] | \\[\s\S] |           \#(?!\{) )* ///
+STRING_DOUBLE  = /// ^(?: [^\\"\#] | \\[\s\S] |           \#(?!\{) )* ///
 HEREDOC_SINGLE = /// ^(?: [^\\']  | \\[\s\S] | '(?!'')            )* ///
-HEREDOC_DOUBLE = /// ^(?: [^\\"#] | \\[\s\S] | "(?!"") | \#(?!\{) )* ///
+HEREDOC_DOUBLE = /// ^(?: [^\\"\#] | \\[\s\S] | "(?!"") | \#(?!\{) )* ///
 
 INSIDE_CSX = /// ^(?:
     [^
@@ -1253,19 +1253,20 @@ REGEX_FLAGS  = /^\w*/
 VALID_FLAGS  = /^(?!.*(.).*\1)[imguy]*$/
 
 HEREGEX      = /// ^
-      (?:
-        [^\\/#]   |
-        \\[\s\S]  |
-        /(?!//)   |
-        # The comment should consume everything until the end of the line, including the '///'
-        \#(?!\{)(?:[^\n]*[\n])
-      )*
+  (?:
+      [^\\/#]   |
+      \\[\s\S]  |
+      /(?!//)   |
+      \\\#      | # Escaped hash.
+      # The comment should consume everything until the end of the line, including the '///'.
+      \#(?!\{)[^\n]*\n
+  )*
 ///
 
 HEREGEX_OMIT = ///
     ((?:\\\\)+)     # Consume (and preserve) an even number of backslashes.
   | \\(\s)          # Preserve escaped whitespace.
-  | \s+(?:#.*)?     # Remove whitespace and comments.
+  | \s+(?:\#.*)?     # Remove whitespace and comments.
 ///g
 
 REGEX_ILLEGAL = /// ^ ( / | /{3}\s*) (\*) ///

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1254,12 +1254,16 @@ VALID_FLAGS  = /^(?!.*(.).*\1)[imguy]*$/
 
 HEREGEX      = /// ^
   (?:
-    # Comments consume everything until the end of the line, including `///`.
-    (?:\s+|^)(?:#(?!\{)[^\n]*)? |
-    [^\\/#]                     |
-    \\[\s\S]                    |
-    /(?!//)                     |
-    \#(?!\{)
+      # Skip `\`, `/`, `#` and `\s` characters.
+      [^\\/#\s]
+      # Match `\` followed by any character.
+    | \\[\s\S]
+      # Match any `/` except `///`.
+    | /(?!//)
+      # Match `#` which is not part of interpolation, e.g. `#{}`.
+    | \#(?!\{)
+      # Comments consume everything until the end of the line, including `///`.
+    | \s+(?:#(?!\{)[^\n]*)?
   )*
 ///
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1216,9 +1216,9 @@ HERE_JSTOKEN = ///^ ```     ((?: [^`\\] | \\[\s\S] | `(?!``) )*) ``` ///
 STRING_START   = /^(?:'''|"""|'|")/
 
 STRING_SINGLE  = /// ^(?: [^\\']  | \\[\s\S]                      )* ///
-STRING_DOUBLE  = /// ^(?: [^\\"\#] | \\[\s\S] |           \#(?!\{) )* ///
+STRING_DOUBLE  = /// ^(?: [^\\"#] | \\[\s\S] |           \#(?!\{) )* ///
 HEREDOC_SINGLE = /// ^(?: [^\\']  | \\[\s\S] | '(?!'')            )* ///
-HEREDOC_DOUBLE = /// ^(?: [^\\"\#] | \\[\s\S] | "(?!"") | \#(?!\{) )* ///
+HEREDOC_DOUBLE = /// ^(?: [^\\"#] | \\[\s\S] | "(?!"") | \#(?!\{) )* ///
 
 INSIDE_CSX = /// ^(?:
     [^
@@ -1254,19 +1254,19 @@ VALID_FLAGS  = /^(?!.*(.).*\1)[imguy]*$/
 
 HEREGEX      = /// ^
   (?:
-      [^\\/#]   |
-      \\[\s\S]  |
-      /(?!//)   |
-      \\\#      | # Escaped hash.
-      # The comment should consume everything until the end of the line, including the '///'.
-      \#(?!\{)[^\n]*\n
+    # Comments consume everything until the end of the line, including `///`.
+    (?:\s+|^)(?:#(?!\{)[^\n]*)? |
+    [^\\/#]                     |
+    \\[\s\S]                    |
+    /(?!//)                     |
+    \#(?!\{)
   )*
 ///
 
 HEREGEX_OMIT = ///
     ((?:\\\\)+)     # Consume (and preserve) an even number of backslashes.
   | \\(\s)          # Preserve escaped whitespace.
-  | \s+(?:\#.*)?     # Remove whitespace and comments.
+  | \s+(?:#.*)?     # Remove whitespace and comments.
 ///g
 
 REGEX_ILLEGAL = /// ^ ( / | /{3}\s*) (\*) ///

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1252,7 +1252,15 @@ REGEX = /// ^
 REGEX_FLAGS  = /^\w*/
 VALID_FLAGS  = /^(?!.*(.).*\1)[imguy]*$/
 
-HEREGEX      = /// ^(?: [^\\/#] | \\[\s\S] | /(?!//) | \#(?!\{) )* ///
+HEREGEX      = /// ^
+      (?:
+        [^\\/#]   |
+        \\[\s\S]  |
+        # The comment should consume everything until the end of the line, including the '///'
+        \#(?!\{)(?:[^\n\r]*[\n\r])  |
+        /(?!//)
+      )*
+///
 
 HEREGEX_OMIT = ///
     ((?:\\\\)+)     # Consume (and preserve) an even number of backslashes.

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1263,7 +1263,7 @@ HEREGEX      = /// ^
       # Match `#` which is not part of interpolation, e.g. `#{}`.
     | \#(?!\{)
       # Comments consume everything until the end of the line, including `///`.
-    | \s+(?:#(?!\{)[^\n]*)?
+    | \s+(?:#(?!\{).*)?
   )*
 ///
 

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1803,3 +1803,12 @@ test "#3098: suppressed newline should be unsuppressed by semicolon", ->
     a = ; 5
         ^
   '''
+
+test "#4811, heregex comments cannot contain three slashes in a row", ->
+  assertErrorFormat '''
+   /// .* # comment ///
+  ''', '''
+  [stdin]:1:1: error: missing ///
+  /// .* # comment ///
+  ^^^
+  '''

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1804,7 +1804,7 @@ test "#3098: suppressed newline should be unsuppressed by semicolon", ->
         ^
   '''
 
-test "#4811, heregex comments cannot contain three slashes in a row", ->
+test "#4811: '///' inside a heregex comment does not close the heregex", ->
   assertErrorFormat '''
    /// .* # comment ///
   ''', '''

--- a/test/regexps.coffee
+++ b/test/regexps.coffee
@@ -313,3 +313,16 @@ test "#4248: Unicode code point escapes", ->
   """
     /a\\udab3\\uddef/;
   """
+
+test "#4811, heregex comments with ///", ->
+  eqJS """
+    ///
+      a | # comment with ///
+      b   # /// 'heregex' in comment will be consumed
+    ///
+  """,
+  """
+   // comment with ///
+   // /// 'heregex' in comment will be consumed
+   /a|b/;
+  """


### PR DESCRIPTION
Fixes #4811. Heregex comment will consume `///` in the same row.
```coffeescript
/// .* # comment ///

# [stdin]:1:1: error: missing ///
# /// .* # comment ///
# ^^^
```

```coffeescript
///
  a | # comment with ///
  b   # /// another comment
///

# // comment with ///
# // /// 'heregex' in comment will be consumed
# /a|b/;
```