### PR TITLE
Fix #4871: `else if` no longer output together

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -881,7 +881,7 @@
             tokens.splice(i + 1, 0, indent, outdent);
             return 1;
           }
-          if (indexOf.call(SINGLE_LINERS, tag) >= 0 && this.tag(i + 1) !== 'INDENT' && !(tag === 'ELSE' && this.tag(i + 1) === 'IF' && ifThens.length > 1) && !conditionTag) {
+          if (indexOf.call(SINGLE_LINERS, tag) >= 0 && this.tag(i + 1) !== 'INDENT' && !(tag === 'ELSE' && this.tag(i + 1) === 'IF') && !conditionTag) {
             starter = tag;
             [indent, outdent] = this.indentation(tokens[i]);
             if (starter === 'THEN') {

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -621,7 +621,7 @@ exports.Rewriter = class Rewriter
         tokens.splice i + 1, 0, indent, outdent
         return 1
       if tag in SINGLE_LINERS and @tag(i + 1) isnt 'INDENT' and
-         not (tag is 'ELSE' and @tag(i + 1) is 'IF' and ifThens.length > 1) and
+         not (tag is 'ELSE' and @tag(i + 1) is 'IF') and
          not conditionTag
         starter = tag
         [indent, outdent] = @indentation tokens[i]

--- a/test/control_flow.coffee
+++ b/test/control_flow.coffee
@@ -1257,3 +1257,33 @@ test "#3909: backslash `for ... in`", ->
   x8 = ( key for key \
     in arr )
   arrayEq x8, arr
+
+test "#4871: `else if` no longer output together ", ->
+   eqJS '''
+   if a then b else if c then d else if e then f else g
+   ''',
+   '''
+   if (a) {
+     b;
+   } else if (c) {
+     d;
+   } else if (e) {
+     f;
+   } else {
+     g;
+   }
+   '''
+
+   eqJS '''
+   if no
+     1
+   else if yes
+     2
+   ''',
+   '''
+   if (false) {
+     1;
+   } else if (true) {
+     2;
+   }
+   '''


### PR DESCRIPTION
Fixes #4871.

```coffeescript
if no
  1
else if yes
  2
```

```javascript
if (false) {
  1;
} else if (true) {
  2;
}
```