### PR TITLE
AST: JSX element as expression

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2554,7 +2554,8 @@
                   }));
                 } else {
                   unwrapped = expression.unwrapAll();
-                  if (unwrapped instanceof JSXElement) {
+                  // distinguish `<a><b /></a>` from `<a>{<b />}</a>`
+                  if (unwrapped instanceof JSXElement && unwrapped.locationData.range[0] === element.locationData.range[0]) {
                     results.push(unwrapped);
                   } else {
                     results.push(new JSXExpressionContainer(unwrapped, {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1739,7 +1739,9 @@ exports.JSXElement = class JSXElement extends Base
               new JSXExpressionContainer emptyExpression, locationData: element.locationData
             else
               unwrapped = expression.unwrapAll()
-              if unwrapped instanceof JSXElement
+              if unwrapped instanceof JSXElement and
+                  # distinguish `<a><b /></a>` from `<a>{<b />}</a>`
+                  unwrapped.locationData.range[0] is element.locationData.range[0]
                 unwrapped
               else
                 new JSXExpressionContainer unwrapped, locationData: element.locationData

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -430,6 +430,36 @@ test "AST as expected for JSXTag node", ->
         type: 'JSXEmptyExpression'
     ]
 
+  testExpression '''
+    <a>{<b />}</a>
+  ''',
+    type: 'JSXElement'
+    openingElement:
+      type: 'JSXOpeningElement'
+      name:
+        type: 'JSXIdentifier'
+        name: 'a'
+      attributes: []
+      selfClosing: no
+    closingElement:
+      type: 'JSXClosingElement'
+      name:
+        type: 'JSXIdentifier'
+        name: 'a'
+    children: [
+      type: 'JSXExpressionContainer'
+      expression:
+        type: 'JSXElement'
+        openingElement:
+          type: 'JSXOpeningElement'
+          name:
+            type: 'JSXIdentifier'
+            name: 'b'
+          selfClosing: true
+        closingElement: null
+        children: []
+    ]
+
 # test "AST as expected for PropertyName node", ->
 #   testExpression 'Object.assign',
 #     properties: [

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -3029,6 +3029,44 @@ test "AST location data as expected for JSXTag node", ->
         line: 1
         column: 10
 
+  testAstLocationData '''
+    <a>{<b />}</a>
+  ''',
+    type: 'JSXElement'
+    children: [
+      expression:
+        start: 4
+        end: 9
+        range: [4, 9]
+        loc:
+          start:
+            line: 1
+            column: 4
+          end:
+            line: 1
+            column: 9
+      start: 3
+      end: 10
+      range: [3, 10]
+      loc:
+        start:
+          line: 1
+          column: 3
+        end:
+          line: 1
+          column: 10
+    ]
+    start: 0
+    end: 14
+    range: [0, 14]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 14
+
 test "AST as expected for Try node", ->
   testAstLocationData 'try cappuccino',
     type: 'TryStatement'


### PR DESCRIPTION
@GeoffreyBooth here's another case I realized wasn't being distinguished by the existing logic for JSX content:

Even though it's unnecessary to do so, you could have a JSX element explicitly wrapped in a JSX expression (`{`/`}`). Eg typically you'd write
```
<a><b /></a>
```
but you could write
```
<a>{<b />}</a>
```
and the AST should be different (the second should have a `JSXExpressionContainer` wrapping the nested `JSXElement`)

This PR covers that case