### PR TITLE
Class prototype property AST

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4292,7 +4292,7 @@
               // The class scope is not available yet, so return the assignment to update later
               assign = this.externalCtor = new Assign(new Value(), value);
             } else if (!assign.variable.this) {
-              name = base instanceof ComputedPropertyName ? new Index(base.value) : new (base.shouldCache() ? Index : Access)(base);
+              name = new (base.shouldCache() ? Index : Access)(base);
               prototype = new Access(new PropertyName('prototype'));
               variable = new Value(new ThisLiteral(), [prototype, name]);
               assign.variable = variable;

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4017,8 +4017,8 @@
           return this.addInitializerMethod(node);
         } else if (!o.compiling && this.validClassProperty(node)) {
           return this.addClassProperty(node);
-        } else if (!o.compiling && this.validClassInstanceProperty(node)) {
-          return this.addClassInstanceProperty(node);
+        } else if (!o.compiling && this.validClassPrototypeProperty(node)) {
+          return this.addClassPrototypeProperty(node);
         } else {
           return null;
         }
@@ -4082,14 +4082,14 @@
         }).withLocationDataFrom(assign);
       }
 
-      validClassInstanceProperty(node) {
+      validClassPrototypeProperty(node) {
         if (!(node instanceof Assign)) {
           return false;
         }
         return node.context === 'object' && !node.variable.hasProperties();
       }
 
-      addClassInstanceProperty(assign) {
+      addClassPrototypeProperty(assign) {
         var value, variable;
         ({variable, value} = assign);
         return new ClassPrototypeProperty({

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4,7 +4,7 @@
   // nodes are created as the result of actions in the [grammar](grammar.html),
   // but some are created by other nodes as a method of code generation. To convert
   // the syntax tree into a string of JavaScript code, call `compile()` on the root.
-  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, Call, Catch, Class, ClassProperty, Code, CodeFragment, ComputedPropertyName, DefaultLiteral, DynamicImport, DynamicImportCall, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncDirectiveReturn, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JSXAttribute, JSXAttributes, JSXElement, JSXEmptyExpression, JSXExpressionContainer, JSXIdentifier, JSXTag, JSXText, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, MetaProperty, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, ObjectProperty, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, Root, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, SwitchCase, SwitchWhen, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, TemplateElement, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, greater, hasLineComments, indentInitial, isAstLocGreater, isFunction, isLiteralArguments, isLiteralThis, isLocationDataEndGreater, isLocationDataStartGreater, isNumber, isPlainObject, isUnassignable, jisonLocationDataToAstLocationData, lesser, locationDataToString, makeDelimitedLiteral, merge, mergeAstLocationData, mergeLocationData, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility, zeroWidthLocationDataFromEndLocation,
+  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, Call, Catch, Class, ClassProperty, ClassPrototypeProperty, Code, CodeFragment, ComputedPropertyName, DefaultLiteral, DynamicImport, DynamicImportCall, Elision, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncDirectiveReturn, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JSXAttribute, JSXAttributes, JSXElement, JSXEmptyExpression, JSXExpressionContainer, JSXIdentifier, JSXTag, JSXText, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, MetaProperty, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, ObjectProperty, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, Root, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, SwitchCase, SwitchWhen, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, TemplateElement, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, attachCommentsToNode, compact, del, ends, extend, flatten, fragmentsToText, greater, hasLineComments, indentInitial, isAstLocGreater, isFunction, isLiteralArguments, isLiteralThis, isLocationDataEndGreater, isLocationDataStartGreater, isNumber, isPlainObject, isUnassignable, jisonLocationDataToAstLocationData, lesser, locationDataToString, makeDelimitedLiteral, merge, mergeAstLocationData, mergeLocationData, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility, zeroWidthLocationDataFromEndLocation,
     indexOf = [].indexOf,
     splice = [].splice,
     slice1 = [].slice;
@@ -4017,6 +4017,8 @@
           return this.addInitializerMethod(node);
         } else if (!o.compiling && this.validClassProperty(node)) {
           return this.addClassProperty(node);
+        } else if (!o.compiling && this.validClassInstanceProperty(node)) {
+          return this.addClassInstanceProperty(node);
         } else {
           return null;
         }
@@ -4077,6 +4079,22 @@
           staticClassName,
           value,
           operatorToken
+        }).withLocationDataFrom(assign);
+      }
+
+      validClassInstanceProperty(node) {
+        if (!(node instanceof Assign)) {
+          return false;
+        }
+        return node.context === 'object' && !node.variable.hasProperties();
+      }
+
+      addClassInstanceProperty(assign) {
+        var value, variable;
+        ({variable, value} = assign);
+        return new ClassPrototypeProperty({
+          name: variable.base,
+          value
         }).withLocationDataFrom(assign);
       }
 
@@ -4274,7 +4292,7 @@
               // The class scope is not available yet, so return the assignment to update later
               assign = this.externalCtor = new Assign(new Value(), value);
             } else if (!assign.variable.this) {
-              name = new (base.shouldCache() ? Index : Access)(base);
+              name = base instanceof ComputedPropertyName ? new Index(base.value) : new (base.shouldCache() ? Index : Access)(base);
               prototype = new Access(new PropertyName('prototype'));
               variable = new Value(new ThisLiteral(), [prototype, name]);
               assign.variable = variable;
@@ -4334,6 +4352,35 @@
     ClassProperty.prototype.isStatement = YES;
 
     return ClassProperty;
+
+  }).call(this);
+
+  exports.ClassPrototypeProperty = ClassPrototypeProperty = (function() {
+    class ClassPrototypeProperty extends Base {
+      constructor({
+          name: name1,
+          value: value1
+        }) {
+        super();
+        this.name = name1;
+        this.value = value1;
+      }
+
+      astProperties(o) {
+        return {
+          key: this.name.ast(o, LEVEL_LIST),
+          value: this.value.ast(o, LEVEL_LIST),
+          computed: this.name instanceof ComputedPropertyName
+        };
+      }
+
+    };
+
+    ClassPrototypeProperty.prototype.children = ['name', 'value'];
+
+    ClassPrototypeProperty.prototype.isStatement = YES;
+
+    return ClassPrototypeProperty;
 
   }).call(this);
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2694,8 +2694,8 @@ exports.Class = class Class extends Base
       @addInitializerMethod node
     else if not o.compiling and @validClassProperty node
       @addClassProperty node
-    else if not o.compiling and @validClassInstanceProperty node
-      @addClassInstanceProperty node
+    else if not o.compiling and @validClassPrototypeProperty node
+      @addClassPrototypeProperty node
     else
       null
 
@@ -2738,11 +2738,11 @@ exports.Class = class Class extends Base
       operatorToken
     }).withLocationDataFrom assign
 
-  validClassInstanceProperty: (node) ->
+  validClassPrototypeProperty: (node) ->
     return no unless node instanceof Assign
     node.context is 'object' and not node.variable.hasProperties()
 
-  addClassInstanceProperty: (assign) ->
+  addClassPrototypeProperty: (assign) ->
     {variable, value} = assign
     new ClassPrototypeProperty({
       name: variable.base

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2896,11 +2896,7 @@ exports.ExecutableClassBody = class ExecutableClassBody extends Base
         # The class scope is not available yet, so return the assignment to update later
         assign = @externalCtor = new Assign new Value, value
       else if not assign.variable.this
-        name =
-          if base instanceof ComputedPropertyName
-            new Index base.value
-          else
-            new (if base.shouldCache() then Index else Access) base
+        name      = new (if base.shouldCache() then Index else Access) base
         prototype = new Access new PropertyName 'prototype'
         variable  = new Value new ThisLiteral(), [ prototype, name ]
 

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1475,6 +1475,28 @@ test "AST as expected for Class node", ->
           shorthand: no
       ]
 
+  testStatement '''
+    class A
+      b: 1
+      [c]: 2
+  ''',
+    type: 'ClassDeclaration'
+    id: ID 'A'
+    superClass: null
+    body:
+      type: 'ClassBody'
+      body: [
+        type: 'ClassPrototypeProperty'
+        key: ID 'b'
+        value: NUMBER 1
+        computed: no
+      ,
+        type: 'ClassPrototypeProperty'
+        key: ID 'c'
+        value: NUMBER 2
+        computed: yes
+      ]
+
 # test "AST as expected for ExecutableClassBody node", ->
 #   code = """
 #     class Klass

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -7010,3 +7010,98 @@ test "AST as expected for Class node", ->
       end:
         line: 9
         column: 12
+
+  testAstLocationData '''
+    class A
+      b: 1
+      [c]: 2
+  ''',
+    type: 'ClassDeclaration'
+    body:
+      body: [
+        key:
+          start: 10
+          end: 11
+          range: [10, 11]
+          loc:
+            start:
+              line: 2
+              column: 2
+            end:
+              line: 2
+              column: 3
+        value:
+          start: 13
+          end: 14
+          range: [13, 14]
+          loc:
+            start:
+              line: 2
+              column: 5
+            end:
+              line: 2
+              column: 6
+        start: 10
+        end: 14
+        range: [10, 14]
+        loc:
+          start:
+            line: 2
+            column: 2
+          end:
+            line: 2
+            column: 6
+      ,
+        key:
+          start: 18
+          end: 19
+          range: [18, 19]
+          loc:
+            start:
+              line: 3
+              column: 3
+            end:
+              line: 3
+              column: 4
+        value:
+          start: 22
+          end: 23
+          range: [22, 23]
+          loc:
+            start:
+              line: 3
+              column: 7
+            end:
+              line: 3
+              column: 8
+        start: 17
+        end: 23
+        range: [17, 23]
+        loc:
+          start:
+            line: 3
+            column: 2
+          end:
+            line: 3
+            column: 8
+      ]
+      start: 8
+      end: 23
+      range: [8, 23]
+      loc:
+        start:
+          line: 2
+          column: 0
+        end:
+          line: 3
+          column: 8
+    start: 0
+    end: 23
+    range: [0, 23]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 3
+        column: 8

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -1930,11 +1930,3 @@ test "#5085: Bug: @ reference to class not maintained in do block", ->
 
   eq thisFoo, 'foo assigned in class'
   eq thisBar, 'foo assigned in class'
-
-test "#5204: Computed class property", ->
-  foo = 'bar'
-  class A
-    [foo]: 'baz'
-  a = new A()
-  eq a.bar, 'baz'
-  eq A::bar, 'baz'

--- a/test/classes.coffee
+++ b/test/classes.coffee
@@ -1930,3 +1930,11 @@ test "#5085: Bug: @ reference to class not maintained in do block", ->
 
   eq thisFoo, 'foo assigned in class'
   eq thisBar, 'foo assigned in class'
+
+test "#5204: Computed class property", ->
+  foo = 'bar'
+  class A
+    [foo]: 'baz'
+  a = new A()
+  eq a.bar, 'baz'
+  eq A::bar, 'baz'


### PR DESCRIPTION
@GeoffreyBooth PR for class "prototype property" AST

As far as I'm aware, there's no corresponding proposed JS syntax/Babel AST for class properties that get attached to the prototype eg:
```
  class A
    b: 3
```

So this PR introduces a new node class/AST type `ClassPrototypeProperty` to represent these

Also contains a fix for #5204 (the invalid JS for computed class prototype properties, not my second comment in that issue). If you'd prefer I could extract the fix to a separate PR against `master`