### PR TITLE
Fix #4843: bad output when assigning to @prop in destructuring assignment with defaults

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4106,11 +4106,11 @@
       }
 
       eachParamName(iterator) {
-        var i, j, len1, param, ref1, results;
+        var j, len1, param, ref1, results;
         ref1 = this.params;
         results = [];
-        for (i = j = 0, len1 = ref1.length; j < len1; i = ++j) {
-          param = ref1[i];
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          param = ref1[j];
           results.push(param.eachName(iterator));
         }
         return results;

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3818,7 +3818,7 @@
         // Check for duplicate parameters and separate `this` assignments.
         paramNames = [];
         this.eachParamName(function(name, node, param) {
-          var target;
+          var newName, propTarget, target;
           if (indexOf.call(paramNames, name) >= 0) {
             node.error(`multiple parameters named '${name}'`);
           }
@@ -3828,8 +3828,23 @@
             if (indexOf.call(JS_FORBIDDEN, name) >= 0) {
               name = `_${name}`;
             }
-            target = new IdentifierLiteral(o.scope.freeVariable(name));
-            param.renameParam(node, target);
+            newName = o.scope.freeVariable(name, {
+              reserve: false
+            });
+            target = new IdentifierLiteral(newName);
+            // Param is object destructuring with a default value: ({@prop = 1}) ->
+            // In a case when the variable name is already reserved, we have to assign
+            // a new variable name to the destructured variable: ({prop:prop1 = 1}) ->
+            if (param.name instanceof Obj && param.name.properties[0] instanceof Assign && name !== newName) {
+              propTarget = new Assign(new IdentifierLiteral(name), target, 'object', {
+                operatorToken: new Literal(':', {
+                  param: true
+                })
+              });
+              param.renameParam(node, propTarget);
+            } else {
+              param.renameParam(node, target);
+            }
             return thisAssignments.push(new Assign(node, target));
           }
         });

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1499,7 +1499,7 @@
     constructor({
         content: content1,
         newLine: newLine1,
-        unshift: unshift
+        unshift
       }) {
       super();
       this.content = content1;
@@ -1546,7 +1546,7 @@
     constructor({
         content: content1,
         newLine: newLine1,
-        unshift: unshift
+        unshift
       }) {
       super();
       this.content = content1;
@@ -4257,8 +4257,8 @@
       // to that name.
       eachName(iterator, name = this.name) {
         var atParam, j, len1, nObj, node, obj, ref1, ref2;
-        atParam = (obj) => {
-          return iterator(`@${obj.properties[0].name.value}`, obj, this, nObj);
+        atParam = (obj, originalObj = null) => {
+          return iterator(`@${obj.properties[0].name.value}`, obj, this, originalObj);
         };
         if (name instanceof Literal) {
           // * simple literals `foo`
@@ -4296,7 +4296,7 @@
               this.eachName(iterator, obj.base);
             // * at-params within destructured parameters `{@foo}`
             } else if (obj.this) {
-              atParam(obj);
+              atParam(obj, nObj);
             } else {
               // * simple destructured parameters {foo}
               iterator(obj.base.value, obj.base, this);

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3817,8 +3817,8 @@
         haveBodyParam = false;
         // Check for duplicate parameters and separate `this` assignments.
         paramNames = [];
-        this.eachParamName(function(name, node, param) {
-          var newName, propTarget, target;
+        this.eachParamName(function(name, node, param, obj) {
+          var replacement, target;
           if (indexOf.call(paramNames, name) >= 0) {
             node.error(`multiple parameters named '${name}'`);
           }
@@ -3828,23 +3828,14 @@
             if (indexOf.call(JS_FORBIDDEN, name) >= 0) {
               name = `_${name}`;
             }
-            newName = o.scope.freeVariable(name, {
+            target = new IdentifierLiteral(o.scope.freeVariable(name, {
               reserve: false
-            });
-            target = new IdentifierLiteral(newName);
-            // Param is object destructuring with a default value: ({@prop = 1}) ->
+            }));
+            // `Param` is object destructuring with a default value: ({@prop = 1}) ->
             // In a case when the variable name is already reserved, we have to assign
             // a new variable name to the destructured variable: ({prop:prop1 = 1}) ->
-            if (param.name instanceof Obj && param.name.properties[0] instanceof Assign && name !== newName) {
-              propTarget = new Assign(new IdentifierLiteral(name), target, 'object', {
-                operatorToken: new Literal(':', {
-                  param: true
-                })
-              });
-              param.renameParam(node, propTarget);
-            } else {
-              param.renameParam(node, target);
-            }
+            replacement = param.name instanceof Obj && obj instanceof Assign && obj.operatorToken.value === '=' ? new Assign(new IdentifierLiteral(name), target, 'object') : target; //, operatorToken: new Literal ':'
+            param.renameParam(node, replacement);
             return thisAssignments.push(new Assign(node, target));
           }
         });
@@ -4115,11 +4106,11 @@
       }
 
       eachParamName(iterator) {
-        var j, len1, param, ref1, results;
+        var i, j, len1, param, ref1, results;
         ref1 = this.params;
         results = [];
-        for (j = 0, len1 = ref1.length; j < len1; j++) {
-          param = ref1[j];
+        for (i = j = 0, len1 = ref1.length; j < len1; i = ++j) {
+          param = ref1[i];
           results.push(param.eachName(iterator));
         }
         return results;
@@ -4265,9 +4256,9 @@
       // `name` is the name of the parameter and `node` is the AST node corresponding
       // to that name.
       eachName(iterator, name = this.name) {
-        var atParam, j, len1, node, obj, ref1, ref2;
+        var atParam, j, len1, nObj, node, obj, ref1, ref2;
         atParam = (obj) => {
-          return iterator(`@${obj.properties[0].name.value}`, obj, this);
+          return iterator(`@${obj.properties[0].name.value}`, obj, this, nObj);
         };
         if (name instanceof Literal) {
           // * simple literals `foo`
@@ -4280,6 +4271,8 @@
         ref2 = (ref1 = name.objects) != null ? ref1 : [];
         for (j = 0, len1 = ref2.length; j < len1; j++) {
           obj = ref2[j];
+          // Save original obj.
+          nObj = obj;
           // * destructured parameter with default value
           if (obj instanceof Assign && (obj.context == null)) {
             obj = obj.variable;
@@ -4330,7 +4323,15 @@
             if (node.this) {
               key = node.properties[0].name;
             }
-            return new Assign(new Value(key), newNode, 'object');
+            // No need to assign a new variable for the destructured variable if the variable isn't reserved.
+            // Examples:
+            // `({@foo}) ->`  should compile to `({foo}) { this.foo = foo}`
+            // `foo = 1; ({@foo}) ->` should compile to `foo = 1; ({foo:foo1}) { this.foo = foo1 }`
+            if (node.this && key.value === newNode.value) {
+              return new Value(newNode);
+            } else {
+              return new Assign(new Value(key), newNode, 'object');
+            }
           } else {
             return newNode;
           }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2802,7 +2802,7 @@ exports.Code = class Code extends Base
     if @front or (o.level >= LEVEL_ACCESS) then @wrapInParentheses answer else answer
 
   eachParamName: (iterator) ->
-    param.eachName iterator for param, i in @params
+    param.eachName iterator for param in @params
 
   # Short-circuit `traverseChildren` method to prevent it from crossing scope
   # boundaries unless `crossScope` is `true`.

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2903,7 +2903,7 @@ exports.Param = class Param extends Base
   # `name` is the name of the parameter and `node` is the AST node corresponding
   # to that name.
   eachName: (iterator, name = @name) ->
-    atParam = (obj) => iterator "@#{obj.properties[0].name.value}", obj, @, nObj
+    atParam = (obj, originalObj = null) => iterator "@#{obj.properties[0].name.value}", obj, @, originalObj
     # * simple literals `foo`
     return iterator name.value, name, @ if name instanceof Literal
     # * at-params `@foo`
@@ -2932,7 +2932,7 @@ exports.Param = class Param extends Base
           @eachName iterator, obj.base
         # * at-params within destructured parameters `{@foo}`
         else if obj.this
-          atParam obj
+          atParam obj, nObj
         # * simple destructured parameters {foo}
         else iterator obj.base.value, obj.base, @
       else if obj instanceof Elision

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -329,6 +329,15 @@ test "Simple Destructuring function arguments with same-named variables in scope
   eq f([2]), 2
   eq x, 1
 
+test "#4843: Bad output when assigning to @prop in destructuring assignment with defaults", ->
+  works = "maybe"
+  drinks = "beer"
+  class A
+    constructor: ({@works = 'no', @drinks = 'wine'}) ->
+  a = new A {works: 'yes', drinks: 'coffee'}
+  eq a.works, 'yes'
+  eq a.drinks, 'coffee'
+
 test "caching base value", ->
 
   obj =


### PR DESCRIPTION
Fixes #4843.

```coffeescript 
works = "maybe"
drinks = "beer"
class A
  constructor: ({@works = 'no', @drinks = 'wine'}) ->

a = new A {works: 'yes', drinks: 'coffee'}
```
Ouput

```javascript
var A, a, drinks, works;

works = maybe;
drinks = beer;

A = class A {
  constructor({works: works1 = 'no', drinks: drinks1 = 'wine'}) {
    this.works = works1;
    this.drinks = drinks1;
  }

};

a = new A({
  works: 'yes',
  drinks: 'coffee'
});
```