### PR TITLE
Set the context of executable class body wrappers

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -543,7 +543,7 @@
 
     return Base;
 
-  })();
+  }).call(this);
 
   //### HoistTarget
 
@@ -997,7 +997,7 @@
 
     return Block;
 
-  })();
+  }).call(this);
 
   //### Literal
 
@@ -1030,7 +1030,7 @@
 
     return Literal;
 
-  })();
+  }).call(this);
 
   exports.NumberLiteral = NumberLiteral = class NumberLiteral extends Literal {};
 
@@ -1094,7 +1094,7 @@
 
     return IdentifierLiteral;
 
-  })();
+  }).call(this);
 
   exports.CSXTag = CSXTag = class CSXTag extends IdentifierLiteral {};
 
@@ -1105,7 +1105,7 @@
 
     return PropertyName;
 
-  })();
+  }).call(this);
 
   exports.ComputedPropertyName = ComputedPropertyName = class ComputedPropertyName extends PropertyName {
     compileNode(o) {
@@ -1137,7 +1137,7 @@
 
     return StatementLiteral;
 
-  })();
+  }).call(this);
 
   exports.ThisLiteral = ThisLiteral = class ThisLiteral extends Literal {
     constructor() {
@@ -1231,7 +1231,7 @@
 
     return Return;
 
-  })();
+  }).call(this);
 
   // `yield return` works exactly like `return`, except that it turns the function
   // into a generator.
@@ -1490,7 +1490,7 @@
 
     return Value;
 
-  })();
+  }).call(this);
 
   //### HereComment
 
@@ -1751,7 +1751,7 @@
 
     return Call;
 
-  })();
+  }).call(this);
 
   //### Super
 
@@ -1789,7 +1789,7 @@
 
     return SuperCall;
 
-  })();
+  }).call(this);
 
   exports.Super = Super = (function() {
     class Super extends Base {
@@ -1837,7 +1837,7 @@
 
     return Super;
 
-  })();
+  }).call(this);
 
   //### RegexWithInterpolations
 
@@ -1889,7 +1889,7 @@
 
     return Extends;
 
-  })();
+  }).call(this);
 
   //### Access
 
@@ -1922,7 +1922,7 @@
 
     return Access;
 
-  })();
+  }).call(this);
 
   //### Index
 
@@ -1948,7 +1948,7 @@
 
     return Index;
 
-  })();
+  }).call(this);
 
   //### Range
 
@@ -2065,7 +2065,7 @@
 
     return Range;
 
-  })();
+  }).call(this);
 
   //### Slice
 
@@ -2103,7 +2103,7 @@
 
     return Slice;
 
-  })();
+  }).call(this);
 
   //### Obj
 
@@ -2348,7 +2348,7 @@
 
     return Obj;
 
-  })();
+  }).call(this);
 
   //### Arr
 
@@ -2517,7 +2517,7 @@
 
     return Arr;
 
-  })();
+  }).call(this);
 
   //### Class
 
@@ -2803,7 +2803,7 @@
 
     return Class;
 
-  })();
+  }).call(this);
 
   exports.ExecutableClassBody = ExecutableClassBody = (function() {
     class ExecutableClassBody extends Base {
@@ -2826,9 +2826,9 @@
         this.setContext();
         ident = new IdentifierLiteral(this.name);
         params = [];
-        args = [];
+        args = [new ThisLiteral];
         wrapper = new Code(params, this.body);
-        klass = new Parens(new Call(wrapper, args));
+        klass = new Parens(new Call(new Value(wrapper, [new Access(new PropertyName('call'))]), args));
         this.body.spaced = true;
         o.classScope = wrapper.makeScope(o.scope);
         if (this.class.hasNameClash) {
@@ -2947,7 +2947,7 @@
 
     return ExecutableClassBody;
 
-  })();
+  }).call(this);
 
   //### Import and Export
   exports.ModuleDeclaration = ModuleDeclaration = (function() {
@@ -2983,7 +2983,7 @@
 
     return ModuleDeclaration;
 
-  })();
+  }).call(this);
 
   exports.ImportDeclaration = ImportDeclaration = class ImportDeclaration extends ModuleDeclaration {
     compileNode(o) {
@@ -3036,7 +3036,7 @@
 
     return ImportClause;
 
-  })();
+  }).call(this);
 
   exports.ExportDeclaration = ExportDeclaration = class ExportDeclaration extends ModuleDeclaration {
     compileNode(o) {
@@ -3118,7 +3118,7 @@
 
     return ModuleSpecifierList;
 
-  })();
+  }).call(this);
 
   exports.ImportSpecifierList = ImportSpecifierList = class ImportSpecifierList extends ModuleSpecifierList {};
 
@@ -3162,7 +3162,7 @@
 
     return ModuleSpecifier;
 
-  })();
+  }).call(this);
 
   exports.ImportSpecifier = ImportSpecifier = class ImportSpecifier extends ModuleSpecifier {
     constructor(imported, local) {
@@ -3730,7 +3730,7 @@
 
     return Assign;
 
-  })();
+  }).call(this);
 
   //### FuncGlyph
   exports.FuncGlyph = FuncGlyph = class FuncGlyph extends Base {
@@ -4186,7 +4186,7 @@
 
     return Code;
 
-  })();
+  }).call(this);
 
   //### Param
 
@@ -4329,7 +4329,7 @@
 
     return Param;
 
-  })();
+  }).call(this);
 
   //### Splat
 
@@ -4364,7 +4364,7 @@
 
     return Splat;
 
-  })();
+  }).call(this);
 
   //### Expansion
 
@@ -4388,7 +4388,7 @@
 
     return Expansion;
 
-  })();
+  }).call(this);
 
   //### Elision
 
@@ -4420,7 +4420,7 @@
 
     return Elision;
 
-  })();
+  }).call(this);
 
   //### While
 
@@ -4507,7 +4507,7 @@
 
     return While;
 
-  })();
+  }).call(this);
 
   //### Op
 
@@ -4805,7 +4805,7 @@
 
     return Op;
 
-  })();
+  }).call(this);
 
   //### In
   exports.In = In = (function() {
@@ -4883,7 +4883,7 @@
 
     return In;
 
-  })();
+  }).call(this);
 
   //### Try
 
@@ -4936,7 +4936,7 @@
 
     return Try;
 
-  })();
+  }).call(this);
 
   //### Throw
 
@@ -4970,7 +4970,7 @@
 
     return Throw;
 
-  })();
+  }).call(this);
 
   //### Existence
 
@@ -5030,7 +5030,7 @@
 
     return Existence;
 
-  })();
+  }).call(this);
 
   //### Parens
 
@@ -5087,7 +5087,7 @@
 
     return Parens;
 
-  })();
+  }).call(this);
 
   //### StringWithInterpolations
   exports.StringWithInterpolations = StringWithInterpolations = (function() {
@@ -5213,7 +5213,7 @@
 
     return StringWithInterpolations;
 
-  })();
+  }).call(this);
 
   //### For
 
@@ -5461,7 +5461,7 @@
 
     return For;
 
-  })();
+  }).call(this);
 
   //### Switch
 
@@ -5548,7 +5548,7 @@
 
     return Switch;
 
-  })();
+  }).call(this);
 
   //### If
 
@@ -5685,7 +5685,7 @@
 
     return If;
 
-  })();
+  }).call(this);
 
   // Constants
   // ---------

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -886,7 +886,7 @@
 
     return Rewriter;
 
-  })();
+  }).call(this);
 
   // Constants
   // ---------

--- a/lib/coffeescript/sourcemap.js
+++ b/lib/coffeescript/sourcemap.js
@@ -203,7 +203,7 @@
 
     return SourceMap;
 
-  })();
+  }).call(this);
 
   // Our API for source maps is just the `SourceMap` class.
   module.exports = SourceMap;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1877,9 +1877,9 @@ exports.ExecutableClassBody = class ExecutableClassBody extends Base
 
     ident   = new IdentifierLiteral @name
     params  = []
-    args    = []
+    args    = [new ThisLiteral]
     wrapper = new Code params, @body
-    klass   = new Parens new Call wrapper, args
+    klass   = new Parens new Call (new Value wrapper, [new Access new PropertyName 'call']), args
 
     @body.spaced = true
 

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -1857,3 +1857,13 @@ test "#4724: backticked expression in a class body with hoisted member", ->
   a = new A
   eq 42, a.x
   eq 84, a.hoisted
+
+test "#4827: executable class body wrappers have correct context", ->
+  test = ->
+    class @A
+    class @B extends @A
+      @property = 1
+
+  o = {}
+  test.call o
+  ok typeof o.A is typeof o.B is 'function'

--- a/test/comments.coffee
+++ b/test/comments.coffee
@@ -364,7 +364,7 @@ test "#3132: Place block-comments nicely", ->
 
     return DummyClass;
 
-  })();"""
+  }).call(this);"""
 
 test "#3638: Demand a whitespace after # symbol", ->
   eqJS """


### PR DESCRIPTION
Fixes #4827.

I did first try to use an arrow function by setting `bound = true` on the wrapper, but this messed with the handling of `@` *within* the class body, where it should refer to the class being defined.

We could opt to perform the binding only if the class `extends` an `@`-value but that would add a bit of extra complexity in the compiler for equivalent and, imo, no less readable output.