### PR TITLE
Fix: a test relied on faulty behavior

### DIFF
--- a/test/exception_handling.coffee
+++ b/test/exception_handling.coffee
@@ -8,7 +8,7 @@ nonce = {}
 # Throw
 
 test "basic exception throwing", ->
-  throws (-> throw 'error'), 'error'
+  throws (-> throw 'error'), /^error$/
 
 
 # Empty Try/Catch/Finally


### PR DESCRIPTION
This came up in CITGM while improving assert.throws in Node.js. See nodejs/node#19867 for more information.

The current tests never checked for the error message and instead, the error message would have been returned, just the same as if there would be no second argument at all.

This makes sure the error message is actually tested for.