### PR TITLE
Fix: destructuring assignment with an empty array in object

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2179,7 +2179,7 @@
       }
 
       isAssignable() {
-        var j, len1, message, prop, ref1;
+        var j, len1, message, prop, ref1, ref2;
         ref1 = this.properties;
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           prop = ref1[j];
@@ -2188,7 +2188,7 @@
           if (message) {
             prop.error(message);
           }
-          if (prop instanceof Assign && prop.context === 'object') {
+          if (prop instanceof Assign && prop.context === 'object' && !(((ref2 = prop.value) != null ? ref2.base : void 0) instanceof Arr)) {
             prop = prop.value;
           }
           if (!prop.isAssignable()) {
@@ -3292,7 +3292,7 @@
       // we've been assigned to, for correct internal references. If the variable
       // has not been seen yet within the current scope, declare it.
       compileNode(o) {
-        var answer, compiledName, hasArrayProp, hasSplat, isValue, name, objDestructAnswer, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
+        var answer, compiledName, hasSplat, isValue, name, objDestructAnswer, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
         isValue = this.variable instanceof Value;
         if (isValue) {
           // When compiling `@variable`, remember if it is part of a function parameter.
@@ -3310,13 +3310,7 @@
             hasSplat = this.variable.contains(function(node) {
               return node instanceof Obj && node.hasSplat();
             });
-            // Check if `@variable` containes an empty array as a property, e.g. `{a:[]} = b`.
-            // An empty array is not assignable and would invoke `@compileDestructuring` method,
-            // which is not needed since this is valid ES syntax and can be compiled directly.
-            hasArrayProp = this.variable.contains(function(node) {
-              return node instanceof Assign && node.context === 'object' && node.value.base instanceof Arr;
-            });
-            if ((!this.variable.isAssignable() || this.variable.isArray() && hasSplat) && !hasArrayProp) {
+            if (!this.variable.isAssignable() || this.variable.isArray() && hasSplat) {
               return this.compileDestructuring(o);
             }
             if (this.variable.isObject() && hasSplat) {
@@ -3339,7 +3333,7 @@
         }
         if (!this.context) {
           varBase = this.variable.unwrapAll();
-          if (!(varBase.isAssignable() || hasArrayProp)) {
+          if (!varBase.isAssignable()) {
             this.variable.error(`'${this.variable.compile(o)}' can't be assigned`);
           }
           varBase.eachName((name) => {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3292,7 +3292,7 @@
       // we've been assigned to, for correct internal references. If the variable
       // has not been seen yet within the current scope, declare it.
       compileNode(o) {
-        var answer, compiledName, hasSplat, isValue, name, objDestructAnswer, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
+        var answer, compiledName, hasArrayProp, hasSplat, isValue, name, objDestructAnswer, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
         isValue = this.variable instanceof Value;
         if (isValue) {
           // When compiling `@variable`, remember if it is part of a function parameter.
@@ -3310,7 +3310,13 @@
             hasSplat = this.variable.contains(function(node) {
               return node instanceof Obj && node.hasSplat();
             });
-            if (!this.variable.isAssignable() || this.variable.isArray() && hasSplat) {
+            // Check if `@variable` containes an empty array as a property, e.g. `{a:[]} = b`.
+            // An empty array is not assignable and would invoke `@compileDestructuring` method,
+            // which is not needed since this is valid ES syntax and can be compiled directly.
+            hasArrayProp = this.variable.contains(function(node) {
+              return node instanceof Assign && node.context === 'object' && node.value.base instanceof Arr;
+            });
+            if ((!this.variable.isAssignable() || this.variable.isArray() && hasSplat) && !hasArrayProp) {
               return this.compileDestructuring(o);
             }
             if (this.variable.isObject() && hasSplat) {
@@ -3333,7 +3339,7 @@
         }
         if (!this.context) {
           varBase = this.variable.unwrapAll();
-          if (!varBase.isAssignable()) {
+          if (!(varBase.isAssignable() || hasArrayProp)) {
             this.variable.error(`'${this.variable.compile(o)}' can't be assigned`);
           }
           varBase.eachName((name) => {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2215,7 +2215,13 @@ exports.Assign = class Assign extends Base
         @variable.base.lhs = yes
         # Check if @variable contains Obj with splats.
         hasSplat = @variable.contains (node) -> node instanceof Obj and node.hasSplat()
-        return @compileDestructuring o if not @variable.isAssignable() or @variable.isArray() and hasSplat
+        # Check if `@variable` containes an empty array as a property, e.g. `{a:[]} = b`.
+        # An empty array is not assignable and would invoke `@compileDestructuring` method,
+        # which is not needed since this is valid ES syntax and can be compiled directly.
+        hasArrayProp = @variable.contains (node) ->
+            node instanceof Assign and node.context is 'object' and node.value.base instanceof Arr
+        if (not @variable.isAssignable() or @variable.isArray() and hasSplat) and not hasArrayProp
+          return @compileDestructuring o
         # Object destructuring. Can be removed once ES proposal hits Stage 4.
         objDestructAnswer = @compileObjectDestruct(o) if @variable.isObject() and hasSplat
         return objDestructAnswer if objDestructAnswer
@@ -2226,7 +2232,7 @@ exports.Assign = class Assign extends Base
 
     unless @context
       varBase = @variable.unwrapAll()
-      unless varBase.isAssignable()
+      unless varBase.isAssignable() or hasArrayProp
         @variable.error "'#{@variable.compile o}' can't be assigned"
 
       varBase.eachName (name) =>

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -985,3 +985,21 @@ test "#4878: Compile error when using destructuring with a splat or expansion in
         []
 
   arrayEq bar(arr), ['a', ['b', 'c', 'd']]
+
+test "destructuring assignment with an empty array in object", ->
+  obj =
+    a1: [1, 2]
+    b1: 3
+
+  {a1:[], b1} = obj
+  eq 'undefined', typeof a1
+  eq b1, 3
+
+  obj =
+    a2:
+      b2: [1, 2]
+    c2: 3
+
+  {a2: {b2:[]}, c2} = obj
+  eq 'undefined', typeof b2
+  eq c2, 3


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines:
http://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a 
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by 
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in 
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in 
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](http://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->
While testing sub-structuring (#4995) I noticed wrong output of destructuring with an empty array in the object.

Current branch:

```coffeescript
{a:[], b} = obj

###
var b;
obj.undefined, b = obj[1];
###
```

Since `@variable.isAssignable()` in `Assign` returns false because of an empty array,  the `::compileDestructuring` is invoked. 
The syntax is valid and can be output directly.

This PR:

```coffeescript
{a:[], b} = obj

###
var b;
({
  a: [],
  b
} = c);
###
```

