### PR TITLE
Fixes 'get' and 'set' keyword example in docs

### DIFF
--- a/documentation/examples/get_set.coffee
+++ b/documentation/examples/get_set.coffee
@@ -6,4 +6,4 @@ Object.defineProperty screen, 'height',
   get: ->
     this.width / this.ratio
   set: (val) ->
-    this.width = val / this.ratio
+    this.width = val * this.ratio


### PR DESCRIPTION
Fixes error in the example for `get` and `set` keyword syntax in docs.

```coffeescript
screen =
  width: 1200
  ratio: 16/9

Object.defineProperty screen, 'height',
  get: ->
    this.width / this.ratio
  set: (val) ->
    this.width = val * this.ratio

# this.height = 675

this.height = 900

# this.width = 1600
```