### PR TITLE
Fix #4836: functions named get or set can be used without parentheses when attached to `@`

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -111,7 +111,7 @@
     // referenced as property names here, so you can still do `jQuery.is()` even
     // though `is` means `===` otherwise.
     identifierToken() {
-      var alias, colon, colonOffset, colonToken, id, idLength, inCSXTag, input, match, poppedToken, prev, prevprev, ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, regExSuper, regex, sup, tag, tagToken;
+      var alias, colon, colonOffset, colonToken, id, idLength, inCSXTag, input, match, poppedToken, prev, prevprev, ref, ref1, ref2, ref3, ref4, ref5, ref6, ref7, ref8, ref9, regExSuper, regex, sup, tag, tagToken;
       inCSXTag = this.atCSXTag();
       regex = inCSXTag ? CSX_ATTRIBUTE : IDENTIFIER;
       if (!(match = regex.exec(this.chunk))) {
@@ -203,7 +203,7 @@
           this.error(`'${prev[1]}' cannot be used as a keyword, or as a function call without parentheses`, prev[2]);
         } else {
           prevprev = this.tokens[this.tokens.length - 2];
-          if (((ref8 = prev[0]) === '@' || ref8 === 'THIS') && prevprev && prevprev.spaced && /^[gs]et$/.test(prevprev[1]) && this.tokens[this.tokens.length - 3][0] !== '.') {
+          if (((ref8 = prev[0]) === '@' || ref8 === 'THIS') && prevprev && prevprev.spaced && /^[gs]et$/.test(prevprev[1]) && ((ref9 = this.tokens[this.tokens.length - 3][0]) !== '.' && ref9 !== '@')) {
             this.error(`'${prevprev[1]}' cannot be used as a keyword, or as a function call without parentheses`, prevprev[2]);
           }
         }

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -197,7 +197,7 @@ exports.Lexer = class Lexer
       else
         prevprev = @tokens[@tokens.length - 2]
         if prev[0] in ['@', 'THIS'] and prevprev and prevprev.spaced and /^[gs]et$/.test(prevprev[1]) and
-        @tokens[@tokens.length - 3][0] isnt '.'
+           @tokens[@tokens.length - 3][0] not in ['.', '@']
           @error "'#{prevprev[1]}' cannot be used as a keyword, or as a function call without parentheses", prevprev[2]
 
     if tag is 'IDENTIFIER' and id in RESERVED

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -795,7 +795,7 @@ test "get and set can be used as class method names", ->
   eq 4, B.get()
   eq 5, B.set()
 
-test "functions named get or set can be used without parentheses when attached to an object; #4524", ->
+test "#4524: functions named get or set can be used without parentheses when attached to an object", ->
   obj =
     get: (x) -> x + 2
     set: (x) -> x + 3
@@ -836,3 +836,18 @@ test "functions named get or set can be used without parentheses when attached t
 
   eq 16, b.get value: @ten
   eq 17, b.set value: @ten
+
+test "#4836: functions named get or set can be used without parentheses when attached to this or @", ->
+  @get = (x) -> x + 2
+  @set = (x) -> x + 3
+  @a = 4
+
+  eq 12, this.get 10
+  eq 13, this.set 10
+  eq 6, this.get @a
+  eq 7, this.set @a
+
+  eq 12, @get 10
+  eq 13, @set 10
+  eq 6, @get @a
+  eq 7, @set @a


### PR DESCRIPTION
Fixes #4836. `@get @someProp` shouldn’t throw an error. This is a weird edge case, where the `@` before `someProp` was screwing up the detection of the `@` before `get`, which signifies that the `get` is attached to something and therefore safe, and not someone trying to use the `get` shorthand syntax. We don’t need to also check for the `THIS` token, because the token before `get` is either `@` or `.`, never `THIS`.