### PR TITLE
Pass lexer data to nodes

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -237,7 +237,7 @@
 
   // The real Lexer produces a generic stream of tokens. This object provides a
   // thin wrapper around it, compatible with the Jison API. We can then pass it
-  // directly as a "Jison lexer".
+  // directly as a “Jison lexer.”
   parser.lexer = {
     lex: function() {
       var tag, token;

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -179,16 +179,15 @@
       tokenHash = buildLocationHash(token[2]);
       // Multiple tokens might have the same location hash, such as the generated
       // `JS` tokens added at the start or end of the token stream to hold
-      // comments that start or end a file. On such “overlapping” tokens, we want
-      // to merge the comments together; and store the data under keys for each
-      // token tag. In testing with the CoffeeScript codebase, the only time
-      // multiple tokens with the same tag overlap is for `OUTDENT` tags, which
-      // never become nodes, so we’re okay with one `OUTDENT` token’s data
-      // overwriting an earlier one.
+      // comments that start or end a file.
       if (tokenData[tokenHash] == null) {
         tokenData[tokenHash] = {};
       }
       if (token.comments) { // `comments` is always an array.
+        // For “overlapping” tokens, that is tokens with the same location data
+        // and therefore matching `tokenHash`es, merge the comments from both/all
+        // tokens together into one array, even if there are duplicate comments;
+        // they will get sorted out later.
         if (tokenData[tokenHash].comments != null) {
           tokenData[tokenHash].comments.push(...token.comments);
         } else {
@@ -196,6 +195,12 @@
         }
       }
       if (token.data) {
+        // For overlapping tokens that both have token data, add each token’s data
+        // under keys defined by each token’s tag. In testing with the
+        // CoffeeScript codebase, the only type of token that overlaps with other
+        // tokens that use the same tag is for `OUTDENT` tags, which never become
+        // nodes, so we’re okay with one `OUTDENT` token’s data overwriting an
+        // earlier one.
         if ((base = tokenData[tokenHash]).data == null) {
           base.data = {};
         }

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -180,22 +180,23 @@
       // Multiple tokens might have the same location hash, such as the generated
       // `JS` tokens added at the start or end of the token stream to hold
       // comments that start or end a file. On such “overlapping” tokens, we want
-      // to merge the comments together.
+      // to merge the comments together; and store the data under keys for each
+      // token tag. In testing with the CoffeeScript codebase, the only time
+      // multiple tokens with the same tag overlap is for `OUTDENT` tags, which
+      // never become nodes, so we’re okay with one `OUTDENT` token’s data
+      // overwriting an earlier one.
       if (tokenData[tokenHash] == null) {
-        tokenData[tokenHash] = {};
+        tokenData[tokenHash] = {
+          data: {}
+        };
       }
+      tokenData[tokenHash].data[token.data.tag] = token.data;
       if (token.comments) { // `comments` is always an array.
         if (tokenData[tokenHash].comments != null) {
           tokenData[tokenHash].comments.push(...token.comments);
         } else {
           tokenData[tokenHash].comments = token.comments;
         }
-      }
-      if (token.data) { // `data` is always an object.
-        // It doesn’t make sense to combine two tokens’ extra data properties, so
-        // just overwrite one with the other in case two tokens with the same hash
-        // both have metadata; but such an overlap shouldn’t happen.
-        tokenData[tokenHash].data = token.data;
       }
     }
     return tokenData;
@@ -221,7 +222,7 @@
           attachCommentsToNode(parserState.tokenData[objHash].comments, obj);
         }
         if (((ref2 = parserState.tokenData[objHash]) != null ? ref2.data : void 0) != null) {
-          obj.data = parserState.tokenData[objHash].data;
+          obj.tokenData = parserState.tokenData[objHash].data;
         }
       }
       return obj;

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -5,7 +5,7 @@
   // arrays, count characters, that sort of thing.
 
   // Peek at the beginning of a given string to see if it matches a sequence.
-  var attachCommentsToNode, buildLocationData, buildLocationHash, extend, flatten, ref, repeat, syntaxErrorToString;
+  var attachCommentsToNode, buildLocationData, buildLocationHash, buildTokenDataDictionary, extend, flatten, ref, repeat, syntaxErrorToString;
 
   exports.starts = function(string, literal, start) {
     return literal === string.substr(start, literal.length);
@@ -165,37 +165,63 @@
     return `${loc.first_line}x${loc.first_column}-${loc.last_line}x${loc.last_column}`;
   };
 
+  // Build a dictionary of extra token properties organized by tokens’ locations
+  // used as lookup hashes.
+  buildTokenDataDictionary = function(parserState) {
+    var i, len1, ref1, token, tokenData, tokenHash;
+    tokenData = {};
+    ref1 = parserState.parser.tokens;
+    for (i = 0, len1 = ref1.length; i < len1; i++) {
+      token = ref1[i];
+      if (!(token.comments || token.data)) {
+        continue;
+      }
+      tokenHash = buildLocationHash(token[2]);
+      // Multiple tokens might have the same location hash, such as the generated
+      // `JS` tokens added at the start or end of the token stream to hold
+      // comments that start or end a file. On such “overlapping” tokens, we want
+      // to merge the comments together.
+      if (tokenData[tokenHash] == null) {
+        tokenData[tokenHash] = {};
+      }
+      if (token.comments) { // `comments` is always an array.
+        if (tokenData[tokenHash].comments != null) {
+          tokenData[tokenHash].comments.push(...token.comments);
+        } else {
+          tokenData[tokenHash].comments = token.comments;
+        }
+      }
+      if (token.data) { // `data` is always an object.
+        // It doesn’t make sense to combine two tokens’ extra data properties, so
+        // just overwrite one with the other in case two tokens with the same hash
+        // both have metadata; but such an overlap shouldn’t happen.
+        tokenData[tokenHash].data = token.data;
+      }
+    }
+    return tokenData;
+  };
+
   // This returns a function which takes an object as a parameter, and if that
   // object is an AST node, updates that object's locationData.
   // The object is returned either way.
   exports.addDataToNode = function(parserState, first, last) {
     return function(obj) {
-      var i, len1, objHash, ref1, token, tokenHash;
+      var objHash, ref1, ref2;
       // Add location data
       if (((obj != null ? obj.updateLocationDataIfMissing : void 0) != null) && (first != null)) {
         obj.updateLocationDataIfMissing(buildLocationData(first, last));
       }
-      // Add comments data
-      if (!parserState.tokenComments) {
-        parserState.tokenComments = {};
-        ref1 = parserState.parser.tokens;
-        for (i = 0, len1 = ref1.length; i < len1; i++) {
-          token = ref1[i];
-          if (!token.comments) {
-            continue;
-          }
-          tokenHash = buildLocationHash(token[2]);
-          if (parserState.tokenComments[tokenHash] == null) {
-            parserState.tokenComments[tokenHash] = token.comments;
-          } else {
-            parserState.tokenComments[tokenHash].push(...token.comments);
-          }
-        }
+      // Add comments and data
+      if (parserState.tokenData == null) {
+        parserState.tokenData = buildTokenDataDictionary(parserState);
       }
       if (obj.locationData != null) {
         objHash = buildLocationHash(obj.locationData);
-        if (parserState.tokenComments[objHash] != null) {
-          attachCommentsToNode(parserState.tokenComments[objHash], obj);
+        if (((ref1 = parserState.tokenData[objHash]) != null ? ref1.comments : void 0) != null) {
+          attachCommentsToNode(parserState.tokenData[objHash].comments, obj);
+        }
+        if (((ref2 = parserState.tokenData[objHash]) != null ? ref2.data : void 0) != null) {
+          obj.data = parserState.tokenData[objHash].data;
         }
       }
       return obj;

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -168,7 +168,7 @@
   // Build a dictionary of extra token properties organized by tokens’ locations
   // used as lookup hashes.
   buildTokenDataDictionary = function(parserState) {
-    var i, len1, ref1, token, tokenData, tokenHash;
+    var base, i, len1, ref1, token, tokenData, tokenHash;
     tokenData = {};
     ref1 = parserState.parser.tokens;
     for (i = 0, len1 = ref1.length; i < len1; i++) {
@@ -186,17 +186,20 @@
       // never become nodes, so we’re okay with one `OUTDENT` token’s data
       // overwriting an earlier one.
       if (tokenData[tokenHash] == null) {
-        tokenData[tokenHash] = {
-          data: {}
-        };
+        tokenData[tokenHash] = {};
       }
-      tokenData[tokenHash].data[token.data.tag] = token.data;
       if (token.comments) { // `comments` is always an array.
         if (tokenData[tokenHash].comments != null) {
           tokenData[tokenHash].comments.push(...token.comments);
         } else {
           tokenData[tokenHash].comments = token.comments;
         }
+      }
+      if (token.data) {
+        if ((base = tokenData[tokenHash]).data == null) {
+          base.data = {};
+        }
+        tokenData[tokenHash].data[token.data.tag] = token.data;
       }
     }
     return tokenData;

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -385,6 +385,7 @@
           value = this.formatString(value, {
             delimiter: quote
           });
+          // Remove indentation from multiline single-quoted strings.
           value = value.replace(SIMPLE_STRING_OMIT, function(match, offset) {
             if ((i === 0 && offset === 0) || (i === $ && offset + match.length === value.length)) {
               return '';
@@ -1032,7 +1033,11 @@
           offsetInChunk
         });
         // Push a fake `'NEOSTRING'` token, which will get turned into a real string later.
-        tokens.push(this.makeToken('NEOSTRING', strPart, offsetInChunk));
+        tokens.push(this.makeToken('NEOSTRING', strPart, offsetInChunk, strPart.length, void 0, {
+          delimiter: delimiter,
+          rawValue: strPart,
+          indentLiteral: this.indentLiteral
+        }));
         str = str.slice(strPart.length);
         offsetInChunk += strPart.length;
         if (!(match = interpolators.exec(str))) {
@@ -1051,7 +1056,7 @@
           column: column,
           untilBalanced: true
         }));
-        // Account for the `#` in `#{`
+        // Account for the `#` in `#{`.
         index += interpolationOffset;
         braceInterpolator = str[index - 1] === '}';
         if (braceInterpolator) {
@@ -1171,7 +1176,7 @@
             tokensToPush = [token];
         }
         if (this.tokens.length > firstIndex) {
-          // Create a 0-length "+" token.
+          // Create a 0-length `+` token.
           plusToken = this.token('+', '+');
           plusToken[2] = {
             first_line: locationToken[2].first_line,
@@ -1255,15 +1260,21 @@
 
     // Same as `token`, except this just returns the token without adding it
     // to the results.
-    makeToken(tag, value, offsetInChunk = 0, length = value.length) {
+    makeToken(tag, value, offsetInChunk = 0, length = value.length, origin, data) {
       var lastCharacter, locationData, token;
       locationData = {};
       [locationData.first_line, locationData.first_column] = this.getLineAndColumnFromChunk(offsetInChunk);
-      // Use length - 1 for the final offset - we're supplying the last_line and the last_column,
-      // so if last_column == first_column, then we're looking at a character of length 1.
+      // Use length - 1 for the final offset - we’re supplying the last_line and the last_column,
+      // so if last_column == first_column, then we’re looking at a character of length 1.
       lastCharacter = length > 0 ? length - 1 : 0;
       [locationData.last_line, locationData.last_column] = this.getLineAndColumnFromChunk(offsetInChunk + lastCharacter);
       token = [tag, value, locationData];
+      if (origin) {
+        token.origin = origin;
+      }
+      if (data) {
+        token.data = data;
+      }
       return token;
     }
 
@@ -1273,12 +1284,9 @@
     // not specified, the length of `value` will be used.
 
     // Returns the new token.
-    token(tag, value, offsetInChunk, length, origin) {
+    token(tag, value, offsetInChunk, length, origin, data) {
       var token;
-      token = this.makeToken(tag, value, offsetInChunk, length);
-      if (origin) {
-        token.origin = origin;
-      }
+      token = this.makeToken(tag, value, offsetInChunk, length, origin, data);
       this.tokens.push(token);
       return token;
     }

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1034,9 +1034,7 @@
         });
         // Push a fake `'NEOSTRING'` token, which will get turned into a real string later.
         tokens.push(this.makeToken('NEOSTRING', strPart, offsetInChunk, strPart.length, void 0, {
-          delimiter: delimiter,
-          rawValue: strPart,
-          indentLiteral: this.indentLiteral
+          delimiter: delimiter
         }));
         str = str.slice(strPart.length);
         offsetInChunk += strPart.length;
@@ -1272,8 +1270,15 @@
       if (origin) {
         token.origin = origin;
       }
+      token.data = {
+        tag: tag,
+        value: value,
+        baseIndent: this.baseIndent,
+        indent: this.indent,
+        indentLiteral: this.indentLiteral
+      };
       if (data) {
-        token.data = data;
+        Object.assign(token.data, data);
       }
       return token;
     }

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -43,6 +43,9 @@
     token.generated = true;
     if (origin) {
       token.origin = origin;
+      token.data = origin.data;
+    } else {
+      token.data = {tag, value};
     }
     if (commentsToken) {
       moveComments(commentsToken, token);

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -193,7 +193,7 @@ lexer = new Lexer
 
 # The real Lexer produces a generic stream of tokens. This object provides a
 # thin wrapper around it, compatible with the Jison API. We can then pass it
-# directly as a "Jison lexer".
+# directly as a “Jison lexer.”
 parser.lexer =
   lex: ->
     token = parser.tokens[@pos++]

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -119,19 +119,24 @@ buildTokenDataDictionary = (parserState) ->
     tokenHash = buildLocationHash token[2]
     # Multiple tokens might have the same location hash, such as the generated
     # `JS` tokens added at the start or end of the token stream to hold
-    # comments that start or end a file. On such “overlapping” tokens, we want
-    # to merge the comments together; and store the data under keys for each
-    # token tag. In testing with the CoffeeScript codebase, the only time
-    # multiple tokens with the same tag overlap is for `OUTDENT` tags, which
-    # never become nodes, so we’re okay with one `OUTDENT` token’s data
-    # overwriting an earlier one.
+    # comments that start or end a file.
     tokenData[tokenHash] ?= {}
     if token.comments # `comments` is always an array.
+      # For “overlapping” tokens, that is tokens with the same location data
+      # and therefore matching `tokenHash`es, merge the comments from both/all
+      # tokens together into one array, even if there are duplicate comments;
+      # they will get sorted out later.
       if tokenData[tokenHash].comments?
         tokenData[tokenHash].comments.push token.comments...
       else
         tokenData[tokenHash].comments = token.comments
     if token.data
+      # For overlapping tokens that both have token data, add each token’s data
+      # under keys defined by each token’s tag. In testing with the
+      # CoffeeScript codebase, the only type of token that overlaps with other
+      # tokens that use the same tag is for `OUTDENT` tags, which never become
+      # nodes, so we’re okay with one `OUTDENT` token’s data overwriting an
+      # earlier one.
       tokenData[tokenHash].data ?= {}
       tokenData[tokenHash].data[token.data.tag] = token.data
   tokenData

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -111,6 +111,17 @@ buildLocationData = (first, last) ->
 buildLocationHash = (loc) ->
   "#{loc.first_line}x#{loc.first_column}-#{loc.last_line}x#{loc.last_column}"
 
+# Build a dictionary of comments organized by tokens’ locations used as
+# lookup hashes.
+consolidateComments = (parserState) ->
+  parserState.tokenComments = {}
+  for token in parserState.parser.tokens when token.comments
+    tokenHash = buildLocationHash token[2]
+    unless parserState.tokenComments[tokenHash]?
+      parserState.tokenComments[tokenHash] = token.comments
+    else
+      parserState.tokenComments[tokenHash].push token.comments...
+
 # This returns a function which takes an object as a parameter, and if that
 # object is an AST node, updates that object's locationData.
 # The object is returned either way.
@@ -121,15 +132,7 @@ exports.addDataToNode = (parserState, first, last) ->
       obj.updateLocationDataIfMissing buildLocationData(first, last)
 
     # Add comments data
-    unless parserState.tokenComments
-      parserState.tokenComments = {}
-      for token in parserState.parser.tokens when token.comments
-        tokenHash = buildLocationHash token[2]
-        unless parserState.tokenComments[tokenHash]?
-          parserState.tokenComments[tokenHash] = token.comments
-        else
-          parserState.tokenComments[tokenHash].push token.comments...
-
+    consolidateComments parserState unless parserState.tokenComments
     if obj.locationData?
       objHash = buildLocationHash obj.locationData
       if parserState.tokenComments[objHash]?

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -125,13 +125,15 @@ buildTokenDataDictionary = (parserState) ->
     # multiple tokens with the same tag overlap is for `OUTDENT` tags, which
     # never become nodes, so we’re okay with one `OUTDENT` token’s data
     # overwriting an earlier one.
-    tokenData[tokenHash] ?= data: {}
-    tokenData[tokenHash].data[token.data.tag] = token.data
+    tokenData[tokenHash] ?= {}
     if token.comments # `comments` is always an array.
       if tokenData[tokenHash].comments?
         tokenData[tokenHash].comments.push token.comments...
       else
         tokenData[tokenHash].comments = token.comments
+    if token.data
+      tokenData[tokenHash].data ?= {}
+      tokenData[tokenHash].data[token.data.tag] = token.data
   tokenData
 
 # This returns a function which takes an object as a parameter, and if that

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -769,8 +769,6 @@ exports.Lexer = class Lexer
       # Push a fake `'NEOSTRING'` token, which will get turned into a real string later.
       tokens.push @makeToken 'NEOSTRING', strPart, offsetInChunk, strPart.length, undefined,
         delimiter: delimiter
-        rawValue: strPart
-        indentLiteral: @indentLiteral
 
       str = str[strPart.length..]
       offsetInChunk += strPart.length
@@ -961,8 +959,13 @@ exports.Lexer = class Lexer
 
     token = [tag, value, locationData]
     token.origin = origin if origin
-    token.data = data if data
-
+    token.data =
+      tag: tag
+      value: value
+      baseIndent: @baseIndent
+      indent: @indent
+      indentLiteral: @indentLiteral
+    Object.assign token.data, data if data
     token
 
   # Add a token to the results.

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -305,6 +305,7 @@ exports.Lexer = class Lexer
     else
       @mergeInterpolationTokens tokens, {delimiter}, (value, i) =>
         value = @formatString value, delimiter: quote
+        # Remove indentation from multiline single-quoted strings.
         value = value.replace SIMPLE_STRING_OMIT, (match, offset) ->
           if (i is 0 and offset is 0) or
              (i is $ and offset + match.length is value.length)
@@ -766,7 +767,10 @@ exports.Lexer = class Lexer
       @validateEscapes strPart, {isRegex: delimiter.charAt(0) is '/', offsetInChunk}
 
       # Push a fake `'NEOSTRING'` token, which will get turned into a real string later.
-      tokens.push @makeToken 'NEOSTRING', strPart, offsetInChunk
+      tokens.push @makeToken 'NEOSTRING', strPart, offsetInChunk, strPart.length, undefined,
+        delimiter: delimiter
+        rawValue: strPart
+        indentLiteral: @indentLiteral
 
       str = str[strPart.length..]
       offsetInChunk += strPart.length

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -780,7 +780,7 @@ exports.Lexer = class Lexer
       rest = str[interpolationOffset..]
       {tokens: nested, index} =
         new Lexer().tokenize rest, line: line, column: column, untilBalanced: on
-      # Account for the `#` in `#{`
+      # Account for the `#` in `#{`.
       index += interpolationOffset
 
       braceInterpolator = str[index - 1] is '}'
@@ -875,7 +875,7 @@ exports.Lexer = class Lexer
           locationToken = token
           tokensToPush = [token]
       if @tokens.length > firstIndex
-        # Create a 0-length "+" token.
+        # Create a 0-length `+` token.
         plusToken = @token '+', '+'
         plusToken[2] =
           first_line:   locationToken[2].first_line
@@ -949,8 +949,8 @@ exports.Lexer = class Lexer
     [locationData.first_line, locationData.first_column] =
       @getLineAndColumnFromChunk offsetInChunk
 
-    # Use length - 1 for the final offset - we're supplying the last_line and the last_column,
-    # so if last_column == first_column, then we're looking at a character of length 1.
+    # Use length - 1 for the final offset - we’re supplying the last_line and the last_column,
+    # so if last_column == first_column, then we’re looking at a character of length 1.
     lastCharacter = if length > 0 then (length - 1) else 0
     [locationData.last_line, locationData.last_column] =
       @getLineAndColumnFromChunk offsetInChunk + lastCharacter

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -944,7 +944,7 @@ exports.Lexer = class Lexer
 
   # Same as `token`, except this just returns the token without adding it
   # to the results.
-  makeToken: (tag, value, offsetInChunk = 0, length = value.length) ->
+  makeToken: (tag, value, offsetInChunk = 0, length = value.length, origin, data) ->
     locationData = {}
     [locationData.first_line, locationData.first_column] =
       @getLineAndColumnFromChunk offsetInChunk
@@ -956,6 +956,8 @@ exports.Lexer = class Lexer
       @getLineAndColumnFromChunk offsetInChunk + lastCharacter
 
     token = [tag, value, locationData]
+    token.origin = origin if origin
+    token.data = data if data
 
     token
 
@@ -965,9 +967,8 @@ exports.Lexer = class Lexer
   # not specified, the length of `value` will be used.
   #
   # Returns the new token.
-  token: (tag, value, offsetInChunk, length, origin) ->
-    token = @makeToken tag, value, offsetInChunk, length
-    token.origin = origin if origin
+  token: (tag, value, offsetInChunk, length, origin, data) ->
+    token = @makeToken tag, value, offsetInChunk, length, origin, data
     @tokens.push token
     token
 

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -27,7 +27,11 @@ moveComments = (fromToken, toToken) ->
 generate = (tag, value, origin, commentsToken) ->
   token = [tag, value]
   token.generated = yes
-  token.origin = origin if origin
+  if origin
+    token.origin = origin
+    token.data = origin.data
+  else
+    token.data = {tag, value}
   moveComments commentsToken, token if commentsToken
   token
 


### PR DESCRIPTION
Along the lines of #5044 and #4984, this PR adds a way to pass arbitrary token data from the lexer to the node classes. Just as inside every node class since #4572 there’s a `@comments` property if comments should be output before or after that node, per this PR there’s now also a `@data` property where we can stash extra data from the lexer or rewriter to sneak through the parser and be accessible in the nodes classes.

In particular, this should make #5019 solvable. Besides creating the new code to allow this `data` property on tokens to sneak through the parser, this PR adds some data to the `StringLiteral` token that should allow us to move a lot of the string manipulation logic out of `lexer.coffee` and into `nodes.coffee`. This is more just an example at this point, with the actual moving of that logic saved for a future PR. If you set a breakpoint in the `nodes.coffee` `StringLiteral` class `compileNode` method, you should see `@data` present with the values we set in the lexer.

@zdenko I think the code at [lexer.coffee#L307-L315](https://github.com/GeoffreyBooth/coffeescript/blob/e8c3889c117850d15f8cb32b0cb40352a49e60ed/src/lexer.coffee#L307-L315) is where multiline `'` and `"` strings get deindented; thanks to the extra data I’m attaching to `StringLiteral`s in [lexer.coffee#L770-L773](https://github.com/GeoffreyBooth/coffeescript/blob/e8c3889c117850d15f8cb32b0cb40352a49e60ed/src/lexer.coffee#L770-L773), the former code block should be able to move into the `StringLiteral` nodes class. (A _lot_ of the string code could move over there, like the lexer functions about escapes and so on.)

Even if we didn’t bother moving whatever we could out of the lexer into nodes (though we should do that), simply being able to pass raw data from the lexer to the nodes should make building a complete AST possible.

There’s one caveat to this PR. Technically this new `data` property isn’t passing _through_ the parser, just as the old `comments` property isn’t; we compare the location data (start row/column, end row/column) of each column with `data` or `comments` properties with the location data of parser-generated nodes, and the properties are reattached when we find matches. This is only an issue when there are multiple tokens with the same location data, which is rare but does happen; the only example I can find is a generated `JS` token added to the start or end of a file to hold comments, but presumably similar “special case” or generated tokens will also share location data with user-generated ones. For comments, overlapping isn’t an issue; I just combine all the comments together. But for token data, that isn’t an option; but I don’t think it should be an issue, since no “special” tokens should ever have data that needs to be preserved. If I’m wrong about this, we’ll need to patch Jison to truly allow extra data to be passed through the parser. cc @helixbass 