### PR TITLE
simplified test file skipping (#4996)

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -41,7 +41,7 @@ testFilesToSkip = []
 # The `skipUnless` function adds file names to the `testFilesToSkip` array
 # when the feature(s) the file(s) depend on are not available.
 skipUnless = (code, names...) ->
-  if not (try new Function code)
+  unless (try new Function code)
     testFilesToSkip = testFilesToSkip.concat names
 
 skipUnless 'async ()   => {}',                     'async.coffee'

--- a/Cakefile
+++ b/Cakefile
@@ -29,12 +29,24 @@ header = """
 # Used in folder names like `docs/v1`.
 majorVersion = parseInt CoffeeScript.VERSION.split('.')[0], 10
 
-# Patterns of names of test files which depend on currently absent features
-testFilesToSkip = [
-  'async.coffee'           unless try new Function 'async ()   => {}'
-  'async_iterators.coffee' unless try new Function 'async () * => {}'
-  'exponent_ops.coffee'    unless try new Function 'x = 3; x **= 2 ** 2; return x === 81'
-].filter _.identity
+# CoffeeScript supports a range of major versions of NodeJS. Major versions of
+# NodeJS differ in the features they support. CoffeeScript features which
+# depend on features which are not available across all supported NodeJS
+# versions need only be tested against versions of NodeJS which provide the
+# required feature. The purpose of the `testFilesToSkip` array is to exempt
+# files which test features not available within the NodeJS runtime currently
+# under test.
+testFilesToSkip = []
+
+# The `skipUnless` function adds file names to the `testFilesToSkip` array
+# when the feature(s) the file(s) depend on are not available.
+skipUnless = (code, names...) ->
+  unless try new Function code
+    testFilesToSkip = testFilesToSkip.concat names
+
+skipUnless 'async ()   => {}',                     'async.coffee'
+skipUnless 'async () * => {}',                     'async_iterators.coffee'
+skipUnless 'x = 3; x **= 2 ** 2; return x === 81', 'exponent_ops.coffee'
 
 # Log a message with a color.
 log = (message, color, explanation) ->

--- a/Cakefile
+++ b/Cakefile
@@ -40,7 +40,7 @@ testFilesToSkip = []
 
 # The `skipUnless` function adds file names to the `testFilesToSkip` array
 # when the feature(s) the file(s) depend on are not available.
-skipUnless = (code, names->
+skipUnless = (code, names) ->
   unless (try new Function code)
     testFilesToSkip = testFilesToSkip.concat names
 

--- a/Cakefile
+++ b/Cakefile
@@ -450,7 +450,7 @@ runTests = (CoffeeScript) ->
 
   # Run every test in the `test` folder, recording failures.
   files = fs.readdirSync 'test'
-            .filter (filename) -> fileName not in testFilesToSkip
+            .filter (filename) -> filename not in testFilesToSkip
 
   startTime = Date.now()
   for file in files when helpers.isCoffee file

--- a/Cakefile
+++ b/Cakefile
@@ -31,13 +31,10 @@ majorVersion = parseInt CoffeeScript.VERSION.split('.')[0], 10
 
 # Patterns of names of test files which depend on currently absent features
 testFilesToSkip = [
-  /async/           unless try new Function 'async ()   => {}'
-  /async_iterators/ unless try new Function 'async () * => {}'
-  /exponent_ops/    unless try new Function 'x = 3; x **= 2 ** 2; return x === 81'
+  'async.coffee'           unless try new Function 'async ()   => {}'
+  'async_iterators.coffee' unless try new Function 'async () * => {}'
+  'exponent_ops.coffee'    unless try new Function 'x = 3; x **= 2 ** 2; return x === 81'
 ].filter _.identity
-
-featuresPresentFor = (fileName) ->
-  not testFilesToSkip.find (filePattern) -> fileName.match filePattern
 
 # Log a message with a color.
 log = (message, color, explanation) ->
@@ -453,7 +450,7 @@ runTests = (CoffeeScript) ->
 
   # Run every test in the `test` folder, recording failures.
   files = fs.readdirSync 'test'
-            .filter featuresPresentFor
+            .filter (filename) -> fileName not in testFilesToSkip
 
   startTime = Date.now()
   for file in files when helpers.isCoffee file

--- a/Cakefile
+++ b/Cakefile
@@ -41,7 +41,7 @@ testFilesToSkip = []
 # The `skipUnless` function adds file names to the `testFilesToSkip` array
 # when the feature(s) the file(s) depend on are not available.
 skipUnless = (code, names...) ->
-  unless try new Function code
+  if not (try new Function code)
     testFilesToSkip = testFilesToSkip.concat names
 
 skipUnless 'async ()   => {}',                     'async.coffee'

--- a/Cakefile
+++ b/Cakefile
@@ -40,13 +40,17 @@ testFilesToSkip = []
 
 # The `skipUnless` function adds file names to the `testFilesToSkip` array
 # when the feature(s) the file(s) depend on are not available.
-skipUnless = (code, names...) ->
+skipUnless = (code, names->
   unless (try new Function code)
     testFilesToSkip = testFilesToSkip.concat names
 
-skipUnless 'async ()   => {}',                     'async.coffee'
-skipUnless 'async () * => {}',                     'async_iterators.coffee'
-skipUnless 'x = 3; x **= 2 ** 2; return x === 81', 'exponent_ops.coffee'
+skipUnless 'async ()   => {}', [ 'async.coffee', 'async_iterators.coffee' ]
+skipUnless 'async () * => {}', [ 'async_iterators.coffee' ]
+skipUnless '''
+  x = 3
+  x **= 2 ** 2
+  return x === 81
+''', [ 'exponent_ops.coffee' ]
 
 # Log a message with a color.
 log = (message, color, explanation) ->

--- a/Cakefile
+++ b/Cakefile
@@ -29,6 +29,7 @@ header = """
 # Used in folder names like `docs/v1`.
 majorVersion = parseInt CoffeeScript.VERSION.split('.')[0], 10
 
+
 # Log a message with a color.
 log = (message, color, explanation) ->
   console.log color + message + reset + ' ' + (explanation or '')

--- a/test/async.coffee
+++ b/test/async.coffee
@@ -1,8 +1,9 @@
 # Functions that contain the `await` keyword will compile into async functions,
 # supported by Node 7.6+, Chrome 55+, Firefox 52+, Safari 10.1+ and Edge.
-# But runtimes that don’t support the `await` keyword will throw an error,
-# even if we put `return unless global.supportsAsync` at the top of this file.
-# Therefore we need to prevent runtimes which will choke on such code from even
+# But runtimes that don’t support the `await` keyword will throw an error just
+# from parsing this file, even without executing it, even if we put
+# `return unless try new Function 'async () => {}'` at the top of this file.
+# Therefore we need to prevent runtimes which will choke on such code from
 # parsing it, which is handled in `Cakefile`.
 
 

--- a/test/repl.coffee
+++ b/test/repl.coffee
@@ -124,7 +124,7 @@ testRepl "keeps running after runtime error", (input, output) ->
   eq 'undefined', output.lastWrite()
 
 testRepl "#4604: wraps an async function", (input, output) ->
-  return unless global.supportsAsync
+  return unless try new Function 'async () => {}' # Feature detect support for async functions.
   input.emitLine 'await new Promise (resolve) -> setTimeout (-> resolve 33), 10'
   setTimeout ->
     eq '33', output.lastWrite()


### PR DESCRIPTION
_This is a re-creation of PR #4998, which automatically closed because I deleted the branch it came from, and was itself a re-creation of PR #4997 without the extraneous history. Original description follows._

Per discussion on #4893 and #4997, managing exclusion of tests when newer features are required is currently non-obvious. The goal of this PR is to make maintenance of such exceptions easy and surprise-free.

The existing method was a hard-wired exception for the file 'async.coffee'. When I added async_iterators for #4893 I was surprised because I didn't know about the ```build:watch:harmony``` build target nor the hardwired exception in runTests. Now both the feature test and filename match are handled on the same lines near the top of Cakefile.

I included two currently unused pattern/feature pairs to demonstrate the intent and value of this approach. Both will likely be used for #4877 and #4893.

I didn't write a test for this change since it's a change to the test system.

After posting this I'm going to figure out how to remove the extra unrelated empty commits, but I wanted to get this out there before the weekend to follow through on my previous commitment.