### PR TITLE
Throw warning for unsupported runtimes, e.g. Node < 6

### DIFF
--- a/bin/cake
+++ b/bin/cake
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+try {
+  new Function('var {a} = {a: 1}')();
+} catch (error) {
+  console.error('Your JavaScript runtime does not support some features used by the cake command. Please use Node 6 or later.');
+  process.exit(1);
+}
+
 var path = require('path');
 var fs   = require('fs');
 

--- a/bin/coffee
+++ b/bin/coffee
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+try {
+  new Function('var {a} = {a: 1}')();
+} catch (error) {
+  console.error('Your JavaScript runtime does not support some features used by the coffee command. Please use Node 6 or later.');
+  process.exit(1);
+}
+
 var path = require('path');
 var fs   = require('fs');
 


### PR DESCRIPTION
Running `coffee` or `cake` in Node 4 or below results in an unhelpful stack trace (per [here](https://stackoverflow.com/q/46797272/223225)):

```bash
user@computer:~/some/path $ coffee -c code.coffee 
/usr/local/lib/node_modules/coffeescript/lib/coffeescript/command.js:23
  ({spawn, exec} = require('child_process'));
   ^

ReferenceError: Invalid left-hand side in assignment
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/coffeescript/bin/coffee:15:5)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
```

We can do better than this. This minor addition first checks that the runtime supports destructuring, and throws an informative error if your runtime doesn’t:

```bash
user@computer:~/some/path $ coffee -c code.coffee
Your JavaScript runtime does not support some features used by the coffee command.
Please use Node 6 or later.
```

Destructuring is really just a proxy for all the advanced ES2015 features that the CoffeeScript module uses, but it should be enough. We already use CI to test that CoffeeScript works in Node 6, and destructuring isn’t supported in Node 4 and below, so this should catch all the unsupported runtimes.