### PR TITLE
Object property AST refinement: compilation level

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3575,10 +3575,10 @@
     astProperties(o) {
       var isComputedPropertyName, keyAst, ref1, ref2;
       isComputedPropertyName = this.key instanceof Value && this.key.base instanceof ComputedPropertyName;
-      keyAst = this.key.ast(o);
+      keyAst = this.key.ast(o, LEVEL_LIST);
       return {
         key: keyAst,
-        value: (ref1 = (ref2 = this.value) != null ? ref2.ast(o) : void 0) != null ? ref1 : keyAst,
+        value: (ref1 = (ref2 = this.value) != null ? ref2.ast(o, LEVEL_LIST) : void 0) != null ? ref1 : keyAst,
         shorthand: !!this.shorthand,
         computed: !!isComputedPropertyName,
         method: false

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2416,11 +2416,11 @@ exports.ObjectProperty = class ObjectProperty extends Base
 
   astProperties: (o) ->
     isComputedPropertyName = @key instanceof Value and @key.base instanceof ComputedPropertyName
-    keyAst = @key.ast o
+    keyAst = @key.ast o, LEVEL_LIST
 
     return
       key: keyAst
-      value: @value?.ast(o) ? keyAst
+      value: @value?.ast(o, LEVEL_LIST) ? keyAst
       shorthand: !!@shorthand
       computed: !!isComputedPropertyName
       method: no

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1245,6 +1245,36 @@ test "AST as expected for Obj node", ->
     ]
     implicit: yes
 
+  testExpression '''
+    a:
+      if b then c
+  ''',
+    type: 'ObjectExpression'
+    properties: [
+      type: 'ObjectProperty'
+      key: ID 'a'
+      value:
+        type: 'ConditionalExpression'
+        test: ID 'b'
+        consequent: ID 'c'
+    ]
+    implicit: yes
+
+  testExpression '''
+    a:
+      c if b
+  ''',
+    type: 'ObjectExpression'
+    properties: [
+      type: 'ObjectProperty'
+      key: ID 'a'
+      value:
+        type: 'ConditionalExpression'
+        test: ID 'b'
+        consequent: ID 'c'
+    ]
+    implicit: yes
+
 #   # TODO: Test destructuring.
 
 #   # console.log JSON.stringify expression, ["type", "generated", "lhs", "value", "properties", "variable"], 2


### PR DESCRIPTION
@GeoffreyBooth I ran into a missing compilation level when generating AST for `ObjectProperty` (similar to eg #5184)

So this explicitly generates AST for the object property key/value at `LEVEL_LIST` (similar to `Assign`)