### PR TITLE
Fix (possible) typo in expressions example (docs).

### DIFF
--- a/documentation/examples/expressions.coffee
+++ b/documentation/examples/expressions.coffee
@@ -6,4 +6,4 @@ grade = (student) ->
   else
     "C"
 
-eldest = if 24 > 21 then "Liz" else "Ike"
+eldest = -> if 24 > 21 then "Liz" else "Ike"


### PR DESCRIPTION
As this example is about functions automatically returning their final value, you probably want this expression to be an actual function.


New output:
![coffee](https://user-images.githubusercontent.com/12675470/44142908-1277b900-a082-11e8-88c5-2cf82f4e41f3.png)
