### PR TITLE
implement coffeescript.registerCompiled method

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -4,7 +4,7 @@
   // on Node.js/V8, or to run CoffeeScript directly in the browser. This module
   // contains the main entry functions for tokenizing, parsing, and compiling
   // source CoffeeScript into JavaScript.
-  var FILE_EXTENSIONS, Lexer, SourceMap, base64encode, checkShebangLine, compile, formatSourcePosition, getSourceMap, helpers, lexer, packageJson, parser, sourceMaps, sources, withPrettyErrors,
+  var FILE_EXTENSIONS, Lexer, SourceMap, addSource, base64encode, checkShebangLine, compile, formatSourcePosition, getSourceMap, helpers, lexer, packageJson, parser, sourceMaps, sources, withPrettyErrors,
     indexOf = [].indexOf;
 
   ({Lexer} = require('./lexer'));
@@ -74,6 +74,18 @@
   // Also save source maps if generated, in form of `(source)`: [`(source map)`].
   sourceMaps = {};
 
+  // This is exported to enable an external module to implement caching of
+  // compilation results. When the compiled js source is loaded from cache, the
+  // original coffee code should be added with this method in order to enable the
+  // Error.prepareStackTrace below to correctly adjust the stack trace for the
+  // corresponding file (the source map will be generated on demand).
+  exports._addSource = addSource = function(filename, code) {
+    if (sources[filename] == null) {
+      sources[filename] = [];
+    }
+    return sources[filename].push(code);
+  };
+
   // Compile CoffeeScript code to JavaScript, using the Coffee/Jison compiler.
 
   // If `options.sourceMap` is specified, then `options.filename` must also be
@@ -94,10 +106,7 @@
     generateSourceMap = options.sourceMap || options.inlineMap || (options.filename == null);
     filename = options.filename || '<anonymous>';
     checkShebangLine(filename, code);
-    if (sources[filename] == null) {
-      sources[filename] = [];
-    }
-    sources[filename].push(code);
+    addSource(filename, code);
     if (generateSourceMap) {
       map = new SourceMap;
     }

--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -79,7 +79,7 @@
   // original coffee code should be added with this method in order to enable the
   // Error.prepareStackTrace below to correctly adjust the stack trace for the
   // corresponding file (the source map will be generated on demand).
-  exports.registerCompiled = registerCompiled = function(filename, source, output, sourcemap) {
+  exports.registerCompiled = registerCompiled = function(filename, source, sourcemap) {
     if (sources[filename] == null) {
       sources[filename] = [];
     }
@@ -206,7 +206,7 @@
       sourceURL = `//# sourceURL=${(ref1 = options.filename) != null ? ref1 : 'coffeescript'}`;
       js = `${js}\n${sourceMapDataURI}\n${sourceURL}`;
     }
-    registerCompiled(filename, code, js, map);
+    registerCompiled(filename, code, map);
     if (options.sourceMap) {
       return {
         js,

--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -4,7 +4,7 @@
   // on Node.js/V8, or to run CoffeeScript directly in the browser. This module
   // contains the main entry functions for tokenizing, parsing, and compiling
   // source CoffeeScript into JavaScript.
-  var FILE_EXTENSIONS, Lexer, SourceMap, addSource, base64encode, checkShebangLine, compile, formatSourcePosition, getSourceMap, helpers, lexer, packageJson, parser, sourceMaps, sources, withPrettyErrors,
+  var FILE_EXTENSIONS, Lexer, SourceMap, base64encode, checkShebangLine, compile, formatSourcePosition, getSourceMap, helpers, lexer, packageJson, parser, registerCompiled, sourceMaps, sources, withPrettyErrors,
     indexOf = [].indexOf;
 
   ({Lexer} = require('./lexer'));
@@ -79,11 +79,17 @@
   // original coffee code should be added with this method in order to enable the
   // Error.prepareStackTrace below to correctly adjust the stack trace for the
   // corresponding file (the source map will be generated on demand).
-  exports._addSource = addSource = function(filename, code) {
+  exports.registerCompiled = registerCompiled = function(filename, source, output, sourcemap) {
     if (sources[filename] == null) {
       sources[filename] = [];
     }
-    return sources[filename].push(code);
+    sources[filename].push(source);
+    if (sourcemap != null) {
+      if (sourceMaps[filename] == null) {
+        sourceMaps[filename] = [];
+      }
+      return sourceMaps[filename].push(sourcemap);
+    }
   };
 
   // Compile CoffeeScript code to JavaScript, using the Coffee/Jison compiler.
@@ -106,7 +112,6 @@
     generateSourceMap = options.sourceMap || options.inlineMap || (options.filename == null);
     filename = options.filename || '<anonymous>';
     checkShebangLine(filename, code);
-    addSource(filename, code);
     if (generateSourceMap) {
       map = new SourceMap;
     }
@@ -171,10 +176,6 @@
     }
     if (generateSourceMap) {
       v3SourceMap = map.generate(options, code);
-      if (sourceMaps[filename] == null) {
-        sourceMaps[filename] = [];
-      }
-      sourceMaps[filename].push(map);
     }
     if (options.transpile) {
       if (typeof options.transpile !== 'object') {
@@ -205,6 +206,7 @@
       sourceURL = `//# sourceURL=${(ref1 = options.filename) != null ? ref1 : 'coffeescript'}`;
       js = `${js}\n${sourceMapDataURI}\n${sourceURL}`;
     }
+    registerCompiled(filename, code, js, map);
     if (options.sourceMap) {
       return {
         js,

--- a/lib/coffeescript/index.js
+++ b/lib/coffeescript/index.js
@@ -152,9 +152,8 @@
     }
   }
 
-  CoffeeScript._compileFile = function(filename, options = {}) {
-    var answer, err, raw, stripped;
-    raw = fs.readFileSync(filename, 'utf8');
+  CoffeeScript._compileRawFileContent = function(raw, filename, options = {}) {
+    var answer, err, stripped;
     // Strip the Unicode byte order mark, if this file begins with one.
     stripped = raw.charCodeAt(0) === 0xFEFF ? raw.substring(1) : raw;
     options = Object.assign({}, options, {
@@ -173,6 +172,12 @@
       throw helpers.updateSyntaxError(err, stripped, filename);
     }
     return answer;
+  };
+
+  CoffeeScript._compileFile = function(filename, options = {}) {
+    var raw;
+    raw = fs.readFileSync(filename, 'utf8');
+    return CoffeeScript._compileRawFileContent(raw, filename, options);
   };
 
   module.exports = CoffeeScript;

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -54,6 +54,16 @@ sources = {}
 # Also save source maps if generated, in form of `(source)`: [`(source map)`].
 sourceMaps = {}
 
+# This is exported to enable an external module to implement caching of
+# compilation results. When the compiled js source is loaded from cache, the
+# original coffee code should be added with this method in order to enable the
+# Error.prepareStackTrace below to correctly adjust the stack trace for the
+# corresponding file (the source map will be generated on demand).
+exports._addSource = addSource = (filename, code) ->
+
+  sources[filename] ?= []
+  sources[filename].push code
+
 # Compile CoffeeScript code to JavaScript, using the Coffee/Jison compiler.
 #
 # If `options.sourceMap` is specified, then `options.filename` must also be
@@ -74,9 +84,8 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
   filename = options.filename or '<anonymous>'
 
   checkShebangLine filename, code
+  addSource filename, code
 
-  sources[filename] ?= []
-  sources[filename].push code
   map = new SourceMap if generateSourceMap
 
   tokens = lexer.tokenize code, options

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -59,10 +59,14 @@ sourceMaps = {}
 # original coffee code should be added with this method in order to enable the
 # Error.prepareStackTrace below to correctly adjust the stack trace for the
 # corresponding file (the source map will be generated on demand).
-exports._addSource = addSource = (filename, code) ->
+exports.registerCompiled = registerCompiled = (filename, source, output, sourcemap) ->
 
   sources[filename] ?= []
-  sources[filename].push code
+  sources[filename].push source
+
+  if sourcemap?
+    sourceMaps[filename] ?= []
+    sourceMaps[filename].push sourcemap
 
 # Compile CoffeeScript code to JavaScript, using the Coffee/Jison compiler.
 #
@@ -84,7 +88,6 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
   filename = options.filename or '<anonymous>'
 
   checkShebangLine filename, code
-  addSource filename, code
 
   map = new SourceMap if generateSourceMap
 
@@ -135,8 +138,6 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
 
   if generateSourceMap
     v3SourceMap = map.generate options, code
-    sourceMaps[filename] ?= []
-    sourceMaps[filename].push map
 
   if options.transpile
     if typeof options.transpile isnt 'object'
@@ -166,6 +167,8 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
     sourceMapDataURI = "//# sourceMappingURL=data:application/json;base64,#{encoded}"
     sourceURL = "//# sourceURL=#{options.filename ? 'coffeescript'}"
     js = "#{js}\n#{sourceMapDataURI}\n#{sourceURL}"
+
+  registerCompiled filename, code, js, map
 
   if options.sourceMap
     {

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -59,7 +59,7 @@ sourceMaps = {}
 # original coffee code should be added with this method in order to enable the
 # Error.prepareStackTrace below to correctly adjust the stack trace for the
 # corresponding file (the source map will be generated on demand).
-exports.registerCompiled = registerCompiled = (filename, source, output, sourcemap) ->
+exports.registerCompiled = registerCompiled = (filename, source, sourcemap) ->
 
   sources[filename] ?= []
   sources[filename].push source
@@ -168,7 +168,7 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
     sourceURL = "//# sourceURL=#{options.filename ? 'coffeescript'}"
     js = "#{js}\n#{sourceMapDataURI}\n#{sourceURL}"
 
-  registerCompiled filename, code, js, map
+  registerCompiled filename, code, map
 
   if options.sourceMap
     {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -110,8 +110,8 @@ if require.extensions
       Use CoffeeScript.register() or require the coffeescript/register module to require #{ext} files.
       """
 
-CoffeeScript._compileFile = (filename, options = {}) ->
-  raw = fs.readFileSync filename, 'utf8'
+CoffeeScript._compileRawFileContent = (raw, filename, options = {}) ->
+
   # Strip the Unicode byte order mark, if this file begins with one.
   stripped = if raw.charCodeAt(0) is 0xFEFF then raw.substring 1 else raw
 
@@ -130,5 +130,10 @@ CoffeeScript._compileFile = (filename, options = {}) ->
     throw helpers.updateSyntaxError err, stripped, filename
 
   answer
+
+CoffeeScript._compileFile = (filename, options = {}) ->
+  raw = fs.readFileSync filename, 'utf8'
+
+  CoffeeScript._compileRawFileContent raw, filename, options
 
 module.exports = CoffeeScript


### PR DESCRIPTION
This method enables an external module to implement caching of
compilation results. When the compiled js source is loaded from cache,
the original coffee code should be added with this method in order to
enable the Error.prepareStackTrace below to correctly adjust the stack
trace for the corresponding file (the source map will be generated on
demand).

This is the minimal solution proposed in https://github.com/jashkenas/coffeescript/issues/5122

I have not added any new tests since the code path is already covered by existing tests (the method was created by extracting existing in-line code into a function).

I have not marked this PR as closing the above issue since I would still be inclined to implement the caching internally if anyone is interested. 