### PR TITLE
JSX fragment/attribute AST

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1990,7 +1990,7 @@
       }
 
       compileNode(o) {
-        var attr, attrProps, fragments, j, len1, obj, ref1, ref2, tag;
+        var attr, fragments, j, len1, obj, ref1, ref2, tag;
         this.attributes.base.csx = true;
         if ((ref1 = this.content) != null) {
           ref1.base.csx = true;
@@ -2001,14 +2001,10 @@
           ref2 = this.attributes.base.objects;
           for (j = 0, len1 = ref2.length; j < len1; j++) {
             obj = ref2[j];
+            this.checkValidAttribute(obj);
             attr = obj.base;
-            attrProps = (attr != null ? attr.properties : void 0) || [];
-            // Catch invalid CSX attributes: <div {a:"b", props} {props} "value" />
-            if (!(attr instanceof Obj || attr instanceof IdentifierLiteral) || (attr instanceof Obj && !attr.generated && (attrProps.length > 1 || !(attrProps[0] instanceof Splat)))) {
-              obj.error("Unexpected token. Allowed CSX attributes are: id=\"val\", src={source}, {props...} or attribute.");
-            }
-            if (obj.base instanceof Obj) {
-              obj.base.csx = true;
+            if (attr instanceof Obj) {
+              attr.csx = true;
             }
             fragments.push(this.makeCode(' '));
             fragments.push(...obj.compileToFragments(o, LEVEL_PAREN));
@@ -2024,6 +2020,22 @@
         return fragments;
       }
 
+      // Catch invalid attributes: <div {a:"b", props} {props} "value" />
+      checkValidAttribute(object) {
+        var attribute, properties;
+        ({
+          base: attribute
+        } = object);
+        properties = (attribute != null ? attribute.properties : void 0) || [];
+        if (!(attribute instanceof Obj || attribute instanceof IdentifierLiteral) || (attribute instanceof Obj && !attribute.generated && (properties.length > 1 || !(properties[0] instanceof Splat)))) {
+          return object.error("Unexpected token. Allowed CSX attributes are: id=\"val\", src={source}, {props...} or attribute.");
+        }
+      }
+
+      isFragment() {
+        return !this.tagName.base.value.length;
+      }
+
       ast() {
         var tagName;
         // The location data spanning the opening element < ... > is captured by
@@ -2037,10 +2049,6 @@
         return super.ast();
       }
 
-      isFragment() {
-        return !this.tagName.base.value.length;
-      }
-
       astType() {
         if (this.isFragment()) {
           return 'JSXFragment';
@@ -2049,13 +2057,40 @@
         }
       }
 
+      getAttributeAst(object) {
+        var ast, attribute;
+        this.checkValidAttribute(object);
+        ({
+          base: attribute
+        } = object);
+        attribute.csx = true;
+        ast = attribute.ast();
+        if (!(attribute instanceof IdentifierLiteral)) {
+          return ast;
+        }
+        return Object.assign({
+          type: 'JSXAttribute',
+          name: ast,
+          value: null
+        }, attribute.astLocationData());
+      }
+
       elementAstProperties() {
-        var closingElement, currentExpr, openingElement, rangeDiff, shiftAstLocationData;
+        var closingElement, currentExpr, object, openingElement, rangeDiff, shiftAstLocationData;
         openingElement = Object.assign({
           type: 'JSXOpeningElement',
           name: this.tagName.unwrap().ast(),
           selfClosing: this.closingElementLocationData == null,
-          attributes: []
+          attributes: flatten((function() {
+            var j, len1, ref1, results;
+            ref1 = this.attributes.base.objects;
+            results = [];
+            for (j = 0, len1 = ref1.length; j < len1; j++) {
+              object = ref1[j];
+              results.push(this.getAttributeAst(object));
+            }
+            return results;
+          }).call(this))
         }, this.openingElementLocationData);
         closingElement = null;
         if (this.closingElementLocationData != null) {
@@ -3026,6 +3061,33 @@
           }
         }
         return results;
+      }
+
+      CSXAttributesToAst() {
+        var propertiesAst, property;
+        propertiesAst = (function() {
+          var j, len1, ref1, results;
+          ref1 = this.properties;
+          results = [];
+          for (j = 0, len1 = ref1.length; j < len1; j++) {
+            property = ref1[j];
+            property.csx = true;
+            results.push(property.ast());
+          }
+          return results;
+        }).call(this);
+        if (!(this.properties.length === 1 && this.properties[0] instanceof Splat)) {
+          return propertiesAst;
+        }
+        // Include surrounding `{` and `}` of spread prop `{...b}` in location data.
+        return Object.assign(propertiesAst[0], this.astLocationData());
+      }
+
+      ast() {
+        if (this.csx) {
+          return this.CSXAttributesToAst();
+        }
+        return super.ast();
       }
 
       astType() {
@@ -4591,6 +4653,38 @@
         return this.variable.base.propagateLhs(true);
       }
 
+      getCSXAttributeValueAst() {
+        var ast, value;
+        value = this.value.base;
+        value.csxAttribute = true;
+        ast = value.ast();
+        if (value instanceof StringLiteral) {
+          return ast;
+        }
+        return Object.assign({
+          type: 'JSXExpressionContainer',
+          expression: ast
+        }, value.astLocationData());
+      }
+
+      CSXAttributeToAst() {
+        return Object.assign({
+          type: 'JSXAttribute',
+          name: Object.assign({
+            type: 'JSXIdentifier',
+            name: this.variable.base.value
+          }, this.variable.base.astLocationData()),
+          value: this.getCSXAttributeValueAst()
+        }, this.astLocationData());
+      }
+
+      ast() {
+        if (this.csx) {
+          return this.CSXAttributeToAst();
+        }
+        return super.ast();
+      }
+
       astType() {
         if (this.isDefaultAssignment()) {
           return 'AssignmentPattern';
@@ -5261,7 +5355,9 @@
       }
 
       astType() {
-        if (this.lhs) {
+        if (this.csx) {
+          return 'JSXSpreadAttribute';
+        } else if (this.lhs) {
           return 'RestElement';
         } else {
           return 'SpreadElement';

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2037,11 +2037,19 @@
         return super.ast();
       }
 
-      astType() {
-        return 'JSXElement';
+      isFragment() {
+        return !this.tagName.base.value.length;
       }
 
-      astProperties() {
+      astType() {
+        if (this.isFragment()) {
+          return 'JSXFragment';
+        } else {
+          return 'JSXElement';
+        }
+      }
+
+      elementAstProperties() {
         var closingElement, currentExpr, openingElement, rangeDiff, shiftAstLocationData;
         openingElement = Object.assign({
           type: 'JSXOpeningElement',
@@ -2081,21 +2089,26 @@
             shiftAstLocationData(currentExpr);
           }
         }
-        return {
-          openingElement,
-          closingElement,
-          children: []
-        };
+        return {openingElement, closingElement};
       }
 
-      // TODO: uncomment when adding support for JSX content AST
-      // if content and not content.base.isEmpty?()
-      //   content.base.csx = yes
-      //   compact flatten [
-      //     content.ast()
-      //   ]
-      // else
-      //   []
+      fragmentAstProperties() {
+        var closingFragment, openingFragment;
+        openingFragment = Object.assign({
+          type: 'JSXOpeningFragment'
+        }, this.openingElementLocationData);
+        closingFragment = Object.assign({
+          type: 'JSXClosingFragment'
+        }, this.closingElementLocationData);
+        return {openingFragment, closingFragment};
+      }
+
+      astProperties() {
+        return Object.assign(this.isFragment() ? this.fragmentAstProperties() : this.elementAstProperties(), {
+          children: []
+        });
+      }
+
       astLocationData() {
         if (this.closingElementLocationData != null) {
           return mergeAstLocationData(this.openingElementLocationData, this.closingElementLocationData);

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4,7 +4,7 @@
   // nodes are created as the result of actions in the [grammar](grammar.html),
   // but some are created by other nodes as a method of code generation. To convert
   // the syntax tree into a string of JavaScript code, call `compile()` on the root.
-  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXElement, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, DefaultLiteral, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, ObjectProperty, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, greater, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, jisonLocationDataToAstLocationData, lesser, locationDataToString, makeDelimitedLiteral, merge, mergeAstLocationData, mergeLocationData, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
+  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXAttribute, CSXAttributes, CSXElement, CSXExpressionContainer, CSXIdentifier, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, DefaultLiteral, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, ObjectProperty, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, attachCommentsToNode, compact, del, dump, ends, extend, flatten, fragmentsToText, greater, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, jisonLocationDataToAstLocationData, lesser, locationDataToString, makeDelimitedLiteral, merge, mergeAstLocationData, mergeLocationData, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
     indexOf = [].indexOf,
     splice = [].splice,
     slice1 = [].slice;
@@ -1975,49 +1975,126 @@
 
   };
 
-  //### Call
-  exports.CSXElement = CSXElement = (function() {
-    class CSXElement extends Base {
-      constructor({
-          tagName: tagName1,
-          attributes,
-          content
-        }) {
+  //### CSX
+  exports.CSXIdentifier = CSXIdentifier = class CSXIdentifier extends IdentifierLiteral {
+    astType() {
+      return 'JSXIdentifier';
+    }
+
+  };
+
+  exports.CSXExpressionContainer = CSXExpressionContainer = (function() {
+    class CSXExpressionContainer extends Base {
+      constructor(expression1) {
         super();
-        this.tagName = tagName1;
-        this.attributes = attributes;
-        this.content = content;
+        this.expression = expression1;
+        this.expression.csxAttribute = true;
+        this.locationData = this.expression.locationData;
       }
 
       compileNode(o) {
-        var attr, fragments, j, len1, obj, ref1, ref2, tag;
-        this.attributes.base.csx = true;
-        if ((ref1 = this.content) != null) {
-          ref1.base.csx = true;
+        return this.expression.compileNode(o);
+      }
+
+      astType() {
+        return 'JSXExpressionContainer';
+      }
+
+      astProperties() {
+        return {
+          expression: this.expression.ast()
+        };
+      }
+
+    };
+
+    CSXExpressionContainer.prototype.children = ['expression'];
+
+    return CSXExpressionContainer;
+
+  }).call(this);
+
+  exports.CSXAttribute = CSXAttribute = (function() {
+    class CSXAttribute extends Base {
+      constructor({
+          name: name1,
+          value
+        }) {
+        super();
+        this.name = name1;
+        this.value = value != null ? (value = value.base, value instanceof StringLiteral ? value : new CSXExpressionContainer(value)) : null;
+      }
+
+      compileNode(o) {
+        var compiledName, val;
+        compiledName = this.name.compileToFragments(o, LEVEL_LIST);
+        if (this.value == null) {
+          return compiledName;
         }
-        fragments = [this.makeCode('<')];
-        fragments.push(...(tag = this.tagName.compileToFragments(o, LEVEL_ACCESS)));
-        if (this.attributes.base instanceof Arr) {
-          ref2 = this.attributes.base.objects;
-          for (j = 0, len1 = ref2.length; j < len1; j++) {
-            obj = ref2[j];
-            this.checkValidAttribute(obj);
-            attr = obj.base;
-            if (attr instanceof Obj) {
-              attr.csx = true;
+        val = this.value.compileToFragments(o, LEVEL_LIST);
+        return compiledName.concat(this.makeCode('='), val);
+      }
+
+      astType() {
+        return 'JSXAttribute';
+      }
+
+      astProperties() {
+        var ref1, ref2;
+        return {
+          name: this.name.ast(),
+          value: (ref1 = (ref2 = this.value) != null ? ref2.ast() : void 0) != null ? ref1 : null
+        };
+      }
+
+    };
+
+    CSXAttribute.prototype.children = ['name', 'value'];
+
+    return CSXAttribute;
+
+  }).call(this);
+
+  exports.CSXAttributes = CSXAttributes = (function() {
+    class CSXAttributes extends Base {
+      constructor(arr) {
+        var attribute, base, j, k, len1, len2, object, property, ref1, ref2, value, variable;
+        super();
+        this.attributes = [];
+        ref1 = arr.objects;
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          object = ref1[j];
+          this.checkValidAttribute(object);
+          ({base} = object);
+          if (base instanceof IdentifierLiteral) {
+            // attribute with no value eg disabled
+            attribute = new CSXAttribute({
+              name: new CSXIdentifier(base.value).withLocationDataFrom(base)
+            });
+            attribute.locationData = base.locationData;
+            this.attributes.push(attribute);
+          } else if (!base.generated) {
+            // object spread attribute eg {...props}
+            attribute = base.properties[0];
+            attribute.csx = true;
+            attribute.locationData = base.locationData;
+            this.attributes.push(attribute);
+          } else {
+            ref2 = base.properties;
+            // Obj containing attributes with values eg a="b" c={d}
+            for (k = 0, len2 = ref2.length; k < len2; k++) {
+              property = ref2[k];
+              ({variable, value} = property);
+              attribute = new CSXAttribute({
+                name: new CSXIdentifier(variable.base.value).withLocationDataFrom(variable.base),
+                value
+              });
+              attribute.locationData = property.locationData;
+              this.attributes.push(attribute);
             }
-            fragments.push(this.makeCode(' '));
-            fragments.push(...obj.compileToFragments(o, LEVEL_PAREN));
           }
         }
-        if (this.content) {
-          fragments.push(this.makeCode('>'));
-          fragments.push(...this.content.compileNode(o, LEVEL_LIST));
-          fragments.push(...[this.makeCode('</'), ...tag, this.makeCode('>')]);
-        } else {
-          fragments.push(this.makeCode(' />'));
-        }
-        return fragments;
+        this.locationData = arr.locationData;
       }
 
       // Catch invalid attributes: <div {a:"b", props} {props} "value" />
@@ -2032,6 +2109,69 @@
         }
       }
 
+      compileNode(o) {
+        var attribute, fragments, j, len1, ref1;
+        fragments = [];
+        ref1 = this.attributes;
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          attribute = ref1[j];
+          fragments.push(this.makeCode(' '));
+          fragments.push(...attribute.compileToFragments(o, LEVEL_TOP));
+        }
+        return fragments;
+      }
+
+      ast() {
+        var attribute, j, len1, ref1, results;
+        ref1 = this.attributes;
+        results = [];
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          attribute = ref1[j];
+          results.push(attribute.ast());
+        }
+        return results;
+      }
+
+    };
+
+    CSXAttributes.prototype.children = ['attributes'];
+
+    return CSXAttributes;
+
+  }).call(this);
+
+  // Node for a CSX element
+  exports.CSXElement = CSXElement = (function() {
+    class CSXElement extends Base {
+      constructor({
+          tagName: tagName1,
+          attributes,
+          content
+        }) {
+        super();
+        this.tagName = tagName1;
+        this.attributes = attributes;
+        this.content = content;
+      }
+
+      compileNode(o) {
+        var fragments, ref1, tag;
+        if ((ref1 = this.content) != null) {
+          ref1.base.csx = true;
+        }
+        fragments = [this.makeCode('<')];
+        fragments.push(...(tag = this.tagName.compileToFragments(o, LEVEL_ACCESS)));
+        fragments.push(...this.attributes.compileToFragments(o));
+        if (this.content) {
+          fragments.push(this.makeCode('>'));
+          fragments.push(...this.content.compileNode(o, LEVEL_LIST));
+          fragments.push(...[this.makeCode('</'), ...tag, this.makeCode('>')]);
+        } else {
+          fragments.push(this.makeCode(' />'));
+        }
+        return fragments;
+      }
+
       isFragment() {
         return !this.tagName.base.value.length;
       }
@@ -2040,7 +2180,7 @@
         var tagName;
         // The location data spanning the opening element < ... > is captured by
         // the generated Arr which contains the element's attributes
-        this.openingElementLocationData = jisonLocationDataToAstLocationData(this.attributes.base.locationData);
+        this.openingElementLocationData = jisonLocationDataToAstLocationData(this.attributes.locationData);
         tagName = this.tagName.base;
         tagName.locationData = tagName.tagNameLocationData;
         if (this.content != null) {
@@ -2057,40 +2197,13 @@
         }
       }
 
-      getAttributeAst(object) {
-        var ast, attribute;
-        this.checkValidAttribute(object);
-        ({
-          base: attribute
-        } = object);
-        attribute.csx = true;
-        ast = attribute.ast();
-        if (!(attribute instanceof IdentifierLiteral)) {
-          return ast;
-        }
-        return Object.assign({
-          type: 'JSXAttribute',
-          name: ast,
-          value: null
-        }, attribute.astLocationData());
-      }
-
       elementAstProperties() {
-        var closingElement, currentExpr, object, openingElement, rangeDiff, shiftAstLocationData;
+        var closingElement, currentExpr, openingElement, rangeDiff, shiftAstLocationData;
         openingElement = Object.assign({
           type: 'JSXOpeningElement',
           name: this.tagName.unwrap().ast(),
           selfClosing: this.closingElementLocationData == null,
-          attributes: flatten((function() {
-            var j, len1, ref1, results;
-            ref1 = this.attributes.base.objects;
-            results = [];
-            for (j = 0, len1 = ref1.length; j < len1; j++) {
-              object = ref1[j];
-              results.push(this.getAttributeAst(object));
-            }
-            return results;
-          }).call(this))
+          attributes: this.attributes.ast()
         }, this.openingElementLocationData);
         closingElement = null;
         if (this.closingElementLocationData != null) {
@@ -2160,6 +2273,8 @@
 
   }).call(this);
 
+  //### Call
+
   // Node for a function invocation.
   exports.Call = Call = (function() {
     class Call extends Base {
@@ -2178,7 +2293,7 @@
         if (this.variable.base instanceof CSXTag) {
           return new CSXElement({
             tagName: this.variable,
-            attributes: this.args[0],
+            attributes: new CSXAttributes(this.args[0].base),
             content: this.args[1]
           });
         }
@@ -2865,10 +2980,6 @@
         }
         idt = o.indent += TAB;
         lastNode = this.lastNode(this.properties);
-        if (this.csx) {
-          // CSX attributes <div id="val" attr={aaa} {props...} />
-          return this.compileCSXAttributes(o);
-        }
         // If this object is the left-hand side of an assignment, all its children
         // are too.
         this.propagateLhs();
@@ -2965,27 +3076,6 @@
         return results;
       }
 
-      compileCSXAttributes(o) {
-        var answer, i, j, join, len1, prop, props;
-        props = this.properties;
-        answer = [];
-        for (i = j = 0, len1 = props.length; j < len1; i = ++j) {
-          prop = props[i];
-          prop.csx = true;
-          join = i === props.length - 1 ? '' : ' ';
-          if (prop instanceof Splat) {
-            prop = new Literal(`{${prop.compile(o)}}`);
-          }
-          answer.push(...prop.compileToFragments(o, LEVEL_TOP));
-          answer.push(this.makeCode(join));
-        }
-        if (this.front) {
-          return this.wrapInParentheses(answer);
-        } else {
-          return answer;
-        }
-      }
-
       // Convert “bare” properties to `ObjectProperty`s (or `Splat`s).
       expandProperty(property) {
         var context, key, operatorToken, variable;
@@ -3061,33 +3151,6 @@
           }
         }
         return results;
-      }
-
-      CSXAttributesToAst() {
-        var propertiesAst, property;
-        propertiesAst = (function() {
-          var j, len1, ref1, results;
-          ref1 = this.properties;
-          results = [];
-          for (j = 0, len1 = ref1.length; j < len1; j++) {
-            property = ref1[j];
-            property.csx = true;
-            results.push(property.ast());
-          }
-          return results;
-        }).call(this);
-        if (!(this.properties.length === 1 && this.properties[0] instanceof Splat)) {
-          return propertiesAst;
-        }
-        // Include surrounding `{` and `}` of spread prop `{...b}` in location data.
-        return Object.assign(propertiesAst[0], this.astLocationData());
-      }
-
-      ast() {
-        if (this.csx) {
-          return this.CSXAttributesToAst();
-        }
-        return super.ast();
       }
 
       astType() {
@@ -4266,9 +4329,6 @@
             }
           }
         }
-        if (this.csx) {
-          this.value.base.csxAttribute = true;
-        }
         val = this.value.compileToFragments(o, LEVEL_LIST);
         compiledName = this.variable.compileToFragments(o, LEVEL_LIST);
         if (this.context === 'object') {
@@ -4276,7 +4336,7 @@
             compiledName.unshift(this.makeCode('['));
             compiledName.push(this.makeCode(']'));
           }
-          return compiledName.concat(this.makeCode(this.csx ? '=' : ': '), val);
+          return compiledName.concat(this.makeCode(': '), val);
         }
         answer = compiledName.concat(this.makeCode(` ${this.context || '='} `), val);
         // Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Assignment_without_declaration,
@@ -4651,38 +4711,6 @@
         // know that, so that those nodes know that they’re assignable as
         // destructured variables.
         return this.variable.base.propagateLhs(true);
-      }
-
-      getCSXAttributeValueAst() {
-        var ast, value;
-        value = this.value.base;
-        value.csxAttribute = true;
-        ast = value.ast();
-        if (value instanceof StringLiteral) {
-          return ast;
-        }
-        return Object.assign({
-          type: 'JSXExpressionContainer',
-          expression: ast
-        }, value.astLocationData());
-      }
-
-      CSXAttributeToAst() {
-        return Object.assign({
-          type: 'JSXAttribute',
-          name: Object.assign({
-            type: 'JSXIdentifier',
-            name: this.variable.base.value
-          }, this.variable.base.astLocationData()),
-          value: this.getCSXAttributeValueAst()
-        }, this.astLocationData());
-      }
-
-      ast() {
-        if (this.csx) {
-          return this.CSXAttributeToAst();
-        }
-        return super.ast();
       }
 
       astType() {
@@ -5347,7 +5375,12 @@
       }
 
       compileNode(o) {
-        return [this.makeCode('...'), ...this.name.compileToFragments(o, LEVEL_OP)];
+        var compiledSplat;
+        compiledSplat = [this.makeCode('...'), ...this.name.compileToFragments(o, LEVEL_OP)];
+        if (!this.csx) {
+          return compiledSplat;
+        }
+        return [this.makeCode('{'), ...compiledSplat, this.makeCode('}')];
       }
 
       unwrap() {
@@ -7105,6 +7138,10 @@
       start: range[0],
       end: range[1]
     };
+  };
+
+  dump = function(obj) {
+    return console.log(require('util').inspect(obj, false, null));
   };
 
 }).call(this);

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4,7 +4,7 @@
   // nodes are created as the result of actions in the [grammar](grammar.html),
   // but some are created by other nodes as a method of code generation. To convert
   // the syntax tree into a string of JavaScript code, call `compile()` on the root.
-  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXAttribute, CSXAttributes, CSXElement, CSXExpressionContainer, CSXIdentifier, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, DefaultLiteral, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, ObjectProperty, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, attachCommentsToNode, compact, del, dump, ends, extend, flatten, fragmentsToText, greater, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, jisonLocationDataToAstLocationData, lesser, locationDataToString, makeDelimitedLiteral, merge, mergeAstLocationData, mergeLocationData, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
+  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, CSXAttribute, CSXAttributes, CSXElement, CSXExpressionContainer, CSXIdentifier, CSXTag, Call, Class, Code, CodeFragment, ComputedPropertyName, DefaultLiteral, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, ObjectProperty, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, greater, hasLineComments, indentInitial, isFunction, isLiteralArguments, isLiteralThis, isNumber, isPlainObject, isUnassignable, jisonLocationDataToAstLocationData, lesser, locationDataToString, makeDelimitedLiteral, merge, mergeAstLocationData, mergeLocationData, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility,
     indexOf = [].indexOf,
     splice = [].splice,
     slice1 = [].slice;
@@ -492,6 +492,17 @@
       // Add location data from another node
       withLocationDataFrom({locationData}) {
         return this.updateLocationDataIfMissing(locationData);
+      }
+
+      // Add location data and comments from another node
+      withLocationDataAndCommentsFrom(node) {
+        var comments;
+        this.withLocationDataFrom(node);
+        ({comments} = node);
+        if (comments != null ? comments.length : void 0) {
+          this.comments = comments;
+        }
+        return this;
       }
 
       // Throw a SyntaxError associated with this node’s location.
@@ -2020,9 +2031,13 @@
           name: name1,
           value
         }) {
+        var ref1;
         super();
         this.name = name1;
         this.value = value != null ? (value = value.base, value instanceof StringLiteral ? value : new CSXExpressionContainer(value)) : null;
+        if ((ref1 = this.value) != null) {
+          ref1.comments = value.comments;
+        }
       }
 
       compileNode(o) {
@@ -2069,7 +2084,7 @@
           if (base instanceof IdentifierLiteral) {
             // attribute with no value eg disabled
             attribute = new CSXAttribute({
-              name: new CSXIdentifier(base.value).withLocationDataFrom(base)
+              name: new CSXIdentifier(base.value).withLocationDataAndCommentsFrom(base)
             });
             attribute.locationData = base.locationData;
             this.attributes.push(attribute);
@@ -2086,7 +2101,7 @@
               property = ref2[k];
               ({variable, value} = property);
               attribute = new CSXAttribute({
-                name: new CSXIdentifier(variable.base.value).withLocationDataFrom(variable.base),
+                name: new CSXIdentifier(variable.base.value).withLocationDataAndCommentsFrom(variable.base),
                 value
               });
               attribute.locationData = property.locationData;
@@ -7138,10 +7153,6 @@
       start: range[0],
       end: range[1]
     };
-  };
-
-  dump = function(obj) {
-    return console.log(require('util').inspect(obj, false, null));
   };
 
 }).call(this);

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -397,6 +397,13 @@ exports.Base = class Base
   withLocationDataFrom: ({locationData}) ->
     @updateLocationDataIfMissing locationData
 
+  # Add location data and comments from another node
+  withLocationDataAndCommentsFrom: (node) ->
+    @withLocationDataFrom node
+    {comments} = node
+    @comments = comments if comments?.length
+    this
+
   # Throw a SyntaxError associated with this node’s location.
   error: (message) ->
     throwSyntaxError message, @locationData
@@ -1347,6 +1354,7 @@ exports.CSXAttribute = class CSXAttribute extends Base
           new CSXExpressionContainer value
       else
         null
+    @value?.comments = value.comments
 
   children: ['name', 'value']
 
@@ -1372,7 +1380,7 @@ exports.CSXAttributes = class CSXAttributes extends Base
       {base} = object
       if base instanceof IdentifierLiteral
         # attribute with no value eg disabled
-        attribute = new CSXAttribute name: new CSXIdentifier(base.value).withLocationDataFrom base
+        attribute = new CSXAttribute name: new CSXIdentifier(base.value).withLocationDataAndCommentsFrom base
         attribute.locationData = base.locationData
         @attributes.push attribute
       else if not base.generated
@@ -1386,7 +1394,7 @@ exports.CSXAttributes = class CSXAttributes extends Base
         for property in base.properties
           {variable, value} = property
           attribute = new CSXAttribute {
-            name: new CSXIdentifier(variable.base.value).withLocationDataFrom variable.base
+            name: new CSXIdentifier(variable.base.value).withLocationDataAndCommentsFrom variable.base
             value
           }
           attribute.locationData = property.locationData
@@ -4741,4 +4749,3 @@ jisonLocationDataToAstLocationData = ({first_line, first_column, last_line, last
     ]
     start: range[0]
     end:   range[1]
-dump = (obj) -> console.log require('util').inspect obj, no, null

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1360,10 +1360,16 @@ exports.CSXElement = class CSXElement extends Base
 
     super()
 
-  astType: ->
-    'JSXElement'
+  isFragment: ->
+    !@tagName.base.value.length
 
-  astProperties: ->
+  astType: ->
+    if @isFragment()
+      'JSXFragment'
+    else
+      'JSXElement'
+
+  elementAstProperties: ->
     openingElement = Object.assign {
       type: 'JSXOpeningElement'
       name: @tagName.unwrap().ast()
@@ -1402,18 +1408,28 @@ exports.CSXElement = class CSXElement extends Base
           currentExpr = currentExpr.object
         shiftAstLocationData currentExpr
 
-    return {
-      openingElement, closingElement
+    {openingElement, closingElement}
+
+  fragmentAstProperties: ->
+    openingFragment = Object.assign {
+      type: 'JSXOpeningFragment'
+    }, @openingElementLocationData
+
+    closingFragment = Object.assign {
+      type: 'JSXClosingFragment'
+    }, @closingElementLocationData
+
+    {openingFragment, closingFragment}
+
+  astProperties: ->
+    Object.assign(
+      if @isFragment()
+        @fragmentAstProperties()
+      else
+        @elementAstProperties()
+    ,
       children: []
-        # TODO: uncomment when adding support for JSX content AST
-        # if content and not content.base.isEmpty?()
-        #   content.base.csx = yes
-        #   compact flatten [
-        #     content.ast()
-        #   ]
-        # else
-        #   []
-    }
+    )
 
   astLocationData: ->
     if @closingElementLocationData?

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -249,6 +249,59 @@ test "AST as expected for CSXTag node", ->
       type: 'JSXClosingFragment'
     children: []
 
+  testExpression '<div a b="c" d={e} {...f} />',
+    type: 'JSXElement'
+    openingElement:
+      type: 'JSXOpeningElement'
+      name:
+        type: 'JSXIdentifier'
+        name: 'div'
+      attributes: [
+        type: 'JSXAttribute'
+        name:
+          type: 'JSXIdentifier'
+          name: 'a'
+      ,
+        type: 'JSXAttribute'
+        name:
+          type: 'JSXIdentifier'
+          name: 'b'
+        value:
+          type: 'StringLiteral'
+          value: 'c'
+      ,
+        type: 'JSXAttribute'
+        name:
+          type: 'JSXIdentifier'
+          name: 'd'
+        value:
+          type: 'JSXExpressionContainer'
+          expression:
+            type: 'Identifier'
+            name: 'e'
+      ,
+        type: 'JSXSpreadAttribute'
+        argument:
+          type: 'Identifier'
+          name: 'f'
+        postfix: no
+      ]
+      selfClosing: yes
+    closingElement: null
+    children: []
+
+  testExpression '<div {f...} />',
+    type: 'JSXElement'
+    openingElement:
+      type: 'JSXOpeningElement'
+      attributes: [
+        type: 'JSXSpreadAttribute'
+        argument:
+          type: 'Identifier'
+          name: 'f'
+        postfix: yes
+      ]
+
 # test "AST as expected for PropertyName node", ->
 #   testExpression 'Object.assign',
 #     properties: [

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -241,6 +241,14 @@ test "AST as expected for CSXTag node", ->
           name: 'Here'
     children: []
 
+  testExpression '<></>',
+    type: 'JSXFragment'
+    openingFragment:
+      type: 'JSXOpeningFragment'
+    closingFragment:
+      type: 'JSXClosingFragment'
+    children: []
+
 # test "AST as expected for PropertyName node", ->
 #   testExpression 'Object.assign',
 #     properties: [

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -2472,3 +2472,194 @@ test "AST location Data as expected for CSXTag node", ->
       end:
         line: 1
         column: 5
+
+  testAstLocationData '''
+    <div
+      a
+      b="c"
+      d={e}
+      {...f}
+    />
+  ''',
+    type: 'JSXElement'
+    openingElement:
+      name:
+        start: 1
+        end: 4
+        range: [1, 4]
+        loc:
+          start:
+            line: 1
+            column: 1
+          end:
+            line: 1
+            column: 4
+      attributes: [
+        name:
+          start: 7
+          end: 8
+          range: [7, 8]
+          loc:
+            start:
+              line: 2
+              column: 2
+            end:
+              line: 2
+              column: 3
+        start: 7
+        end: 8
+        range: [7, 8]
+        loc:
+          start:
+            line: 2
+            column: 2
+          end:
+            line: 2
+            column: 3
+      ,
+        name:
+          start: 11
+          end: 12
+          range: [11, 12]
+          loc:
+            start:
+              line: 3
+              column: 2
+            end:
+              line: 3
+              column: 3
+        value:
+          start: 13
+          end: 16
+          range: [13, 16]
+          loc:
+            start:
+              line: 3
+              column: 4
+            end:
+              line: 3
+              column: 7
+        start: 11
+        end: 16
+        range: [11, 16]
+        loc:
+          start:
+            line: 3
+            column: 2
+          end:
+            line: 3
+            column: 7
+      ,
+        name:
+          start: 19
+          end: 20
+          range: [19, 20]
+          loc:
+            start:
+              line: 4
+              column: 2
+            end:
+              line: 4
+              column: 3
+        value:
+          expression:
+            start: 22
+            end: 23
+            range: [22, 23]
+            loc:
+              start:
+                line: 4
+                column: 5
+              end:
+                line: 4
+                column: 6
+          start: 21
+          end: 24
+          range: [21, 24]
+          loc:
+            start:
+              line: 4
+              column: 4
+            end:
+              line: 4
+              column: 7
+        start: 19
+        end: 24
+        range: [19, 24]
+        loc:
+          start:
+            line: 4
+            column: 2
+          end:
+            line: 4
+            column: 7
+      ,
+        argument:
+          start: 31
+          end: 32
+          range: [31, 32]
+          loc:
+            start:
+              line: 5
+              column: 6
+            end:
+              line: 5
+              column: 7
+        start: 27
+        end: 33
+        range: [27, 33]
+        loc:
+          start:
+            line: 5
+            column: 2
+          end:
+            line: 5
+            column: 8
+      ]
+      start: 0
+      end: 36
+      range: [0, 36]
+      loc:
+        start:
+          line: 1
+          column: 0
+        end:
+          line: 6
+          column: 2
+    start: 0
+    end: 36
+    range: [0, 36]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 6
+        column: 2
+
+  testAstLocationData '<div {f...} />',
+    type: 'JSXElement'
+    openingElement:
+      attributes: [
+        argument:
+          start: 6
+          end: 7
+          range: [6, 7]
+          loc:
+            start:
+              line: 1
+              column: 6
+            end:
+              line: 1
+              column: 7
+        start: 5
+        end: 11
+        range: [5, 11]
+        loc:
+          start:
+            line: 1
+            column: 5
+          end:
+            line: 1
+            column: 11
+      ]

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -2438,3 +2438,37 @@ test "AST location Data as expected for CSXTag node", ->
         line: 1
         column: 31
 
+  testAstLocationData '<></>',
+    type: 'JSXFragment'
+    openingFragment:
+      start: 0
+      end: 2
+      range: [0, 2]
+      loc:
+        start:
+          line: 1
+          column: 0
+        end:
+          line: 1
+          column: 2
+    closingFragment:
+      start: 2
+      end: 5
+      range: [2, 5]
+      loc:
+        start:
+          line: 1
+          column: 2
+        end:
+          line: 1
+          column: 5
+    start: 0
+    end: 5
+    range: [0, 5]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 5

--- a/test/csx.coffee
+++ b/test/csx.coffee
@@ -58,8 +58,8 @@ test 'object attribute', ->
     <div x={{y: 42}} />
   ''', '''
     <div x={{
-        y: 42
-      }} />;
+      y: 42
+    }} />;
   '''
 
 test 'attribute without value', ->
@@ -230,9 +230,9 @@ test 'nested CSX within an attribute, with object attr value', ->
   ''', '''
     <Company>
       <Person name={<NameComponent attr3={{
-          'a': {},
-          b: '{'
-        }} />} />
+      'a': {},
+      b: '{'
+    }} />} />
     </Company>;
   '''
 
@@ -241,11 +241,11 @@ test 'complex nesting', ->
     <div code={someFunc({a:{b:{}, C:'}{}{'}})} />
   ''', '''
     <div code={someFunc({
-        a: {
-          b: {},
-          C: '}{}{'
-        }
-      })} />;
+      a: {
+        b: {},
+        C: '}{}{'
+      }
+    })} />;
   '''
 
 test 'multiline tag with nested CSX within an attribute', ->
@@ -456,10 +456,10 @@ test 'tag with {{}}', ->
     <Person name={{value: item, key, item}} />
   ''', '''
     <Person name={{
-        value: item,
-        key,
-        item
-      }} />;
+      value: item,
+      key,
+      item
+    }} />;
   '''
 
 test 'tag with namespace', ->
@@ -545,11 +545,11 @@ test 'complex multiline spread attribute', ->
   ''', '''
     <Component {...y} a={b} {...x} b="c" {...z}>
       <div code={someFunc({
-        a: {
-          b: {},
-          C: '}'
-        }
-      })} />
+      a: {
+        b: {},
+        C: '}'
+      }
+    })} />
     </Component>;
   '''
 

--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -1623,42 +1623,42 @@ test "CSX error: ambiguous tag-like expression", ->
   '''
 
 test 'CSX error: invalid attributes', ->
-  assertErrorFormat '''
+  assertErrorFormatAst '''
     <div a="b" {props} />
   ''', '''
     [stdin]:1:12: error: Unexpected token. Allowed CSX attributes are: id="val", src={source}, {props...} or attribute.
     <div a="b" {props} />
                ^^^^^^^
   '''
-  assertErrorFormat '''
+  assertErrorFormatAst '''
     <div a={b} {a:{b}} />
   ''', '''
     [stdin]:1:12: error: Unexpected token. Allowed CSX attributes are: id="val", src={source}, {props...} or attribute.
     <div a={b} {a:{b}} />
                ^^^^^^^
   '''
-  assertErrorFormat '''
+  assertErrorFormatAst '''
     <div {"#{a}"} />
   ''', '''
     [stdin]:1:6: error: Unexpected token. Allowed CSX attributes are: id="val", src={source}, {props...} or attribute.
     <div {"#{a}"} />
          ^^^^^^^^
   '''
-  assertErrorFormat '''
+  assertErrorFormatAst '''
     <div props... />
   ''', '''
     [stdin]:1:11: error: Unexpected token. Allowed CSX attributes are: id="val", src={source}, {props...} or attribute.
     <div props... />
               ^^^
   '''
-  assertErrorFormat '''
+  assertErrorFormatAst '''
     <div {a:"b", props..., c:d()} />
   ''', '''
     [stdin]:1:6: error: Unexpected token. Allowed CSX attributes are: id="val", src={source}, {props...} or attribute.
     <div {a:"b", props..., c:d()} />
          ^^^^^^^^^^^^^^^^^^^^^^^^
   '''
-  assertErrorFormat '''
+  assertErrorFormatAst '''
     <div {props..., a, b} />
   ''', '''
     [stdin]:1:6: error: Unexpected token. Allowed CSX attributes are: id="val", src={source}, {props...} or attribute.


### PR DESCRIPTION
@GeoffreyBooth PR for JSX fragments (eg `<></>`) and attributes (eg `<div a="b" c={d} {...e} />`)

So the only other remaining JSX piece is JSX content, which I can address once we've introduced ASTs for string interpolations

Based on `jsx-element-ast`, [here](https://github.com/helixbass/copheescript/compare/jsx-element-ast...jsx-fragment-ast) is the diff against that branch