### PR TITLE
Remove extra word in comment in src/nodes.coffee

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -207,7 +207,7 @@ exports.Base = class Base
 
   # Occasionally it may be useful to make an expression behave as if it was 'hoisted', whereby the
   # result of the expression is available before its location in the source, but the expression's
-  # variable scope corresponds the source position. This is used extensively to deal with executable
+  # variable scope corresponds to the source position. This is used extensively to deal with executable
   # class bodies in classes.
   #
   # Calling this method mutates the node, proxying the `compileNode` and `compileToFragments`


### PR DESCRIPTION
Just a correction to a comment to add the "___to___" near the end of this sentence:

> Occasionally it may be useful to make an expression behave as if it was 'hoisted', whereby the result of the expression is available before its location in the source, but the expression's variable scope corresponds ___to___ the source position.