### PR TITLE
[Enhancement] improve Elision output

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3626,7 +3626,10 @@
               subpattern: true
             }).compileToFragments(o, LEVEL_LIST));
           } else {
-            assigns.push(idx.compileToFragments(o, LEVEL_LIST));
+            if (expandedIdx) {
+              // Output `Elision` only if `idx` is `i++`, e.g. expandedIdx.
+              assigns.push(idx.compileToFragments(o, LEVEL_LIST));
+            }
           }
         }
         if (!(top || this.subpattern)) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2472,7 +2472,8 @@ exports.Assign = class Assign extends Base
       unless obj instanceof Elision
         assigns.push new Assign(obj, val, null, param: @param, subpattern: yes).compileToFragments o, LEVEL_LIST
       else
-        assigns.push idx.compileToFragments o, LEVEL_LIST
+        # Output `Elision` only if `idx` is `i++`, e.g. expandedIdx.
+        assigns.push idx.compileToFragments o, LEVEL_LIST if expandedIdx
 
     assigns.push vvar unless top or @subpattern
     fragments = @joinFragmentArrays assigns, ', '

--- a/test/arrays.coffee
+++ b/test/arrays.coffee
@@ -74,8 +74,8 @@ test "array elisions destructuring with splats and expansions", ->
   arrayEq [a,b], [2,[5,6,7,8,9]]
   [,c,...,,d,,e] = arr
   arrayEq [c,d,e], [2,7,9]
-  [...,e,,,f,,,] = arr
-  arrayEq [e,f], [4,7]
+  [...,f,,,g,,,] = arr
+  arrayEq [f,g], [4,7]
 
 test "array elisions as function parameters", ->
   arr = [1,2,3,4,5,6,7,8,9]


### PR DESCRIPTION
This PR improves compiled code in `Assign::compileDestructuring`.

Current output:
```javascript
// CS: [a, , , {b, c...}, d] = arr

a = arr[0], 1, 2, (({b} = ref = arr[3]), c = objectWithoutKeys(ref, ['b'])), d = arr[4];
            ^  ^
```
`1` and `2` are values of the `idx` and can be skipped in cases when there are no `Splat` or `Expansion` in the destructured array.

Improved output:
```javascript
// CS: [a, , , {b, c...}, d] = arr

a = arr[0], (({b} = ref = arr[3]), c = objectWithoutKeys(ref, ['b'])), d = arr[4];
```