### PR TITLE
Make `node --harmony bin/cake test` pass on Node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 6
   - 8
+  - 9
 
 cache:
   directories:
@@ -14,5 +15,6 @@ script:
   - node ./bin/cake build:full
   - node ./bin/cake build:browser
   - node ./bin/cake test
+  - node --harmony ./bin/cake test
   - node ./bin/cake test:browser
   - node ./bin/cake test:integrations

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   matrix:
     - nodejs_version: '6'
     - nodejs_version: '8'
+    - nodejs_version: '9'
     - nodejs_version: '' # Installs latest.
 
 install:
@@ -19,6 +20,7 @@ test_script:
   - node ./bin/cake build:full
   - node ./bin/cake build:browser
   - node ./bin/cake test
+  - node --harmony ./bin/cake test
   - node ./bin/cake test:browser
   - node ./bin/cake test:integrations
 

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -266,6 +266,7 @@ test "classes with value'd constructors", ->
     inner = ++counter
     ->
       @value = inner
+      @
 
   class One
     constructor: classMaker()


### PR DESCRIPTION
Make classMaker() explicitly return an object

Without this change, `node --harmony bin/cake test` the test "classes with value'd constructors" fails because classMaker returns a number.