### PR TITLE
Fix #1403: Variables inconsistently masked inside of `do`

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -5288,7 +5288,7 @@
       // comprehensions. Some of the generated code can be shared in common, and
       // some cannot.
       compileNode(o) {
-        var body, bodyFragments, compare, compareDown, declare, declareDown, defPart, defPartFragments, down, forPartFragments, fragments, guardPart, idt1, increment, index, ivar, kvar, kvarAssign, last, lvar, name, namePart, ref, ref1, resultPart, returnResult, rvar, scope, source, step, stepNum, stepVar, svar, varPart;
+        var body, bodyFragments, compare, compareDown, declare, declareDown, defPart, down, forPartFragments, fragments, guardPart, idt1, increment, index, ivar, kvar, kvarAssign, last, lvar, name, namePart, ref, ref1, resultPart, returnResult, rvar, scope, source, step, stepNum, stepVar, svar, varPart;
         body = Block.wrap([this.body]);
         ref1 = body.expressions, last = ref1[ref1.length - 1];
         if ((last != null ? last.jumps() : void 0) instanceof Return) {
@@ -5397,7 +5397,6 @@
         if (this.pattern) {
           body.expressions.unshift(new Assign(this.name, this.from ? new IdentifierLiteral(kvar) : new Literal(`${svar}[${kvar}]`)));
         }
-        defPartFragments = [].concat(this.makeCode(defPart), this.pluckDirectCall(o, body));
         if (namePart) {
           varPart = `\n${idt1}${namePart};`;
         }
@@ -5415,10 +5414,7 @@
         if (bodyFragments && bodyFragments.length > 0) {
           bodyFragments = [].concat(this.makeCode('\n'), bodyFragments, this.makeCode('\n'));
         }
-        fragments = [];
-        if ((defPartFragments != null) && fragmentsToText(defPartFragments) !== '') {
-          fragments = fragments.concat(defPartFragments);
-        }
+        fragments = [this.makeCode(defPart)];
         if (resultPart) {
           fragments.push(this.makeCode(resultPart));
         }
@@ -5427,32 +5423,6 @@
           fragments.push(this.makeCode(returnResult));
         }
         return fragments;
-      }
-
-      pluckDirectCall(o, body) {
-        var base, defs, expr, fn, idx, j, len1, ref, ref1, ref2, ref3, ref4, ref5, ref6, val;
-        defs = [];
-        ref1 = body.expressions;
-        for (idx = j = 0, len1 = ref1.length; j < len1; idx = ++j) {
-          expr = ref1[idx];
-          expr = expr.unwrapAll();
-          if (!(expr instanceof Call)) {
-            continue;
-          }
-          val = (ref2 = expr.variable) != null ? ref2.unwrapAll() : void 0;
-          if (!((val instanceof Code) || (val instanceof Value && ((ref3 = val.base) != null ? ref3.unwrapAll() : void 0) instanceof Code && val.properties.length === 1 && ((ref4 = (ref5 = val.properties[0].name) != null ? ref5.value : void 0) === 'call' || ref4 === 'apply')))) {
-            continue;
-          }
-          fn = ((ref6 = val.base) != null ? ref6.unwrapAll() : void 0) || val;
-          ref = new IdentifierLiteral(o.scope.freeVariable('fn'));
-          base = new Value(ref);
-          if (val.base) {
-            [val.base, base] = [base, val];
-          }
-          body.expressions[idx] = new Call(base, expr.args);
-          defs = defs.concat(this.makeCode(this.tab), new Assign(ref, fn).compileToFragments(o, LEVEL_TOP), this.makeCode(';\n'));
-        }
-        return defs;
       }
 
     };

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3647,7 +3647,7 @@ exports.For = class For extends While
         body = Block.wrap [new If @guard, body] if @guard
     if @pattern
       body.expressions.unshift new Assign @name, if @from then new IdentifierLiteral kvar else new Literal "#{svar}[#{kvar}]"
-    defPartFragments = [].concat @makeCode(defPart), @pluckDirectCall(o, body)
+
     varPart = "\n#{idt1}#{namePart};" if namePart
     if @object
       forPartFragments = [@makeCode("#{kvar} in #{svar}")]
@@ -3658,35 +3658,13 @@ exports.For = class For extends While
     if bodyFragments and bodyFragments.length > 0
       bodyFragments = [].concat @makeCode('\n'), bodyFragments, @makeCode('\n')
 
-    fragments = []
-    if defPartFragments? and fragmentsToText(defPartFragments) isnt ''
-      fragments = fragments.concat defPartFragments
+    fragments = [@makeCode(defPart)]
     fragments.push @makeCode(resultPart) if resultPart
     fragments = fragments.concat @makeCode(@tab), @makeCode( 'for ('),
       forPartFragments, @makeCode(") {#{guardPart}#{varPart}"), bodyFragments,
       @makeCode(@tab), @makeCode('}')
     fragments.push @makeCode(returnResult) if returnResult
     fragments
-
-  pluckDirectCall: (o, body) ->
-    defs = []
-    for expr, idx in body.expressions
-      expr = expr.unwrapAll()
-      continue unless expr instanceof Call
-      val = expr.variable?.unwrapAll()
-      continue unless (val instanceof Code) or
-                      (val instanceof Value and
-                      val.base?.unwrapAll() instanceof Code and
-                      val.properties.length is 1 and
-                      val.properties[0].name?.value in ['call', 'apply'])
-      fn    = val.base?.unwrapAll() or val
-      ref   = new IdentifierLiteral o.scope.freeVariable 'fn'
-      base  = new Value ref
-      if val.base
-        [val.base, base] = [base, val]
-      body.expressions[idx] = new Call base, expr.args
-      defs = defs.concat @makeCode(@tab), (new Assign(ref, fn).compileToFragments(o, LEVEL_TOP)), @makeCode(';\n')
-    defs
 
 #### Switch
 


### PR DESCRIPTION
Fixes #1403.
It seems that `For::pluckDirectCall` isn't needed.

Examples from #1403 
```coffeescript
for dummy in [0...1]
  masked = 10
  do -> alert masked = masked + 1
alert 'a line needs to be here to trigger the issue'
```
```javascript
for (dummy = i = 0; i < 1; dummy = ++i) {
  masked = 10;
  (function() {
    return alert(masked = masked + 1);
  })();
}
alert('a line needs to be here to trigger the issue');
```
---
```coffeescript
for dummy in [0...1]
  notMasked = 10
  do -> alert notMasked += 1
alert 'a line needs to be here to trigger the issue'
```
```javascript
for (dummy = j = 0; j < 1; dummy = ++j) {
  notMasked = 10;
  (function() {
    return alert(notMasked += 1);
  })();
}
alert('a line needs to be here to trigger the issue');
```