### PR TITLE
fix JSX expression indentation bug

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1012,7 +1012,7 @@
     // This method allows us to have strings within interpolations within strings,
     // ad infinitum.
     matchWithInterpolations(regex, delimiter, closingDelimiter, interpolators) {
-      var braceInterpolator, close, column, firstToken, index, interpolationOffset, interpolator, lastToken, line, match, nested, offsetInChunk, open, ref, rest, str, strPart, tokens;
+      var braceInterpolator, close, column, firstToken, index, interpolationOffset, interpolator, lastToken, line, match, nested, offsetInChunk, open, ref, ref1, rest, str, strPart, tokens;
       if (closingDelimiter == null) {
         closingDelimiter = delimiter;
       }
@@ -1065,6 +1065,10 @@
         if (((ref = nested[1]) != null ? ref[0] : void 0) === 'TERMINATOR') {
           // Remove leading `'TERMINATOR'` (if any).
           nested.splice(1, 1);
+        }
+        if (((ref1 = nested[nested.length - 3]) != null ? ref1[0] : void 0) === 'INDENT' && nested[nested.length - 2][0] === 'OUTDENT') {
+          // Remove trailing `'INDENT'/'OUTDENT'` pair (if any).
+          nested.splice(-3, 2);
         }
         if (!braceInterpolator) {
           // We are not using `{` and `}`, so wrap the interpolated tokens instead.

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -794,6 +794,8 @@ exports.Lexer = class Lexer
 
       # Remove leading `'TERMINATOR'` (if any).
       nested.splice 1, 1 if nested[1]?[0] is 'TERMINATOR'
+      # Remove trailing `'INDENT'/'OUTDENT'` pair (if any).
+      nested.splice -3, 2 if nested[nested.length - 3]?[0] is 'INDENT' and nested[nested.length - 2][0] is 'OUTDENT'
 
       unless braceInterpolator
         # We are not using `{` and `}`, so wrap the interpolated tokens instead.

--- a/test/csx.coffee
+++ b/test/csx.coffee
@@ -799,3 +799,27 @@ test '#5055: JSX expression indentation bug', ->
       {someCondition && <span />}
     </div>;
   '''
+
+  eqJS '''
+    <div>
+      {someString +
+          "abc"
+      }
+    </div>
+  ''', '''
+    <div>
+      {someString + "abc"}
+    </div>;
+  '''
+
+  eqJS '''
+    <div>
+      {a ?
+      <span />
+      }
+    </div>
+  ''', '''
+    <div>
+      {typeof a !== "undefined" && a !== null ? a : <span />}
+    </div>;
+  '''

--- a/test/csx.coffee
+++ b/test/csx.coffee
@@ -786,3 +786,16 @@ test 'JSX fragments: fragment with component nodes', ->
       </Fragment>;
     };
   '''
+
+test '#5055: JSX expression indentation bug', ->
+  eqJS '''
+    <div>
+      {someCondition &&
+        <span />
+      }
+    </div>
+  ''', '''
+    <div>
+      {someCondition && <span />}
+    </div>;
+  '''

--- a/test/csx.coffee
+++ b/test/csx.coffee
@@ -801,14 +801,12 @@ test '#5055: JSX expression indentation bug', ->
   '''
 
   eqJS '''
-    <div>
-      {someString +
-          "abc"
+    <div>{someString +
+         "abc"
       }
     </div>
   ''', '''
-    <div>
-      {someString + "abc"}
+    <div>{someString + "abc"}
     </div>;
   '''
 


### PR DESCRIPTION
Fixes #5055 

So now eg this compiles:
```
<div>
  {someCondition &&
    <span />
  }
</div>
```

Basically it was choking on the closing empty `INDENT`/`OUTDENT` pair at the end of the parsed tokens inside the nested `{...}` expression

So in `matchWithInterpolations()`, similar to the existing tweaking of `nested` to remove a leading `TERMINATOR`, added a tweaking to remove a closing `INDENT`/`OUTDENT` pair