### PR TITLE
Fix #5013: return statement as an expression

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1267,16 +1267,6 @@
         if (!props && base instanceof Value) {
           return base;
         }
-        // When `Parens` block includes a `StatementLiteral`, `Return`, `YieldReturn` or `AwaitReturn`
-        // (e.g. `(b; break) for a in arr`, '-> (return)`, '-> (yield return)`),
-        // it won't compile since `Parens` (`(b; break)`) is compiled as `Value` and
-        // pure statement (`break`) can't be used in an expression.
-        // For this reasons, we return `Block` instead of `Parens`.
-        if (base instanceof Parens && base.contains(function(n) {
-          return n instanceof StatementLiteral || n instanceof Return;
-        })) {
-          return base.unwrap();
-        }
         this.base = base;
         this.properties = props || [];
         if (tag) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1267,13 +1267,14 @@
         if (!props && base instanceof Value) {
           return base;
         }
+        // When `Parens` block includes a `StatementLiteral`, `Return`, `YieldReturn` or `AwaitReturn`
+        // (e.g. `(b; break) for a in arr`, '-> (return)`, '-> (yield return)`),
+        // it won't compile since `Parens` (`(b; break)`) is compiled as `Value` and
+        // pure statement (`break`) can't be used in an expression.
+        // For this reasons, we return `Block` instead of `Parens`.
         if (base instanceof Parens && base.contains(function(n) {
-          return n instanceof StatementLiteral;
+          return n instanceof StatementLiteral || n instanceof Return;
         })) {
-          // When `Parens` block includes a `StatementLiteral` (e.g. `(b; break) for a in arr`),
-          // it won't compile since `Parens` (`(b; break)`) is compiled as `Value` and
-          // pure statement (`break`) can't be used in an expression.
-          // For this reasons, we return `Block` instead of `Parens`.
           return base.unwrap();
         }
         this.base = base;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -863,11 +863,14 @@ exports.Value = class Value extends Base
   constructor: (base, props, tag, isDefaultValue = no) ->
     super()
     return base if not props and base instanceof Value
-    # When `Parens` block includes a `StatementLiteral` (e.g. `(b; break) for a in arr`),
+    # When `Parens` block includes a `StatementLiteral`, `Return`, `YieldReturn` or `AwaitReturn`
+    # (e.g. `(b; break) for a in arr`, '-> (return)`, '-> (yield return)`),
     # it won't compile since `Parens` (`(b; break)`) is compiled as `Value` and
     # pure statement (`break`) can't be used in an expression.
     # For this reasons, we return `Block` instead of `Parens`.
-    return base.unwrap() if base instanceof Parens and base.contains (n) -> n instanceof StatementLiteral
+    if base instanceof Parens and
+        base.contains (n) -> n instanceof StatementLiteral or n instanceof Return
+      return base.unwrap()
     @base           = base
     @properties     = props or []
     @[tag]          = yes if tag

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -863,14 +863,6 @@ exports.Value = class Value extends Base
   constructor: (base, props, tag, isDefaultValue = no) ->
     super()
     return base if not props and base instanceof Value
-    # When `Parens` block includes a `StatementLiteral`, `Return`, `YieldReturn` or `AwaitReturn`
-    # (e.g. `(b; break) for a in arr`, '-> (return)`, '-> (yield return)`),
-    # it won't compile since `Parens` (`(b; break)`) is compiled as `Value` and
-    # pure statement (`break`) can't be used in an expression.
-    # For this reasons, we return `Block` instead of `Parens`.
-    if base instanceof Parens and
-        base.contains (n) -> n instanceof StatementLiteral or n instanceof Return
-      return base.unwrap()
     @base           = base
     @properties     = props or []
     @[tag]          = yes if tag

--- a/test/control_flow.coffee
+++ b/test/control_flow.coffee
@@ -1112,37 +1112,6 @@ test "#3921: `switch`", ->
     else "none"
   eq "five", c
 
-# Issue #3441: Parentheses wrapping expression throw invalid error in `then` clause
-test "#3441: `StatementLiteral` in parentheses", ->
-  i = 0
-  r1 = ((i++; break) while i < 10)
-  arrayEq r1, []
-
-  i = 0
-  r2 = ((i++; continue) while i < 10)
-  arrayEq r2, []
-
-  i = 0
-  r4 = while i < 10 then (i++; break)
-  arrayEq r4, []
-
-  i = 0
-  r5 = while i < 10 then (i++; continue)
-  arrayEq r5, []
-
-  arr = [0..9]
-  r6 = ((a; break) for a in arr)
-  arrayEq r6, []
-
-  r7 = ((a; continue) for a in arr)
-  arrayEq r7, []
-
-  r8 = for a in arr then (a; break)
-  arrayEq r8, []
-
-  r9 = for a in arr then (a; continue)
-  arrayEq r9, []
-
 # Issue #3909: backslash to break line in `for` loops throw syntax error
 test "#3909: backslash `for own ... of`", ->
 

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -953,6 +953,51 @@ test "`yield` outside of a function", ->
     ^^^^^^^^^^^^
   '''
 
+test "#4097: `yield return` as an expression", ->
+  assertErrorFormat '''
+    -> (yield return)
+  ''', '''
+    [stdin]:1:5: error: cannot use a pure statement in an expression
+    -> (yield return)
+        ^^^^^^^^^^^^
+  '''
+
+test "#5013: `await return` as an expression", ->
+  assertErrorFormat '''
+    -> (await return)
+  ''', '''
+    [stdin]:1:5: error: cannot use a pure statement in an expression
+    -> (await return)
+        ^^^^^^^^^^^^
+  '''
+
+test "#5013: `return` as an expression", ->
+  assertErrorFormat '''
+    -> (return)
+  ''', '''
+    [stdin]:1:5: error: cannot use a pure statement in an expression
+    -> (return)
+        ^^^^^^
+  '''
+
+test "#5013: `break` as an expression", ->
+  assertErrorFormat '''
+    (b = 1; break) for b in a
+  ''', '''
+    [stdin]:1:9: error: cannot use a pure statement in an expression
+    (b = 1; break) for b in a
+            ^^^^^
+  '''
+
+test "#5013: `continue` as an expression", ->
+  assertErrorFormat '''
+    (b = 1; continue) for b in a
+  ''', '''
+    [stdin]:1:9: error: cannot use a pure statement in an expression
+    (b = 1; continue) for b in a
+            ^^^^^^^^
+  '''
+
 test "`&&=` and `||=` with a space in-between", ->
   assertErrorFormat '''
     a = 0

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -953,15 +953,6 @@ test "`yield` outside of a function", ->
     ^^^^^^^^^^^^
   '''
 
-test "#4097: `yield return` as an expression", ->
-  assertErrorFormat '''
-    -> (yield return)
-  ''', '''
-    [stdin]:1:5: error: cannot use a pure statement in an expression
-    -> (yield return)
-        ^^^^^^^^^^^^
-  '''
-
 test "`&&=` and `||=` with a space in-between", ->
   assertErrorFormat '''
     a = 0

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -572,3 +572,17 @@ test "#4657: destructured array parameters", ->
   result = f [1, 2, 3, 4]
   arrayEq result.a, [1, 2, 3]
   eq result.b, 4
+
+test "#5013: return statements in parentheses", ->
+  compile = (code) -> CoffeeScript.compile(code, bare: yes).trim().replace(/\s+/g, " ")
+
+  eq "(function() {});",         compile("-> (return)")
+  eq "(function*() {});",        compile("-> (yield return)")
+  eq "(async function() {});",   compile("-> (await return)")
+
+  foo = (cond) ->
+    (a = 1; return) if cond
+    a = 2
+
+  eq undefined, foo yes
+  eq 2, foo no

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -572,17 +572,3 @@ test "#4657: destructured array parameters", ->
   result = f [1, 2, 3, 4]
   arrayEq result.a, [1, 2, 3]
   eq result.b, 4
-
-test "#5013: return statements in parentheses", ->
-  compile = (code) -> CoffeeScript.compile(code, bare: yes).trim().replace(/\s+/g, " ")
-
-  eq "(function() {});",         compile("-> (return)")
-  eq "(function*() {});",        compile("-> (yield return)")
-  eq "(async function() {});",   compile("-> (await return)")
-
-  foo = (cond) ->
-    (a = 1; return) if cond
-    a = 2
-
-  eq undefined, foo yes
-  eq 2, foo no


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines:
http://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a 
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by 
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in 
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in 
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](http://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->
Fixes #5013 and return statement as an expression in general.

```coffeescript
-> (return)
# (function() {});

-> (yield return)
# (function*() {});

-> (await return)
# (async function() {});
```