### PR TITLE
Fix #5112: A string of `, ` in an array should not be detected as an elision

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2469,10 +2469,10 @@
           return [this.makeCode('[]')];
         }
         o.indent += TAB;
-        fragmentIsElision = function(fragment) {
-          return fragmentsToText(fragment).trim() === ',';
+        fragmentIsElision = function([fragment]) {
+          return fragment.type === 'Elision' && fragment.code.trim() === ',';
         };
-        // Detect if `Elisions` at the beginning of the array are processed (e.g. [, , , a]).
+        // Detect if `Elision`s at the beginning of the array are processed (e.g. [, , , a]).
         passedElision = false;
         answer = [];
         ref1 = this.objects;
@@ -2536,7 +2536,7 @@
             fragment = answer[fragmentIndex];
             if (fragment.isHereComment) {
               fragment.code = `${multident(fragment.code, o.indent, false)}\n${o.indent}`;
-            } else if (fragment.code === ', ' && !(fragment != null ? fragment.isElision : void 0)) {
+            } else if (fragment.code === ', ' && !(fragment != null ? fragment.isElision : void 0) && fragment.type !== 'StringLiteral') {
               fragment.code = `,\n${o.indent}`;
             }
           }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1644,8 +1644,9 @@ exports.Arr = class Arr extends Base
   compileNode: (o) ->
     return [@makeCode '[]'] unless @objects.length
     o.indent += TAB
-    fragmentIsElision = (fragment) -> fragmentsToText(fragment).trim() is ','
-    # Detect if `Elisions` at the beginning of the array are processed (e.g. [, , , a]).
+    fragmentIsElision = ([ fragment ]) ->
+      fragment.type is 'Elision' and fragment.code.trim() is ','
+    # Detect if `Elision`s at the beginning of the array are processed (e.g. [, , , a]).
     passedElision = no
 
     answer = []
@@ -1687,7 +1688,7 @@ exports.Arr = class Arr extends Base
       for fragment, fragmentIndex in answer
         if fragment.isHereComment
           fragment.code = "#{multident(fragment.code, o.indent, no)}\n#{o.indent}"
-        else if fragment.code is ', ' and not fragment?.isElision
+        else if fragment.code is ', ' and not fragment?.isElision and fragment.type isnt 'StringLiteral'
           fragment.code = ",\n#{o.indent}"
       answer.unshift @makeCode "[\n#{o.indent}"
       answer.push @makeCode "\n#{@tab}]"

--- a/test/arrays.coffee
+++ b/test/arrays.coffee
@@ -115,6 +115,12 @@ test "array elisions nested destructuring", ->
   deepEqual d, {x:2}
   arrayEq w, [1,2,4]
 
+test "#5112: array elisions not detected inside strings", ->
+  arr = [
+    str: ", #{3}"
+  ]
+  eq arr[0].str, ', 3'
+
 # Splats in Array Literals
 
 test "array splat expansions with assignments", ->


### PR DESCRIPTION
Fix #5112: A string of `, ` in an array should not be detected as an elision