### PR TITLE
Fix #5103: Add support for BigInt literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - 6
   - 8
   - 10
+  - 12
+  - node # Latest
 
 cache:
   directories:

--- a/Cakefile
+++ b/Cakefile
@@ -446,7 +446,7 @@ runTests = (CoffeeScript) ->
   skipUnless 'var a = 2 ** 2; a **= 3', ['exponentiation.coffee']
   skipUnless 'var {...a} = {}', ['object_rest_spread.coffee']
   skipUnless '/foo.bar/s.test("foo\tbar")', ['regex_dotall.coffee']
-  skipUnless '1n', ['number_bigint.coffee']
+  skipUnless '1n', ['numbers_bigint.coffee']
   files = fs.readdirSync('test').filter (filename) ->
     filename not in testFilesToSkip
 

--- a/Cakefile
+++ b/Cakefile
@@ -446,6 +446,7 @@ runTests = (CoffeeScript) ->
   skipUnless 'var a = 2 ** 2; a **= 3', ['exponentiation.coffee']
   skipUnless 'var {...a} = {}', ['object_rest_spread.coffee']
   skipUnless '/foo.bar/s.test("foo\tbar")', ['regex_dotall.coffee']
+  skipUnless '1n', ['number_bigint.coffee']
   files = fs.readdirSync('test').filter (filename) ->
     filename not in testFilesToSkip
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,8 @@ environment:
     - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '10'
-    - nodejs_version: '' # Installs latest.
+    - nodejs_version: '12'
+    - nodejs_version: '' # Latest
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1198,10 +1198,10 @@ CSX_ATTRIBUTE = /// ^
 ///
 
 NUMBER     = ///
-  ^ 0b[01]+    |              # binary
-  ^ 0o[0-7]+   |              # octal
-  ^ 0x[\da-f]+ |              # hex
-  ^ \d+n       |              # bigint
+  ^ 0b[01]+n?    |            # binary
+  ^ 0o[0-7]+n?   |            # octal
+  ^ 0x[\da-f]+n? |            # hex
+  ^ \d+n         |            # decimal bigint
   ^ \d*\.?\d+ (?:e[+-]?\d+)?  # decimal
 ///i
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1201,7 +1201,7 @@ NUMBER     = ///
   ^ 0b[01]+    |              # binary
   ^ 0o[0-7]+   |              # octal
   ^ 0x[\da-f]+ |              # hex
-  ^ \n+n       |              # bigint
+  ^ \d+n       |              # bigint
   ^ \d*\.?\d+ (?:e[+-]?\d+)?  # decimal
 ///i
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1201,6 +1201,7 @@ NUMBER     = ///
   ^ 0b[01]+    |              # binary
   ^ 0o[0-7]+   |              # octal
   ^ 0x[\da-f]+ |              # hex
+  ^ \n+n       |              # bigint
   ^ \d*\.?\d+ (?:e[+-]?\d+)?  # decimal
 ///i
 

--- a/test/numbers_bigint.coffee
+++ b/test/numbers_bigint.coffee
@@ -10,8 +10,8 @@ test "Parser recognizes decimal BigInt literals", ->
 test "Parser recognizes binary BigInt literals", ->
   eq 42n, 0b101010n
 
-test "Parser recognizes decimal BigInt literals", ->
+test "Parser recognizes octal BigInt literals", ->
   eq 42n, 0o52n
 
-test "Parser recognizes decimal BigInt literals", ->
+test "Parser recognizes hexadecimal BigInt literals", ->
   eq 42n, 0x2an

--- a/test/numbers_bigint.coffee
+++ b/test/numbers_bigint.coffee
@@ -1,0 +1,8 @@
+# BigInt Literals
+# ---------------
+
+test "BigInt exists", ->
+  'object' is typeof BigInt
+
+test "Parser recognizes BigInt literals", ->
+  eq 'bigint', typeof 42n

--- a/test/numbers_bigint.coffee
+++ b/test/numbers_bigint.coffee
@@ -5,7 +5,7 @@ test "BigInt exists", ->
   'object' is typeof BigInt
 
 test "Parser recognizes decimal BigInt literals", ->
-  eq 'bigint', typeof 42n
+  eq 42n, BigInt 42
 
 test "Parser recognizes binary BigInt literals", ->
   eq 42n, 0b101010n

--- a/test/numbers_bigint.coffee
+++ b/test/numbers_bigint.coffee
@@ -4,5 +4,14 @@
 test "BigInt exists", ->
   'object' is typeof BigInt
 
-test "Parser recognizes BigInt literals", ->
+test "Parser recognizes decimal BigInt literals", ->
   eq 'bigint', typeof 42n
+
+test "Parser recognizes binary BigInt literals", ->
+  eq 42n, 0b101010n
+
+test "Parser recognizes decimal BigInt literals", ->
+  eq 42n, 0o52n
+
+test "Parser recognizes decimal BigInt literals", ->
+  eq 42n, 0x2an


### PR DESCRIPTION
* `src/lexer.coffee`
  * Add `/^\d+n/` as valid numeric literal syntax
  * Allow trailing `n` on binary, octal and hex literals
* `test/numbers_bigint.coffee`
  * BigInt exists
  * `42n` equals  `BigInt 42`
  * `42n` equals `0b101010n`
  * `42n` equals `0o52n`
  * `42n` equals `0x2an`
* `Cakefile`
  * skip `test/numbers/bigint.coffee` if `1n` isn't valid and true.

Tested in node v6, v8, v9 and v10.