### PR TITLE
Index AST refinement: compilation level

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2020,15 +2020,16 @@
       // becomes the `property`, and the preceding properties (e.g. `a.b`) become
       // a child `Value` node assigned to the `object` property.
       astProperties(o) {
-        var property, ref1, ref2;
+        var computed, property, ref1, ref2;
         ref1 = this.properties, [property] = slice1.call(ref1, -1);
         if (this.isCSXTag()) {
           property.name.csx = true;
         }
+        computed = property instanceof Index || !(((ref2 = property.name) != null ? ref2.unwrap() : void 0) instanceof PropertyName);
         return {
           object: this.object().ast(o, LEVEL_ACCESS),
-          property: property.ast(o),
-          computed: property instanceof Index || !(((ref2 = property.name) != null ? ref2.unwrap() : void 0) instanceof PropertyName),
+          property: property.ast(o, (computed ? LEVEL_PAREN : void 0)),
+          computed,
           optional: !!property.soak,
           shorthand: !!property.shorthand
         };

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1362,12 +1362,14 @@ exports.Value = class Value extends Base
   astProperties: (o) ->
     [..., property] = @properties
     property.name.csx = yes if @isCSXTag()
-    return
+    computed = property instanceof Index or property.name?.unwrap() not instanceof PropertyName
+    return {
       object: @object().ast o, LEVEL_ACCESS
-      property: property.ast o
-      computed: property instanceof Index or property.name?.unwrap() not instanceof PropertyName
+      property: property.ast o, (LEVEL_PAREN if computed)
+      computed
       optional: !!property.soak
       shorthand: !!property.shorthand
+    }
 
   astLocationData: ->
     return super() unless @isCSXTag()

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -838,6 +838,17 @@ test "AST as expected for Index node", ->
     optional: no
     shorthand: no
 
+  testExpression 'a[if b then c]',
+    type: 'MemberExpression'
+    object: ID 'a'
+    property:
+      type: 'ConditionalExpression'
+      test: ID 'b'
+      consequent: ID 'c'
+    computed: yes
+    optional: no
+    shorthand: no
+
 test "AST as expected for Range node", ->
   testExpression '[x..y]',
     type: 'Range'


### PR DESCRIPTION
@GeoffreyBooth I ran into an inconsistency with the way `Index` ASTs were being generated while working on the Prettier plugin

Basically, the "compilation" level needed to be explicitly set when generating AST corresponding to `Index` nodes