### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -747,7 +747,7 @@ cubes = (function() {
 </code></pre>
 </blockquote><p>This will make the <code>coffee</code> and <code>cake</code> commands available globally.</p>
 <p>When you need CoffeeScript as a dependency of a project, within that project’s folder you can install it locally:</p>
-<blockquote class="uneditable-code-block"><pre><code class="language-bash">npm install --save coffeescript
+<blockquote class="uneditable-code-block"><pre><code class="language-bash">npm install coffeescript
 </code></pre>
 </blockquote><p>The <code>coffee</code> and <code>cake</code> commands will first look in the current folder to see if CoffeeScript is installed locally, and use that version if so. This allows different versions of CoffeeScript to be installed globally and locally.</p>
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines:
https://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](https://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->

"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358