### PR TITLE
Fix #3306: trailing comma in a function call in the last line throws a syntax error

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -510,7 +510,7 @@
             while (inImplicit()) {
               [stackTag, stackIdx, {sameLine, startsLine}] = stackTop();
               // Close implicit calls when reached end of argument list
-              if (inImplicitCall() && prevTag !== ',') {
+              if (inImplicitCall() && prevTag !== ',' || (prevTag === ',' && tag === 'TERMINATOR' && (nextTag == null))) {
                 endImplicitCall();
               // Close implicit objects such as:
               // return a: 1, b: 2 unless true

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -347,7 +347,8 @@ exports.Rewriter = class Rewriter
         while inImplicit()
           [stackTag, stackIdx, {sameLine, startsLine}] = stackTop()
           # Close implicit calls when reached end of argument list
-          if inImplicitCall() and prevTag isnt ','
+          if inImplicitCall() and prevTag isnt ',' or
+              (prevTag is ',' and tag is 'TERMINATOR' and not nextTag?)
             endImplicitCall()
           # Close implicit objects such as:
           # return a: 1, b: 2 unless true

--- a/test/compilation.coffee
+++ b/test/compilation.coffee
@@ -170,3 +170,10 @@ test "using transpile from the Node API requires an object", ->
 test "transpile option applies to imported .coffee files", ->
   return if global.testingBrowser
   doesNotThrow -> transpile 'run', "import { getSep } from './test/importing/transpile_import'\ngetSep()"
+
+test "#3306: trailing comma in a function call in the last line", ->
+  eqJS '''
+  foo bar,
+  ''', '''
+  foo(bar);
+  '''


### PR DESCRIPTION
Fixes #3306.
Trailing comma in a function call in the last line throws syntax error because the implicit call isn't closed in `Rewriter::addImplicitBracesAndParens`.

```coffeescript
foo bar,
```