### PR TITLE
Fix #5034: Adjacent JSX elements must be wrapped in an enclosing tag

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -671,13 +671,22 @@
       // A Block node does not return its entire body, rather it
       // ensures that the final expression is returned.
       makeReturn(res) {
-        var expr, len;
+        var csxCheckIndex, expr, j, len, ref1;
         len = this.expressions.length;
         while (len--) {
           expr = this.expressions[len];
           this.expressions[len] = expr.makeReturn(res);
           if (expr instanceof Return && !expr.expression) {
             this.expressions.splice(len, 1);
+          }
+          // We also need to check that we’re not returning a CSX tag if there’s an
+          // adjacent one at the same level; JSX doesn’t allow that.
+          if (expr.unwrapAll().csx) {
+            for (csxCheckIndex = j = ref1 = len; (ref1 <= 0 ? j <= 0 : j >= 0); csxCheckIndex = ref1 <= 0 ? ++j : --j) {
+              if (this.expressions[csxCheckIndex].unwrapAll().csx) {
+                expr.error('Adjacent JSX elements must be wrapped in an enclosing tag');
+              }
+            }
           }
           break;
         }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -482,6 +482,12 @@ exports.Block = class Block extends Base
       expr = @expressions[len]
       @expressions[len] = expr.makeReturn res
       @expressions.splice(len, 1) if expr instanceof Return and not expr.expression
+      # We also need to check that we’re not returning a CSX tag if there’s an
+      # adjacent one at the same level; JSX doesn’t allow that.
+      if expr.unwrapAll().csx
+        for csxCheckIndex in [len..0]
+          if @expressions[csxCheckIndex].unwrapAll().csx
+            expr.error 'Adjacent JSX elements must be wrapped in an enclosing tag'
       break
     this
 

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1662,6 +1662,27 @@ test 'CSX error: invalid attributes', ->
          ^^^^^^^^^^^^^^^^
   '''
 
+test '#5034: CSX error: Adjacent JSX elements must be wrapped in an enclosing tag', ->
+  assertErrorFormat '''
+    render = ->
+      <Row>a</Row>
+      <Row>b</Row>
+  ''', '''
+    [stdin]:3:4: error: Adjacent JSX elements must be wrapped in an enclosing tag
+      <Row>b</Row>
+       ^^^^^^^^^^^
+  '''
+  assertErrorFormat '''
+    render = -> (
+      <Row>a</Row>
+      <Row>b</Row>
+    )
+  ''', '''
+    [stdin]:3:4: error: Adjacent JSX elements must be wrapped in an enclosing tag
+      <Row>b</Row>
+       ^^^^^^^^^^^
+  '''
+
 test 'Bound method called as callback before binding throws runtime error', ->
   class Base
     constructor: ->


### PR DESCRIPTION
```coffee
render = ->
  <Row>a</Row>
  <Row>b</Row>
```
```log
[stdin]:3:4: error: Adjacent JSX elements must be wrapped in an enclosing tag
  <Row>b</Row>
   ^^^^^^^^^^^
```
Not sure why the initial `<` isn’t part of the error highlight, but that’s a separate bug. @xixixao 