### PR TITLE
Fix5004: incorrect compiled code when a destructuring array contains accessors

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3593,7 +3593,10 @@
         slicer = function(type) {
           return function(vvar, start, end = false) {
             var args, slice;
-            args = [new IdentifierLiteral(vvar), new NumberLiteral(start)];
+            if (!(vvar instanceof Value)) {
+              vvar = new IdentifierLiteral(vvar);
+            }
+            args = [vvar, new NumberLiteral(start)];
             if (end) {
               args.push(new NumberLiteral(end));
             }
@@ -3745,7 +3748,7 @@
             refExp = (function() {
               switch (false) {
                 case !isSplat:
-                  return compSplice(objects[expIdx].unwrapAll().value, rightObjs.length * -1);
+                  return compSplice(new Value(objects[expIdx].name), rightObjs.length * -1);
                 case !isExpans:
                   return compSlice(vvarText, rightObjs.length * -1);
               }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2426,7 +2426,8 @@ exports.Assign = class Assign extends Base
       vvarText = ref
 
     slicer = (type) -> (vvar, start, end = no) ->
-      args = [new IdentifierLiteral(vvar), new NumberLiteral(start)]
+      vvar = new IdentifierLiteral vvar unless vvar instanceof Value
+      args = [vvar, new NumberLiteral(start)]
       args.push new NumberLiteral end if end
       slice = new Value (new IdentifierLiteral utility type, o), [new Access new PropertyName 'call']
       new Value new Call slice, args
@@ -2517,7 +2518,7 @@ exports.Assign = class Assign extends Base
       if rightObjs.length isnt 0
         # Slice or splice `objects`.
         refExp = switch
-          when isSplat then compSplice objects[expIdx].unwrapAll().value, rightObjs.length * -1
+          when isSplat then compSplice new Value(objects[expIdx].name), rightObjs.length * -1
           when isExpans then compSlice vvarText, rightObjs.length * -1
         if complexObjects rightObjs
           restVar = refExp

--- a/test/assignment.coffee
+++ b/test/assignment.coffee
@@ -959,7 +959,7 @@ test "#4878: Compile error when using destructuring with a splat or expansion in
     ([first, ...] = list); first
 
   f4 = (list) ->
-    ([first, ...rest] = list); rest
+    ([first, rest...] = list); rest
 
   arrayEq f1(arr), arr
   arrayEq f2(arr), arr
@@ -979,9 +979,39 @@ test "#4878: Compile error when using destructuring with a splat or expansion in
   bar = (list) ->
     ret =
       if list?.length > 0
-        [first, ...rest] = list
+        [first, rest...] = list
         [first, rest]
       else
         []
 
   arrayEq bar(arr), ['a', ['b', 'c', 'd']]
+
+
+test "#5004: array destructuring with accessors", ->
+  obj =
+    arr: ['a', 'b', 'c', 'd']
+    list: {}
+    f1: ->
+      [@first, @rest...] = @arr
+    f2: ->
+      [@second, @third..., @last] = @rest
+    f3: ->
+      [@list.a, @list.middle..., @list.d] = @arr
+
+  obj.f1()
+  eq obj.first, 'a'
+  arrayEq obj.rest, ['b', 'c', 'd']
+
+  obj.f2()
+  eq obj.second, 'b'
+  arrayEq obj.third, ['c']
+  eq obj.last, 'd'
+
+  obj.f3()
+  eq obj.list.a, 'a'
+  arrayEq obj.list.middle, ['b', 'c']
+  eq obj.list.d, 'd'
+
+  [obj.list.middle..., d] = obj.arr
+  eq d, 'd'
+  arrayEq obj.list.middle, ['a', 'b', 'c']


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines:
http://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a 
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by 
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in 
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in 
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](http://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->
Fixes #5004.

```coffeescript
[@all_but_last_two... , @penultimate, @last] = array

###
[...this.all_but_last_two] = array, [this.penultimate, this.last] = splice.call(this.all_but_last_two, -2);
###
```

---

```coffeescript
[obj.first , obj.middle..., obj.last] = array

###
[obj.first, ...obj.middle] = array, [obj.last] = splice.call(obj.middle, -1);
###
```