### PR TITLE
Optimize 'for-range-by' loop when 'by' is literal number

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2058,7 +2058,7 @@
         stepCond = `${(ref2 = this.stepNum) != null ? ref2 : this.stepVar} > 0`;
         lowerBound = `${lt} ${(known ? to : this.toVar)}`;
         upperBound = `${gt} ${(known ? to : this.toVar)}`;
-        condPart = this.step != null ? `${stepNotZero} && (${stepCond} ? ${lowerBound} : ${upperBound})` : known ? `${(from <= to ? lt : gt)} ${to}` : `(${this.fromVar} <= ${this.toVar} ? ${lowerBound} : ${upperBound})`;
+        condPart = this.step != null ? (this.stepNum != null) && this.stepNum !== 0 ? this.stepNum > 0 ? `${lowerBound}` : `${upperBound}` : `${stepNotZero} && (${stepCond} ? ${lowerBound} : ${upperBound})` : known ? `${(from <= to ? lt : gt)} ${to}` : `(${this.fromVar} <= ${this.toVar} ? ${lowerBound} : ${upperBound})`;
         cond = this.stepVar ? `${this.stepVar} > 0` : `${this.fromVar} <= ${this.toVar}`;
         // Generate the step.
         stepPart = this.stepVar ? `${idx} += ${this.stepVar}` : known ? namedIndex ? from <= to ? `++${idx}` : `--${idx}` : from <= to ? `${idx}++` : `${idx}--` : namedIndex ? `${cond} ? ++${idx} : --${idx}` : `${cond} ? ${idx}++ : ${idx}--`;

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1371,7 +1371,7 @@ exports.Range = class Range extends Base
     upperBound = "#{gt} #{ if known then to else @toVar }"
     condPart =
       if @step?
-        if @stepNum? and @stepNum != 0
+        if @stepNum? and @stepNum isnt 0
           if @stepNum > 0 then "#{lowerBound}" else "#{upperBound}"
         else
           "#{stepNotZero} && (#{stepCond} ? #{lowerBound} : #{upperBound})"

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1370,12 +1370,15 @@ exports.Range = class Range extends Base
     lowerBound = "#{lt} #{ if known then to else @toVar }"
     upperBound = "#{gt} #{ if known then to else @toVar }"
     condPart =
-       if @step?
-         "#{stepNotZero} && (#{stepCond} ? #{lowerBound} : #{upperBound})"
-       else
-         if known
-           "#{ if from <= to then lt else gt } #{to}"
-         else
+      if @step?
+        if @stepNum? and @stepNum != 0
+          if @stepNum > 0 then "#{lowerBound}" else "#{upperBound}"
+        else
+          "#{stepNotZero} && (#{stepCond} ? #{lowerBound} : #{upperBound})"
+      else
+        if known
+          "#{ if from <= to then lt else gt } #{to}"
+        else
           "(#{@fromVar} <= #{@toVar} ? #{lowerBound} : #{upperBound})"
 
     cond = if @stepVar then "#{@stepVar} > 0" else "#{@fromVar} <= #{@toVar}"


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines:
http://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a 
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by 
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in 
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in 
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](http://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->
Fixes #5015. Simplify and optimize `for-range-by` loop when `step` is a literal number.

```coffeescript
for x in [1..a] by 1
# for (x = i = 1, ref = a; i <= ref; x = i += 1)

for x in [a..1] by 1
# for (x = i = ref = a; i <= 1; x = i += 1)

for x in [a..b] by 1
# for (x = i = ref = a, ref1 = b; i <= ref1; x = i += 1)

for x in [1..2] by 1
# for (x = i = 1; i <= 2; x = i += 1)

for x in [1..a] by -1
# for (x = i = 1, ref = a; i >= ref; x = i += -1)

for x in [a..1] by -1
# for (x = i = ref = a; i >= 1; x = i += -1)

for x in [a..b] by -1
# for (x = i = ref = a, ref1 = b; i >= ref1; x = i += -1)

for x in [2..1] by -1
# for (x = i = 2; i >= 1; x = i += -1)
```