### PR TITLE
Allow implicit call with class with no body

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -542,6 +542,8 @@
               // the continuation of an object.
               } else if (inImplicitObject() && tag === 'TERMINATOR' && prevTag !== ',' && !(startsLine && this.looksObjectish(i + 1))) {
                 endImplicitObject();
+              } else if (inImplicitControl() && tokens[stackTop()[1]][0] === 'CLASS' && tag === 'TERMINATOR') {
+                stack.pop();
               } else {
                 break;
               }

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -379,6 +379,8 @@ exports.Rewriter = class Rewriter
           else if inImplicitObject() and tag is 'TERMINATOR' and prevTag isnt ',' and
                   not (startsLine and @looksObjectish(i + 1))
             endImplicitObject()
+          else if inImplicitControl() and tokens[stackTop()[1]][0] is 'CLASS' and tag is 'TERMINATOR'
+            stack.pop()
           else
             break
 

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -908,4 +908,19 @@ test "#5052: implicit call of class with no body", ->
   doesNotThrow -> CoffeeScript.compile 'f class'
   doesNotThrow -> CoffeeScript.compile 'f class A'
   doesNotThrow -> CoffeeScript.compile 'f class A extends B'
-  doesNotThrow -> CoffeeScript.compile 'f class A, b'
+
+  f = (args...) -> args
+  a = 1
+
+  [klass, shouldBeA] = f class A, a
+  eq shouldBeA, a
+
+  [shouldBeA] = f a, class A
+  eq shouldBeA, a
+
+  [obj, klass, shouldBeA] =
+    f
+      b: 1
+      class A
+      a
+  eq shouldBeA, a

--- a/test/function_invocation.coffee
+++ b/test/function_invocation.coffee
@@ -903,3 +903,9 @@ test "#4473: variable scope in chained calls", ->
 
   obj.foo({f} = {f: 1}).bar(-> f = 5)
   eq f, 5
+
+test "#5052: implicit call of class with no body", ->
+  doesNotThrow -> CoffeeScript.compile 'f class'
+  doesNotThrow -> CoffeeScript.compile 'f class A'
+  doesNotThrow -> CoffeeScript.compile 'f class A extends B'
+  doesNotThrow -> CoffeeScript.compile 'f class A, b'


### PR DESCRIPTION
Fixes #5052 

Tweaks `addImplicitBracesAndParens()` to correctly close an inline implicit call which has an argument  that's a class with no body

So now eg `f class A` compiles

The issue was that it was generating the implicit opening `(` but failing to generate the closing `)` at the end of the line since when it saw `class` it pushed a `CONTROL` token that expected to see an `INDENT`-`OUTDENT` pair before unblocking the closing of the implicit call