### PR TITLE
Fix #4437: variable scope in chained calls

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1441,7 +1441,17 @@
         var fragments, j, len1, prop, props;
         this.base.front = this.front;
         props = this.properties;
-        fragments = this.base.compileToFragments(o, (props.length ? LEVEL_ACCESS : null));
+        if (props.length && (this.base.cached != null)) {
+          // Cached fragments enable correct order of the compilation,
+          // and reuse of variables in the scope.
+          // Example:
+          // `a(x = 5).b(-> x = 6)` should compile in the same order as
+          // `a(x = 5); b(-> x = 6)`
+          // (see issue #4437, https://github.com/jashkenas/coffeescript/issues/4437)
+          fragments = this.base.cached;
+        } else {
+          fragments = this.base.compileToFragments(o, (props.length ? LEVEL_ACCESS : null));
+        }
         if (props.length && SIMPLENUM.test(fragmentsToText(fragments))) {
           fragments.push(this.makeCode('.'));
         }
@@ -1690,7 +1700,7 @@
 
       // Compile a vanilla function call.
       compileNode(o) {
-        var arg, argIndex, compiledArgs, fragments, j, len1, ref1, ref2;
+        var arg, argCode, argIndex, cache, compiledArgs, fragments, j, len1, ref1, ref2, ref3, ref4, varAccess;
         if (this.csx) {
           return this.compileCSX(o);
         }
@@ -1698,9 +1708,35 @@
           ref1.front = this.front;
         }
         compiledArgs = [];
-        ref2 = this.args;
-        for (argIndex = j = 0, len1 = ref2.length; j < len1; argIndex = ++j) {
-          arg = ref2[argIndex];
+        // If variable is `Accessor` fragments are cached and used later
+        // in `Value::compileNode` to ensure correct order of the compilation,
+        // and reuse of variables in the scope.
+        // Example:
+        // `a(x = 5).b(-> x = 6)` should compile in the same order as
+        // `a(x = 5); b(-> x = 6)`
+        // (see issue #4437, https://github.com/jashkenas/coffeescript/issues/4437)
+        varAccess = ((ref2 = this.variable) != null ? (ref3 = ref2.properties) != null ? ref3[0] : void 0 : void 0) instanceof Access;
+        argCode = (function() {
+          var j, len1, ref4, results;
+          ref4 = this.args || [];
+          results = [];
+          for (j = 0, len1 = ref4.length; j < len1; j++) {
+            arg = ref4[j];
+            if (arg instanceof Code) {
+              results.push(arg);
+            }
+          }
+          return results;
+        }).call(this);
+        if (argCode.length > 0 && varAccess && !this.variable.base.cached) {
+          [cache] = this.variable.base.cache(o, LEVEL_ACCESS, function() {
+            return false;
+          });
+          this.variable.base.cached = cache;
+        }
+        ref4 = this.args;
+        for (argIndex = j = 0, len1 = ref4.length; j < len1; argIndex = ++j) {
+          arg = ref4[argIndex];
           if (argIndex) {
             compiledArgs.push(this.makeCode(", "));
           }

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -862,23 +862,23 @@ test "#4836: functions named get or set can be used without parentheses when att
   eq 7, @set @a
 
 test "#4473: variable scope in chained calls", ->
-  A = class A
-    foo: (a) ->
+  obj =
+    foo: -> this
+    bar: (a) ->
       a()
       this
-    bar: (a) -> this
 
-  a = (a) -> new A
-  b = (b) ->
-    b()
-    new A
-  c = (c) -> new A
+  obj.foo(a = 1).bar(-> a = 2)
+  eq a, 2
 
-  a(x = 1).foo( -> x = 2)
-  eq x, 2
+  obj.bar(-> b = 2).foo(b = 1)
+  eq b, 1
 
-  b(-> y = 2).bar(y = 1)
-  eq y, 1
+  obj.foo(c = 1).bar(-> c = 2).foo(c = 3)
+  eq c, 3
 
-  c(z = 1).foo(-> z = 2).bar(z = 3)
-  eq z, 3
+  obj.foo([d, e] = [1, 2]).bar(-> d = 4)
+  eq d, 4
+
+  obj.foo({f} = {f: 1}).bar(-> f = 5)
+  eq f, 5

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -860,3 +860,25 @@ test "#4836: functions named get or set can be used without parentheses when att
   eq 13, @set 10
   eq 6, @get @a
   eq 7, @set @a
+
+test "#4473: variable scope in chained calls", ->
+  A = class A
+    foo: (a) ->
+      a()
+      this
+    bar: (a) -> this
+
+  a = (a) -> new A
+  b = (b) ->
+    b()
+    new A
+  c = (c) -> new A
+
+  a(x = 1).foo( -> x = 2)
+  eq x, 2
+
+  b(-> y = 2).bar(y = 1)
+  eq y, 1
+
+  c(z = 1).foo(-> z = 2).bar(z = 3)
+  eq z, 3


### PR DESCRIPTION
Fixes #4437.

```coffeescript
foo(x = 3).bar(-> x = 4)
```
```js
var x;
foo(x = 3).bar(function() {
  return x = 4;
});
```
___
```coffeescript
foo(-> x = 3).bar(x = 4)
```
```js
var x;
foo(function() {
  return x = 3;
}).bar(x = 4);
```