### PR TITLE
AST: Preserve infinity literal

### DIFF
--- a/lib/coffeescript/grammar.js
+++ b/lib/coffeescript/grammar.js
@@ -291,7 +291,10 @@
       }),
       o('INFINITY',
       function() {
-        return new InfinityLiteral($1);
+        return new InfinityLiteral($1.toString(),
+      {
+          originalValue: $1.original
+        });
       }),
       o('NAN',
       function() {

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -284,7 +284,7 @@
     // Matches numbers, including decimals, hex, and exponential notation.
     // Be careful not to interfere with ranges in progress.
     numberToken() {
-      var lexedLength, match, number, parsedValue, tag;
+      var lexedLength, match, number, parsedValue, tag, tokenData;
       if (!(match = NUMBER.exec(this.chunk))) {
         return 0;
       }
@@ -312,10 +312,14 @@
           });
       }
       parsedValue = Number(number);
+      tokenData = {parsedValue};
       tag = Number.isFinite(parsedValue) ? 'NUMBER' : 'INFINITY';
+      if (tag === 'INFINITY') {
+        tokenData.original = number;
+      }
       this.token(tag, number, {
         length: lexedLength,
-        data: {parsedValue}
+        data: tokenData
       });
       return lexedLength;
     }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1232,8 +1232,21 @@
   };
 
   exports.InfinityLiteral = InfinityLiteral = class InfinityLiteral extends NumberLiteral {
+    constructor(value1, {originalValue: originalValue = 'Infinity'} = {}) {
+      super();
+      this.value = value1;
+      this.originalValue = originalValue;
+    }
+
     compileNode() {
       return [this.makeCode('2e308')];
+    }
+
+    ast(o, level) {
+      if (this.originalValue !== 'Infinity') {
+        return new NumberLiteral(this.value).withLocationDataFrom(this).ast(o, level);
+      }
+      return super.ast(o, level);
     }
 
     astType() {

--- a/lib/coffeescript/parser.js
+++ b/lib/coffeescript/parser.js
@@ -219,7 +219,10 @@ this.$ = yy.addDataToNode(yy, _$[$0], $$[$0], _$[$0], $$[$0], true)(new yy.Boole
         }));
 break;
 case 58:
-this.$ = yy.addDataToNode(yy, _$[$0], $$[$0], _$[$0], $$[$0], true)(new yy.InfinityLiteral($$[$0]));
+this.$ = yy.addDataToNode(yy, _$[$0], $$[$0], _$[$0], $$[$0], true)(new yy.InfinityLiteral($$[$0].toString(),
+      {
+          originalValue: $$[$0].original
+        }));
 break;
 case 59:
 this.$ = yy.addDataToNode(yy, _$[$0], $$[$0], _$[$0], $$[$0], true)(new yy.NaNLiteral($$[$0]));

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -214,7 +214,7 @@ grammar =
     o 'UNDEFINED',                              -> new UndefinedLiteral $1
     o 'NULL',                                   -> new NullLiteral $1
     o 'BOOL',                                   -> new BooleanLiteral $1.toString(), originalValue: $1.original
-    o 'INFINITY',                               -> new InfinityLiteral $1
+    o 'INFINITY',                               -> new InfinityLiteral $1.toString(), originalValue: $1.original
     o 'NAN',                                    -> new NaNLiteral $1
   ]
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -261,11 +261,14 @@ exports.Lexer = class Lexer
         @error "octal literal '#{number}' must be prefixed with '0o'", length: lexedLength
 
     parsedValue = Number number
+    tokenData = {parsedValue}
 
     tag = if Number.isFinite(parsedValue) then 'NUMBER' else 'INFINITY'
+    if tag is 'INFINITY'
+      tokenData.original = number
     @token tag, number,
       length: lexedLength
-      data: {parsedValue}
+      data: tokenData
     lexedLength
 
   # Matches strings, including multiline strings, as well as heredocs, with or without

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -871,8 +871,16 @@ exports.NumberLiteral = class NumberLiteral extends Literal
         raw: @value
 
 exports.InfinityLiteral = class InfinityLiteral extends NumberLiteral
+  constructor: (@value, {@originalValue = 'Infinity'} = {}) ->
+    super()
+
   compileNode: ->
     [@makeCode '2e308']
+
+  ast: (o, level) ->
+    unless @originalValue is 'Infinity'
+      return new NumberLiteral(@value).withLocationDataFrom(@).ast o, level
+    super o, level
 
   astType: -> 'Identifier'
 

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -147,6 +147,13 @@ test "AST as expected for InfinityLiteral node", ->
     type: 'Identifier'
     name: 'Infinity'
 
+  testExpression '2e308',
+    type: 'NumericLiteral'
+    value: Infinity
+    extra:
+      raw: '2e308'
+      rawValue: Infinity
+
 test "AST as expected for NaNLiteral node", ->
   testExpression 'NaN',
     type: 'Identifier'

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -154,6 +154,19 @@ test "AST location data as expected for InfinityLiteral node", ->
         line: 1
         column: 8
 
+  testAstLocationData '2e308',
+    type: 'NumericLiteral'
+    start: 0
+    end: 5
+    range: [0, 5]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 5
+
 test "AST location data as expected for NaNLiteral node", ->
   testAstLocationData 'NaN',
     type: 'Identifier'


### PR DESCRIPTION
@GeoffreyBooth here's another one I came across working on the Prettier plugin

We need to be able to distinguish `2e308` from `Infinity` when generating AST (both become `InfinityLiteral`s). So used the typical technique for passing the original value as token data through the grammar