### PR TITLE
Adopt es6 position of splats

### DIFF
--- a/documentation/examples/array_spread.coffee
+++ b/documentation/examples/array_spread.coffee
@@ -1,4 +1,4 @@
 popular  = ['pepperoni', 'sausage', 'cheese']
 unwanted = ['anchovies', 'olives']
 
-all = [popular..., unwanted..., 'mushrooms']
+all = [...popular, ...unwanted, 'mushrooms']

--- a/documentation/examples/object_spread.coffee
+++ b/documentation/examples/object_spread.coffee
@@ -2,4 +2,4 @@ user =
   name: 'Werner Heisenberg'
   occupation: 'theoretical physicist'
 
-currentUser = { user..., status: 'Uncertain' }
+currentUser = { ...user, status: 'Uncertain' }

--- a/documentation/examples/splats.coffee
+++ b/documentation/examples/splats.coffee
@@ -1,6 +1,6 @@
 gold = silver = rest = "unknown"
 
-awardMedals = (first, second, others...) ->
+awardMedals = (first, second, ...others) ->
   gold   = first
   silver = second
   rest   = others
@@ -18,7 +18,7 @@ contenders = [
   "Usain Bolt"
 ]
 
-awardMedals contenders...
+awardMedals ...contenders
 
 alert """
 Gold: #{gold}


### PR DESCRIPTION
Now that CoffeeScript supports splats, rest and spread on either side of the variable name I think it makes sense to adopt ES6's position in the docs:

`after...` and `...before`

It will be easier to adopt for those already familiar with the syntax in JS.
