### PR TITLE
[CS1] AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - node
 
 before_install:
-  - "test $(echo $TRAVIS_NODE_VERSION | cut -d. -f1) = '0' && npm install --global npm@2"
+  - "test $(echo $TRAVIS_NODE_VERSION | cut -d. -f1) = '0' && npm install --global npm@2 && npm --version || true"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: node_js
 
 node_js:
+  - 0.8
   - 0.10
   - 0.12
   - 4
   - 6
   - 8
   - node
+
+before_install:
+  - "test $TRAVIS_NODE_VERSION < 4 && npm install --global npm@2"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - node
 
 before_install:
-  - "test $TRAVIS_NODE_VERSION < 4 && npm install --global npm@2"
+  - "test $(echo $TRAVIS_NODE_VERSION | cut -d. -f1) = '0' && npm install --global npm@2"
 
 cache:
   directories:

--- a/Cakefile
+++ b/Cakefile
@@ -1,4 +1,5 @@
 fs                        = require 'fs'
+os                        = require 'os'
 path                      = require 'path'
 _                         = require 'underscore'
 { spawn, exec, execSync } = require 'child_process'
@@ -361,6 +362,9 @@ runTests = (CoffeeScript) ->
   failures    = []
 
   global[name] = func for name, func of require 'assert'
+
+  # `os.tmpdir()` was added in Node 0.9.9, but we support 0.8+.
+  os.tmpdir ?= -> path.resolve process.env.TMPDIR
 
   # Convenience aliases.
   global.CoffeeScript = CoffeeScript

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - IF DEFINED %nodejs_version% IF %nodejs_version% LSS 4 npm install --global npm@2
+  - IF NOT [%nodejs_version%] == [] IF "%nodejs_version%" LSS 4 npm install --global npm@2
   - node --version
   - npm --version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - IF %nodejs_version% LSS 4 npm -g install npm@2
   - node --version
   - npm --version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,13 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - IF %nodejs_version% LSS 4 npm -g install npm@2
+  - IF %nodejs_version% NEQ "" IF %nodejs_version% LSS 4 npm -g install npm@2
   - node --version
   - npm --version
   - npm install
+
+cache:
+  - node_modules
 
 test_script:
   - node ./bin/cake build:except-parser
@@ -22,7 +25,6 @@ test_script:
   - node ./bin/cake build:browser
   - node --harmony ./bin/cake test
   - node --harmony ./bin/cake test:browser
-
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - IF [%nodejs_version%] NEQ [] IF %nodejs_version% LSS 4 npm install --global npm@2
+  - IF DEFINED %nodejs_version% IF %nodejs_version% LSS 4 npm install --global npm@2
   - node --version
   - npm --version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - IF %nodejs_version% NEQ "" IF %nodejs_version% LSS 4 npm install --global npm@2
+  - IF [%nodejs_version%] NEQ [""] IF %nodejs_version% LSS 4 npm install --global npm@2
   - node --version
   - npm --version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - IF %nodejs_version% NEQ "" IF %nodejs_version% LSS 4 npm -g install npm@2
+  - IF %nodejs_version% NEQ "" IF %nodejs_version% LSS 4 npm install --global npm@2
   - node --version
   - npm --version
   - npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+environment:
+  matrix:
+    - nodejs_version: '0.8'
+    - nodejs_version: '0.10'
+    - nodejs_version: '0.12'
+    - nodejs_version: '4'
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+    - nodejs_version: '' # Installs latest.
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
+  - npm install
+
+test_script:
+  - node ./bin/cake build:except-parser
+  - node ./bin/cake build:parser
+  - node --harmony ./bin/cake build:full
+  - node ./bin/cake build:browser
+  - node --harmony ./bin/cake test
+  - node --harmony ./bin/cake test:browser
+
+
+build: off
+
+version: "{build}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - IF [%nodejs_version%] NEQ [""] IF %nodejs_version% LSS 4 npm install --global npm@2
+  - IF [%nodejs_version%] NEQ [] IF %nodejs_version% LSS 4 npm install --global npm@2
   - node --version
   - npm --version
   - npm install

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -77,7 +77,7 @@ if require?
 
     try
       assertErrorFormat """
-        require '#{tempFile}'
+        require '#{tempFile.replace /\\/g, '\\\\'}'
       """,
       """
         #{fs.realpathSync tempFile}:1:15: error: unexpected in


### PR DESCRIPTION
This adds AppVeyor Windows CI builds to the 1.x branch. This also gets the tests running under CI for Node 0.8 for both Windows and Linux. After this, our repo will be built and tested under Node 0.8, 0.10, 0.12, 4, 6, 8 and latest, for both Windows and Linux.

Part of #4731 (a PR which fixed tests for Windows) was backported, and a polyfill was added for `os.tmpdir` to get four more tests to pass in Node 0.8.