### PR TITLE
Fix #4898: Lexer: backslash line continuation is inconsistent

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -595,7 +595,6 @@
       prev = this.prev();
       backslash = (prev != null ? prev[0] : void 0) === '\\';
       if (!(backslash && this.seenFor)) {
-        // console.log backslash, @seenExport
         this.seenFor = false;
       }
       if (!((backslash && this.seenImport) || this.importSpecifierList)) {
@@ -630,7 +629,9 @@
       }
       if (size > this.indent) {
         if (noNewlines) {
-          this.indebt = size - this.indent;
+          if (!backslash) {
+            this.indebt = size - this.indent;
+          }
           this.suppressNewlines();
           return indent.length;
         }

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -478,7 +478,7 @@ exports.Lexer = class Lexer
 
     if size > @indent
       if noNewlines
-        @indebt = size - @indent
+        @indebt = size - @indent unless backslash
         @suppressNewlines()
         return indent.length
       unless @tokens.length

--- a/test/control_flow.coffee
+++ b/test/control_flow.coffee
@@ -1287,3 +1287,56 @@ test "#4871: `else if` no longer output together ", ->
      2;
    }
    '''
+
+test "#4898: Lexer: backslash line continuation is inconsistent", ->
+  if ( \
+      false \
+      or \
+      true \
+    )
+    a = 42
+
+  eq a, 42
+
+  if ( \
+      false \
+      or \
+      true \
+  )
+    b = 42
+
+  eq b, 42
+
+  if ( \
+            false \
+         or \
+   true \
+  )
+    c = 42
+
+  eq c, 42
+
+  if \
+   false \
+        or \
+   true
+    d = 42
+
+  eq d, 42
+
+  if \
+              false or \
+  true
+    e = 42
+
+  eq e, 42
+
+  if \
+       false or \
+    true \
+       then \
+   f = 42 \
+   else
+     f = 24
+
+  eq f, 42


### PR DESCRIPTION
Fixes #4898. When indent line is ended with the backslash, `Lexer` incorrectly sets indentation levels.

```coffeescript
if ( \
      false \
      or \
      true \
    )
    42

###
if (false || true) {
  42;
}
###
```
---

```coffeescript
if ( \
    false \
    or \
    true \
)
  42

###
if (false || true) {
  42;
}
###
```