### PR TITLE
Fix #4874: Backslash not supported in import or export statements

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -593,14 +593,15 @@
       }
       indent = match[0];
       prev = this.prev();
-      backslash = (prev != null) && prev[0] === '\\';
+      backslash = (prev != null ? prev[0] : void 0) === '\\';
       if (!(backslash && this.seenFor)) {
+        // console.log backslash, @seenExport
         this.seenFor = false;
       }
-      if (!this.importSpecifierList) {
+      if (!((backslash && this.seenImport) || this.importSpecifierList)) {
         this.seenImport = false;
       }
-      if (!this.exportSpecifierList) {
+      if (!((backslash && this.seenExport) || this.exportSpecifierList)) {
         this.seenExport = false;
       }
       size = indent.length - 1 - indent.lastIndexOf('\n');

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -454,10 +454,10 @@ exports.Lexer = class Lexer
     indent = match[0]
 
     prev = @prev()
-    backslash = prev? and prev[0] is '\\'
+    backslash = prev?[0] is '\\'
     @seenFor = no unless backslash and @seenFor
-    @seenImport = no unless @importSpecifierList
-    @seenExport = no unless @exportSpecifierList
+    @seenImport = no unless (backslash and @seenImport) or @importSpecifierList
+    @seenExport = no unless (backslash and @seenExport) or @exportSpecifierList
 
     size = indent.length - 1 - indent.lastIndexOf '\n'
     noNewlines = @unfinished()

--- a/test/modules.coffee
+++ b/test/modules.coffee
@@ -853,3 +853,70 @@ test "#4491: import- and export-specific lexing should stop after import/export 
 
     from('foo');
     """
+
+# Issue #4874: Backslash not supported in import or export statements
+test "#4874: backslash `import`", ->
+
+  eqJS """
+    import foo \
+        from 'lib'
+
+    foo a
+    """,
+  """
+    import foo from 'lib';
+
+    foo(a);
+    """
+
+  eqJS """
+    import \
+                    foo \
+        from \
+    'lib'
+
+    foo a
+    """,
+  """
+    import foo from 'lib';
+
+    foo(a);
+    """
+
+  eqJS """
+    import \
+          utilityBelt \
+    , {
+      each
+    } from \
+    'underscore'
+    """,
+  """
+    import utilityBelt, {
+      each
+    } from 'underscore';
+    """
+
+test "#4874: backslash `export`", ->
+  eqJS """
+    export \
+      * \
+            from \
+      'underscore'
+    """,
+  """
+    export * from 'underscore';
+    """
+
+  eqJS """
+    export \
+        { max, min } \
+              from \
+      'underscore'
+  """,
+  """
+    export {
+      max,
+      min
+    } from 'underscore';
+    """


### PR DESCRIPTION
FIxes #4874.

```coffeescript
import foo \
    from 'lib'
```
___
```coffeescript
import \
                foo \
    from \
'lib'
```
___
```coffeescript
import \
      utilityBelt \
, {
  each
} from \
'underscore'
```
___
```coffeescript
export \
  * \
        from \
  'underscore'
```
___
```coffeescript
export \
    { max, min } \
          from \
  'underscore'
```