### PR TITLE
Fix #5213: Update Babel options to restore MINIFY=false

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -78,10 +78,11 @@ transpile = (code, options = {}) ->
   presets.push ['minify', {mangle: no, evaluate: no, removeUndefined: no}] if options.minify
   babelOptions =
     presets: presets
-    compact: not options.minify
+    compact: options.minify
+    minified: options.minify
     comments: not options.minify
     sourceType: options.sourceType
-  { code } = babel.transform code, babelOptions unless presets.length is 0
+  { code } = babel.transformSync code, babelOptions unless presets.length is 0
   code
 
 testBuiltCode = (watch = no) ->


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines:
https://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](https://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->
