### PR TITLE
Partially fix #5121: array literal ending with empty function

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -846,7 +846,7 @@
           return i + 2;
         };
         return this.scanTokens(function(token, i, tokens) {
-          var conditionTag, j, k, ref, ref1, tag;
+          var conditionTag, j, k, ref, ref1, ref2, tag;
           [tag] = token;
           conditionTag = (tag === '->' || tag === '=>') && this.findTagsBackwards(i, ['IF', 'WHILE', 'FOR', 'UNTIL', 'SWITCH', 'WHEN', 'LEADING_WHEN', '[', 'INDEX_START']) && !(this.findTagsBackwards(i, ['THEN', '..', '...']));
           if (tag === 'TERMINATOR') {
@@ -868,7 +868,7 @@
               return 2 + j;
             }
           }
-          if ((tag === '->' || tag === '=>') && (this.tag(i + 1) === ',' || this.tag(i + 1) === '.' && token.newLine)) {
+          if ((tag === '->' || tag === '=>') && (((ref2 = this.tag(i + 1)) === ',' || ref2 === ']') || this.tag(i + 1) === '.' && token.newLine)) {
             [indent, outdent] = this.indentation(tokens[i]);
             tokens.splice(i + 1, 0, indent, outdent);
             return 1;

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -618,7 +618,7 @@ exports.Rewriter = class Rewriter
         for j in [1..2] when @tag(i + j) in ['OUTDENT', 'TERMINATOR', 'FINALLY']
           tokens.splice i + j, 0, @indentation()...
           return 2 + j
-      if tag in ['->', '=>'] and (@tag(i + 1) is ',' or @tag(i + 1) is '.' and token.newLine)
+      if tag in ['->', '=>'] and (@tag(i + 1) in [',', ']'] or @tag(i + 1) is '.' and token.newLine)
         [indent, outdent] = @indentation tokens[i]
         tokens.splice i + 1, 0, indent, outdent
         return 1

--- a/test/functions.coffee
+++ b/test/functions.coffee
@@ -497,3 +497,10 @@ test "#4657: destructured array parameters", ->
 test "#5128: default parameters of function in binary operation", ->
   foo = yes or (a, b = {}) -> null
   eq foo, yes
+
+test "#5121: array end bracket after function glyph", ->
+  a = [->]
+  eq a.length, 1
+
+  b = [c: ->]
+  eq b.length, 1


### PR DESCRIPTION
@GeoffreyBooth I'd noted in #5121 that at least the cases where the `->` is immediately followed by `]` should be a simple fix

And then ran into that case working on the Prettier plugin

So this is a one-line fix (extending the similar fix from #4588) for those cases (I'd leave #5121 open since there is another case there that this PR doesn't address)