### PR TITLE
Fix #4868: Incorrect ‘Can’t call super with @params’ error

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4265,29 +4265,19 @@
       // Find all super calls in the given context node;
       // returns `true` if `iterator` is called.
       eachSuperCall(context, iterator) {
-        var childArgs, seenSuper;
+        var seenSuper;
         seenSuper = false;
-        childArgs = function(args) {
-          var arg, cArgs, j, len1;
-          cArgs = [];
-          for (j = 0, len1 = args.length; j < len1; j++) {
-            arg = args[j];
-            if (arg instanceof Class || arg instanceof Code) {
-              continue;
-            }
-            cArgs.push(arg);
-          }
-          return cArgs;
-        };
         context.traverseChildren(true, (child) => {
-          var cArgs;
+          var childArgs;
           if (child instanceof SuperCall) {
             // `super` in a constructor (the only `super` without an accessor)
             // cannot be given an argument with a reference to `this`, as that would
             // be referencing `this` before calling `super`.
             if (!child.variable.accessor) {
-              cArgs = childArgs(child.args);
-              Block.wrap(cArgs).traverseChildren(true, (node) => {
+              childArgs = child.args.filter(function(arg) {
+                return !(arg instanceof Class) && (!(arg instanceof Code) || arg.bound);
+              });
+              Block.wrap(childArgs).traverseChildren(true, (node) => {
                 if (node.this) {
                   return node.error("Can't call super with @params in derived class constructors");
                 }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -163,15 +163,17 @@
           return node instanceof SuperCall;
         }))) {
           func.bound = true;
-        } else if ((argumentsNode = this.contains(isLiteralArguments)) || this.contains(isLiteralThis)) {
-          args = [new ThisLiteral];
-          if (argumentsNode) {
-            meth = 'apply';
-            args.push(new IdentifierLiteral('arguments'));
-          } else {
-            meth = 'call';
+        } else {
+          if ((argumentsNode = this.contains(isLiteralArguments)) || this.contains(isLiteralThis)) {
+            args = [new ThisLiteral];
+            if (argumentsNode) {
+              meth = 'apply';
+              args.push(new IdentifierLiteral('arguments'));
+            } else {
+              meth = 'call';
+            }
+            func = new Value(func, [new Access(new PropertyName(meth))]);
           }
-          func = new Value(func, [new Access(new PropertyName(meth))]);
         }
         parts = (new Call(func, args)).compileNode(o);
         switch (false) {
@@ -414,12 +416,14 @@
                   }
                 }
               }
-            } else if (match(children)) {
-              this[attr] = replacement(children, this);
-              return true;
             } else {
-              if (children.replaceInContext(match, replacement)) {
+              if (match(children)) {
+                this[attr] = replacement(children, this);
                 return true;
+              } else {
+                if (children.replaceInContext(match, replacement)) {
+                  return true;
+                }
               }
             }
           }
@@ -716,19 +720,21 @@
             // enclose it in a new scope; we just compile the statements in this
             // block along with our own.
             compiledNodes.push(node.compileNode(o));
-          } else if (top) {
-            node.front = true;
-            fragments = node.compileToFragments(o);
-            if (!node.isStatement(o)) {
-              fragments = indentInitial(fragments, this);
-              [lastFragment] = slice1.call(fragments, -1);
-              if (!(lastFragment.code === '' || lastFragment.isComment)) {
-                fragments.push(this.makeCode(';'));
-              }
-            }
-            compiledNodes.push(fragments);
           } else {
-            compiledNodes.push(node.compileToFragments(o, LEVEL_LIST));
+            if (top) {
+              node.front = true;
+              fragments = node.compileToFragments(o);
+              if (!node.isStatement(o)) {
+                fragments = indentInitial(fragments, this);
+                [lastFragment] = slice1.call(fragments, -1);
+                if (!(lastFragment.code === '' || lastFragment.isComment)) {
+                  fragments.push(this.makeCode(';'));
+                }
+              }
+              compiledNodes.push(fragments);
+            } else {
+              compiledNodes.push(node.compileToFragments(o, LEVEL_LIST));
+            }
           }
         }
         if (top) {
@@ -828,8 +834,10 @@
               fragments.push(this.makeCode(scope.assignedVariables().join(`,\n${this.tab + TAB}`)));
             }
             fragments.push(this.makeCode(`;\n${(this.spaced ? '\n' : '')}`));
-          } else if (fragments.length && post.length) {
-            fragments.push(this.makeCode("\n"));
+          } else {
+            if (fragments.length && post.length) {
+              fragments.push(this.makeCode("\n"));
+            }
           }
         }
         return fragments.concat(post);
@@ -856,8 +864,10 @@
               if (indent) {
                 fragmentIndent = indent[0];
                 break;
-              } else if (indexOf.call(pastFragment.code, '\n') >= 0) {
-                break;
+              } else {
+                if (indexOf.call(pastFragment.code, '\n') >= 0) {
+                  break;
+                }
               }
             }
             code = `\n${fragmentIndent}` + ((function() {
@@ -886,11 +896,13 @@
                 if (pastFragmentIndex === 0) {
                   pastFragment.code = '\n' + pastFragment.code;
                   newLineIndex = 0;
-                } else if (pastFragment.isStringWithInterpolations && pastFragment.code === '{') {
-                  code = code.slice(1) + '\n'; // Move newline to end.
-                  newLineIndex = 1;
                 } else {
-                  continue;
+                  if (pastFragment.isStringWithInterpolations && pastFragment.code === '{') {
+                    code = code.slice(1) + '\n'; // Move newline to end.
+                    newLineIndex = 1;
+                  } else {
+                    continue;
+                  }
                 }
               }
               delete fragment.precedingComments;
@@ -926,8 +938,10 @@
                   if (indent) {
                     fragmentIndent = indent[0];
                     break;
-                  } else if (indexOf.call(upcomingFragment.code, '\n') >= 0) {
-                    break;
+                  } else {
+                    if (indexOf.call(upcomingFragment.code, '\n') >= 0) {
+                      break;
+                    }
                   }
                 }
               }
@@ -962,11 +976,13 @@
                 if (upcomingFragmentIndex === fragments.length - 1) {
                   upcomingFragment.code = upcomingFragment.code + '\n';
                   newLineIndex = upcomingFragment.code.length;
-                } else if (upcomingFragment.isStringWithInterpolations && upcomingFragment.code === '}') {
-                  code = `${code}\n`;
-                  newLineIndex = 0;
                 } else {
-                  continue;
+                  if (upcomingFragment.isStringWithInterpolations && upcomingFragment.code === '}') {
+                    code = `${code}\n`;
+                    newLineIndex = 0;
+                  } else {
+                    continue;
+                  }
                 }
               }
               delete fragment.followingComments;
@@ -1206,10 +1222,12 @@
             fragment = answer[j];
             if (fragment.isHereComment && indexOf.call(fragment.code, '\n') >= 0) {
               fragment.code = multident(fragment.code, this.tab);
-            } else if (fragment.isLineComment) {
-              fragment.code = `${this.tab}${fragment.code}`;
             } else {
-              break;
+              if (fragment.isLineComment) {
+                fragment.code = `${this.tab}${fragment.code}`;
+              } else {
+                break;
+              }
             }
           }
         } else {
@@ -1486,10 +1504,12 @@
       eachName(iterator) {
         if (this.hasProperties()) {
           return iterator(this);
-        } else if (this.base.isAssignable()) {
-          return this.base.eachName(iterator);
         } else {
-          return this.error('tried to assign to unassignable value');
+          if (this.base.isAssignable()) {
+            return this.base.eachName(iterator);
+          } else {
+            return this.error('tried to assign to unassignable value');
+          }
         }
       }
 
@@ -4245,15 +4265,29 @@
       // Find all super calls in the given context node;
       // returns `true` if `iterator` is called.
       eachSuperCall(context, iterator) {
-        var seenSuper;
+        var childArgs, seenSuper;
         seenSuper = false;
+        childArgs = function(args) {
+          var arg, cArgs, j, len1;
+          cArgs = [];
+          for (j = 0, len1 = args.length; j < len1; j++) {
+            arg = args[j];
+            if (arg instanceof Class || arg instanceof Code) {
+              continue;
+            }
+            cArgs.push(arg);
+          }
+          return cArgs;
+        };
         context.traverseChildren(true, (child) => {
+          var cArgs;
           if (child instanceof SuperCall) {
             // `super` in a constructor (the only `super` without an accessor)
             // cannot be given an argument with a reference to `this`, as that would
             // be referencing `this` before calling `super`.
             if (!child.variable.accessor) {
-              Block.wrap(child.args).traverseChildren(true, (node) => {
+              cArgs = childArgs(child.args);
+              Block.wrap(cArgs).traverseChildren(true, (node) => {
                 if (node.this) {
                   return node.error("Can't call super with @params in derived class constructors");
                 }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2856,13 +2856,21 @@ exports.Code = class Code extends Base
   eachSuperCall: (context, iterator) ->
     seenSuper = no
 
+    childArgs = (args) ->
+      cArgs = []
+      for arg in args
+        continue if arg instanceof Class or arg instanceof Code
+        cArgs.push arg
+      cArgs
+
     context.traverseChildren yes, (child) =>
       if child instanceof SuperCall
         # `super` in a constructor (the only `super` without an accessor)
         # cannot be given an argument with a reference to `this`, as that would
         # be referencing `this` before calling `super`.
         unless child.variable.accessor
-          Block.wrap(child.args).traverseChildren yes, (node) =>
+          cArgs = childArgs child.args
+          Block.wrap(cArgs).traverseChildren yes, (node) =>
             node.error "Can't call super with @params in derived class constructors" if node.this
         seenSuper = yes
         iterator child

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2856,21 +2856,15 @@ exports.Code = class Code extends Base
   eachSuperCall: (context, iterator) ->
     seenSuper = no
 
-    childArgs = (args) ->
-      cArgs = []
-      for arg in args
-        continue if arg instanceof Class or arg instanceof Code
-        cArgs.push arg
-      cArgs
-
     context.traverseChildren yes, (child) =>
       if child instanceof SuperCall
         # `super` in a constructor (the only `super` without an accessor)
         # cannot be given an argument with a reference to `this`, as that would
         # be referencing `this` before calling `super`.
         unless child.variable.accessor
-          cArgs = childArgs child.args
-          Block.wrap(cArgs).traverseChildren yes, (node) =>
+          childArgs = child.args.filter (arg) ->
+            arg not instanceof Class and (arg not instanceof Code or arg.bound)
+          Block.wrap(childArgs).traverseChildren yes, (node) =>
             node.error "Can't call super with @params in derived class constructors" if node.this
         seenSuper = yes
         iterator child

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -1874,3 +1874,28 @@ test "#4827: executable class body wrappers have correct context", ->
   o = {}
   test.call o
   ok typeof o.A is typeof o.B is 'function'
+
+test "#4868: Incorrect ‘Can’t call super with @params’ error", ->
+  class A
+    constructor: (@func = ->) ->
+      @x = 1
+      @func()
+
+  class B extends A
+    constructor: ->
+      super -> @x = 2
+
+  a = new A
+  b = new B
+  eq 1, a.x
+  eq 2, b.x
+
+  class C
+    constructor: (@c = class) -> @c
+
+  class D extends C
+    constructor: ->
+      super class then constructor: (@a) -> @a = 3
+
+  d = new (new D).c
+  eq 3, d.a


### PR DESCRIPTION
Fixes #4868. 
The function body, passed as a parameter, to `super` is excluded from the arguments check in the `Code::eachSuperCall`. 

```coffeescript
class B extends A
  constructor: -> super -> @x

###
B = class B extends A {
  constructor() {
    super(function() {
      return this.x;
    });
  }
};
###

class extends A then constructor: (@a) -> super(class then constructor: (@b) -> @b)

###
(class extends A {
  constructor(a) {
    super(class {
      constructor(b) {
        this.b = b;
        this.b;
      }

    });
    this.a = a;
  }
});
###
```