### PR TITLE
[Enhancement] Improve heregex comment error message

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1005,7 +1005,7 @@
     // This method allows us to have strings within interpolations within strings,
     // ad infinitum.
     matchWithInterpolations(regex, delimiter, closingDelimiter, interpolators) {
-      var braceInterpolator, close, column, firstToken, index, interpolationOffset, interpolator, lastToken, line, match, nested, offsetInChunk, open, ref, rest, str, strPart, tokens;
+      var braceInterpolator, close, column, errorMatch, firstToken, index, interpolationOffset, interpolator, isRegex, lastToken, line, match, nested, offsetInChunk, open, ref, regExError, rest, str, strPart, tokens;
       if (closingDelimiter == null) {
         closingDelimiter = delimiter;
       }
@@ -1018,12 +1018,10 @@
         return null;
       }
       str = this.chunk.slice(offsetInChunk);
+      isRegex = delimiter.charAt(0) === '/';
       while (true) {
         [strPart] = regex.exec(str);
-        this.validateEscapes(strPart, {
-          isRegex: delimiter.charAt(0) === '/',
-          offsetInChunk
-        });
+        this.validateEscapes(strPart, {isRegex, offsetInChunk});
         // Push a fake `'NEOSTRING'` token, which will get turned into a real string later.
         tokens.push(this.makeToken('NEOSTRING', strPart, offsetInChunk));
         str = str.slice(strPart.length);
@@ -1071,6 +1069,15 @@
         offsetInChunk += index;
       }
       if (str.slice(0, closingDelimiter.length) !== closingDelimiter) {
+        // Find heregex comment ending with '///'.
+        regExError = /\s+\#(?!\{)[^\n]*(\/\/\/)/g;
+        if (isRegex && (errorMatch = regExError.exec(this.chunk))) {
+          ({index} = errorMatch);
+          this.error(`'${closingDelimiter}' inside a heregex comment does not close the heregex`, {
+            length: errorMatch[0].length,
+            offset: index
+          });
+        }
         this.error(`missing ${closingDelimiter}`, {
           length: delimiter.length
         });

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1808,7 +1808,7 @@ test "#4811: '///' inside a heregex comment does not close the heregex", ->
   assertErrorFormat '''
    /// .* # comment ///
   ''', '''
-  [stdin]:1:1: error: missing ///
+  [stdin]:1:7: error: '///' inside a heregex comment does not close the heregex
   /// .* # comment ///
-  ^^^
+        ^^^^^^^^^^^^^^
   '''


### PR DESCRIPTION
A small enhancement to provide a more descriptive error message when heregex comment ends with `///`.

```coffeescript
///[1-9] |
   0(?!0) # zero must not be followed by zero///
```

Before:
```
[stdin]:1:1: error: missing ///
///[1-9] |
^^^
```

After:
```
[stdin]:2:10: error: '///' inside a heregex comment does not close the heregex
   0(?!0) # zero must not be followed by zero ///
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```