### PR TITLE
AST: JSX empty expression

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2512,7 +2512,7 @@
       }
 
       contentAst(o) {
-        var base1, child, children, content, element, expression, j, len1, results, unwrapped;
+        var base1, child, children, content, element, emptyExpression, expression, j, len1, results, unwrapped;
         if (!(this.content && !(typeof (base1 = this.content.base).isEmpty === "function" ? base1.isEmpty() : void 0))) {
           return [];
         }
@@ -2533,7 +2533,25 @@
               } else {
                 ({expression} = element);
                 if (expression == null) {
-                  results.push(new JSXEmptyExpression().withLocationDataFrom(element));
+                  emptyExpression = new JSXEmptyExpression();
+                  // We don’t currently have a token corresponding to the empty space
+                  // between the JSX expression braces, so piece together the location
+                  // data by trimming the braces from the Interpolation’s location data.
+                  // Technically the last_line/last_column calculation here could be
+                  // incorrect if the ending brace is preceded by a newline, but
+                  // last_line/last_column aren’t used for AST generation anyway.
+                  emptyExpression.locationData = {
+                    first_line: element.locationData.first_line,
+                    first_column: element.locationData.first_column + 1,
+                    last_line: element.locationData.last_line,
+                    last_column: element.locationData.last_column - 1,
+                    last_line_exclusive: element.locationData.last_line,
+                    last_column_exclusive: element.locationData.last_column,
+                    range: [element.locationData.range[0] + 1, element.locationData.range[1] - 1]
+                  };
+                  results.push(new JSXExpressionContainer(emptyExpression, {
+                    locationData: element.locationData
+                  }));
                 } else {
                   unwrapped = expression.unwrapAll();
                   if (unwrapped instanceof JSXElement) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1718,7 +1718,25 @@ exports.JSXElement = class JSXElement extends Base
           else # Interpolation
             {expression} = element
             unless expression?
-              new JSXEmptyExpression().withLocationDataFrom element
+              emptyExpression = new JSXEmptyExpression()
+              # We don’t currently have a token corresponding to the empty space
+              # between the JSX expression braces, so piece together the location
+              # data by trimming the braces from the Interpolation’s location data.
+              # Technically the last_line/last_column calculation here could be
+              # incorrect if the ending brace is preceded by a newline, but
+              # last_line/last_column aren’t used for AST generation anyway.
+              emptyExpression.locationData =
+                first_line:            element.locationData.first_line
+                first_column:          element.locationData.first_column + 1
+                last_line:             element.locationData.last_line
+                last_column:           element.locationData.last_column - 1
+                last_line_exclusive:   element.locationData.last_line
+                last_column_exclusive: element.locationData.last_column
+                range: [
+                  element.locationData.range[0] + 1
+                  element.locationData.range[1] - 1
+                ]
+              new JSXExpressionContainer emptyExpression, locationData: element.locationData
             else
               unwrapped = expression.unwrapAll()
               if unwrapped instanceof JSXElement

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -425,7 +425,9 @@ test "AST as expected for JSXTag node", ->
         raw: 'abc'
       value: 'abc'
     ,
-      type: 'JSXEmptyExpression'
+      type: 'JSXExpressionContainer'
+      expression:
+        type: 'JSXEmptyExpression'
     ]
 
 # test "AST as expected for PropertyName node", ->

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -2996,6 +2996,17 @@ test "AST location data as expected for JSXTag node", ->
           line: 1
           column: 5
     ,
+      expression:
+        start: 6
+        end: 6
+        range: [6, 6]
+        loc:
+          start:
+            line: 1
+            column: 6
+          end:
+            line: 1
+            column: 6
       start: 5
       end: 7
       range: [5, 7]


### PR DESCRIPTION
@GeoffreyBooth in merging the latest `ast` into my branch and updating the Prettier plugin to use that dependency, I found that the AST structure being generated for JSX empty expressions (`{}`) was incorrect

Instead of a `JSXEmptyExpression` node *replacing* the typical `JSXExpressionContainer` node, it actually needs to be *nested inside* a `JSXExpressionContainer` node

So this PR updates the AST generated for JSX empty expressions to correctly match Babel AST