### PR TITLE
Fix #4609: support new.target

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -202,8 +202,8 @@
       } else if (tag === 'PROPERTY' && prev) {
         if (prev.spaced && (ref7 = prev[0], indexOf.call(CALLABLE, ref7) >= 0) && /^[gs]et$/.test(prev[1]) && this.tokens.length > 1 && ((ref8 = this.tokens[this.tokens.length - 2][0]) !== '.' && ref8 !== '?.' && ref8 !== '@')) {
           this.error(`'${prev[1]}' cannot be used as a keyword, or as a function call without parentheses`, prev[2]);
-        } else if (prev[0] === '.' && this.tokens.length > 1 && this.tokens[this.tokens.length - 2][1] === 'new') {
-          this.tokens[this.tokens.length - 2][0] = 'IDENTIFIER';
+        } else if (prev[0] === '.' && this.tokens.length > 1 && (prevprev = this.tokens[this.tokens.length - 2])[0] === 'UNARY' && prevprev[1] === 'new') {
+          prevprev[0] = 'IDENTIFIER';
         } else if (this.tokens.length > 2) {
           prevprev = this.tokens[this.tokens.length - 2];
           if (((ref9 = prev[0]) === '@' || ref9 === 'THIS') && prevprev && prevprev.spaced && /^[gs]et$/.test(prevprev[1]) && ((ref10 = this.tokens[this.tokens.length - 3][0]) !== '.' && ref10 !== '?.' && ref10 !== '@')) {

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -202,6 +202,8 @@
       } else if (tag === 'PROPERTY' && prev) {
         if (prev.spaced && (ref7 = prev[0], indexOf.call(CALLABLE, ref7) >= 0) && /^[gs]et$/.test(prev[1]) && this.tokens.length > 1 && ((ref8 = this.tokens[this.tokens.length - 2][0]) !== '.' && ref8 !== '?.' && ref8 !== '@')) {
           this.error(`'${prev[1]}' cannot be used as a keyword, or as a function call without parentheses`, prev[2]);
+        } else if (prev[0] === '.' && this.tokens.length > 1 && this.tokens[this.tokens.length - 2][1] === 'new') {
+          this.tokens[this.tokens.length - 2][0] = 'IDENTIFIER';
         } else if (this.tokens.length > 2) {
           prevprev = this.tokens[this.tokens.length - 2];
           if (((ref9 = prev[0]) === '@' || ref9 === 'THIS') && prevprev && prevprev.spaced && /^[gs]et$/.test(prevprev[1]) && ((ref10 = this.tokens[this.tokens.length - 3][0]) !== '.' && ref10 !== '?.' && ref10 !== '@')) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1445,6 +1445,7 @@
       // evaluate anything twice when building the soak chain.
       compileNode(o) {
         var fragments, j, len1, prop, props;
+        this.checkNewTarget(o);
         this.base.front = this.front;
         props = this.properties;
         if (props.length && (this.base.cached != null)) {
@@ -1466,6 +1467,19 @@
           fragments.push(...(prop.compileToFragments(o)));
         }
         return fragments;
+      }
+
+      checkNewTarget(o) {
+        if (!(this.base instanceof IdentifierLiteral && this.base.value === 'new' && this.properties.length)) {
+          return;
+        }
+        if (this.properties[0] instanceof Access && this.properties[0].name.value === 'target') {
+          if (o.scope.parent == null) {
+            return this.error("new.target can only occur inside functions");
+          }
+        } else {
+          return this.error("the only valid meta property for new is new.target");
+        }
       }
 
       // Unfold a soak into an `If`: `a?.b` -> `a.b if a?`

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -196,6 +196,8 @@ exports.Lexer = class Lexer
          @tokens.length > 1 and @tokens[@tokens.length - 2][0] not in ['.', '?.', '@']
         @error "'#{prev[1]}' cannot be used as a keyword, or as a function call
         without parentheses", prev[2]
+      else if prev[0] is '.' and @tokens.length > 1 and @tokens[@tokens.length - 2][1] is 'new'
+        @tokens[@tokens.length - 2][0] = 'IDENTIFIER'
       else if @tokens.length > 2
         prevprev = @tokens[@tokens.length - 2]
         if prev[0] in ['@', 'THIS'] and prevprev and prevprev.spaced and

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -196,8 +196,8 @@ exports.Lexer = class Lexer
          @tokens.length > 1 and @tokens[@tokens.length - 2][0] not in ['.', '?.', '@']
         @error "'#{prev[1]}' cannot be used as a keyword, or as a function call
         without parentheses", prev[2]
-      else if prev[0] is '.' and @tokens.length > 1 and @tokens[@tokens.length - 2][1] is 'new'
-        @tokens[@tokens.length - 2][0] = 'IDENTIFIER'
+      else if prev[0] is '.' and @tokens.length > 1 and (prevprev = @tokens[@tokens.length - 2])[0] is 'UNARY' and prevprev[1] is 'new'
+        prevprev[0] = 'IDENTIFIER'
       else if @tokens.length > 2
         prevprev = @tokens[@tokens.length - 2]
         if prev[0] in ['@', 'THIS'] and prevprev and prevprev.spaced and

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -1900,3 +1900,25 @@ test "#4868: Incorrect ‘Can’t call super with @params’ error", ->
 
   d = new (new D).c
   eq 3, d.a
+
+test "#4609: Support new.target", ->
+  class A
+    constructor: ->
+      @calledAs = new.target.name
+
+  class B extends A
+
+  b = new B
+  eq b.calledAs, 'B'
+
+  newTarget = null
+  Foo = ->
+    newTarget = !!new.target
+
+  Foo()
+  eq newTarget, no
+
+  newTarget = null
+
+  new Foo()
+  eq newTarget, yes

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1907,3 +1907,21 @@ test "#3933: prevent implicit calls when cotrol flow is missing `THEN`", ->
       when a ->
              ^^
   '''
+
+test "`new.target` outside of a function", ->
+  assertErrorFormat '''
+    new.target
+  ''', '''
+    [stdin]:1:1: error: new.target can only occur inside functions
+    new.target
+    ^^^^^^^^^^
+  '''
+
+test "`new.target` is only allowed meta property", ->
+  assertErrorFormat '''
+    -> new.something
+  ''', '''
+    [stdin]:1:4: error: the only valid meta property for new is new.target
+    -> new.something
+       ^^^^^^^^^^^^^
+  '''


### PR DESCRIPTION
Fixes #4609 

Allow `new.target` inside functions/methods

Throw an error if `new.target` is used outside of a function

Throw an error that mimics eg Babel/`espree` if you try to reference a property other than `target` on `new`

@GeoffreyBooth seemed to make sense to target this PR against `master`? Then I'll add AST support separately