### PR TITLE
Preserve environment when calling coffee from test

### DIFF
--- a/test/invocation_argument_parsing.coffee
+++ b/test/invocation_argument_parsing.coffee
@@ -11,7 +11,7 @@ coffeeCommand = if isWindows() then 'node coffee' else 'coffee'
 spawnOptions =
   cwd: coffeeBinFolder
   encoding: 'utf8'
-  env:
+  env: Object.assign {}, process.env,
     PATH: coffeeBinFolder + (if isWindows() then ';' else ':') + process.env.PATH
   shell: isWindows()
 


### PR DESCRIPTION
This change spawns `coffee` with a new PATH, but without removing all other environment variables.  This is useful for preserving environment needed by Node, for example, `LD_LIBRARY_PATH` on Unix.  In particular, fix #5179.