### PR TITLE
Basic comments AST; PassthroughLiteral AST

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -146,6 +146,7 @@
     // which might’ve gotten misaligned from the original source due to the
     // `clean` function in the lexer).
     if (options.ast) {
+      nodes.allCommentsHash = helpers.buildTokenDataDictionary(tokens);
       sourceCodeNumberOfLines = (code.match(/\r?\n/g) || '').length + 1;
       sourceCodeLastLine = /.*$/.exec(code)[0];
       ast = nodes.ast(options);

--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -146,7 +146,7 @@
     // which might’ve gotten misaligned from the original source due to the
     // `clean` function in the lexer).
     if (options.ast) {
-      nodes.allCommentsHash = helpers.buildTokenDataDictionary(tokens);
+      nodes.allCommentTokens = helpers.extractAllCommentTokens(tokens);
       sourceCodeNumberOfLines = (code.match(/\r?\n/g) || '').length + 1;
       sourceCodeLastLine = /.*$/.exec(code)[0];
       ast = nodes.ast(options);

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -175,12 +175,11 @@
 
   // Build a dictionary of extra token properties organized by tokens’ locations
   // used as lookup hashes.
-  buildTokenDataDictionary = function(parserState) {
-    var base, i, len1, ref1, token, tokenData, tokenHash;
+  exports.buildTokenDataDictionary = buildTokenDataDictionary = function(tokens) {
+    var base, i, len1, token, tokenData, tokenHash;
     tokenData = {};
-    ref1 = parserState.parser.tokens;
-    for (i = 0, len1 = ref1.length; i < len1; i++) {
-      token = ref1[i];
+    for (i = 0, len1 = tokens.length; i < len1; i++) {
+      token = tokens[i];
       if (!token.comments) {
         continue;
       }
@@ -218,7 +217,7 @@
       // Add comments, building the dictionary of token data if it hasn’t been
       // built yet.
       if (parserState.tokenData == null) {
-        parserState.tokenData = buildTokenDataDictionary(parserState);
+        parserState.tokenData = buildTokenDataDictionary(parserState.parser.tokens);
       }
       if (obj.locationData != null) {
         objHash = buildLocationHash(obj.locationData);

--- a/lib/coffeescript/helpers.js
+++ b/lib/coffeescript/helpers.js
@@ -165,6 +165,32 @@
     }
   };
 
+  // Build a list of all comments attached to tokens.
+  exports.extractAllCommentTokens = function(tokens) {
+    var allCommentsObj, comment, commentKey, i, j, k, key, len1, len2, len3, ref1, results, sortedKeys, token;
+    allCommentsObj = {};
+    for (i = 0, len1 = tokens.length; i < len1; i++) {
+      token = tokens[i];
+      if (token.comments) {
+        ref1 = token.comments;
+        for (j = 0, len2 = ref1.length; j < len2; j++) {
+          comment = ref1[j];
+          commentKey = comment.locationData.range[0];
+          allCommentsObj[commentKey] = comment;
+        }
+      }
+    }
+    sortedKeys = Object.keys(allCommentsObj).sort(function(a, b) {
+      return a - b;
+    });
+    results = [];
+    for (k = 0, len3 = sortedKeys.length; k < len3; k++) {
+      key = sortedKeys[k];
+      results.push(allCommentsObj[key]);
+    }
+    return results;
+  };
+
   // Get a lookup hash for a token based on its location data.
   // Multiple tokens might have the same location hash, but using exclusive
   // location data distinguishes e.g. zero-length generated tokens from

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -399,19 +399,19 @@
     // stream and saved for later, to be reinserted into the output after
     // everything has been parsed and the JavaScript code generated.
     commentToken(chunk = this.chunk) {
-      var comment, commentAttachments, content, contents, here, i, match, matchIllegal, newLine, placeholderToken, prev;
+      var commentAttachment, commentAttachments, content, contents, hasSeenFirstCommentLine, here, hereLeadingWhitespace, hereTrailingWhitespace, i, leadingNewline, leadingNewlineOffset, leadingNewlines, leadingWhitespace, length, match, matchIllegal, nonHere, nonInitial, offsetInChunk, placeholderToken, precededByBlankLine, precedingNonCommentLines, prev, withLeadingWhitespace;
       if (!(match = chunk.match(COMMENT))) {
         return 0;
       }
-      [comment, here] = match;
+      [withLeadingWhitespace, hereLeadingWhitespace, here, hereTrailingWhitespace, nonHere] = match;
       contents = null;
       // Does this comment follow code on the same line?
-      newLine = /^\s*\n+\s*#/.test(comment);
+      leadingNewline = /^\s*\n+\s*#/.test(withLeadingWhitespace);
       if (here) {
-        matchIllegal = HERECOMMENT_ILLEGAL.exec(comment);
+        matchIllegal = HERECOMMENT_ILLEGAL.exec(here);
         if (matchIllegal) {
           this.error(`block comments cannot contain ${matchIllegal[0]}`, {
-            offset: matchIllegal.index,
+            offset: '###'.length + matchIllegal.index,
             length: matchIllegal[0].length
           });
         }
@@ -420,50 +420,92 @@
         // Remove leading newlines, like `Rewriter::removeLeadingNewlines`, to
         // avoid the creation of unwanted `TERMINATOR` tokens.
         chunk = chunk.replace(/^\n+/, '');
-        this.lineToken(chunk);
+        this.lineToken({chunk});
         // Pull out the ###-style comment’s content, and format it.
         content = here;
-        if (indexOf.call(content, '\n') >= 0) {
-          content = content.replace(RegExp(`\\n${repeat(' ', this.indent)}`, "g"), '\n');
-        }
-        contents = [content];
+        contents = [
+          {
+            content,
+            length: withLeadingWhitespace.length - hereLeadingWhitespace.length - hereTrailingWhitespace.length,
+            leadingWhitespace: hereLeadingWhitespace
+          }
+        ];
       } else {
         // The `COMMENT` regex captures successive line comments as one token.
         // Remove any leading newlines before the first comment, but preserve
         // blank lines between line comments.
-        content = comment.replace(/^(\n*)/, '');
-        content = content.replace(/^([ |\t]*)#/gm, '');
-        contents = content.split('\n');
+        leadingNewlines = '';
+        content = nonHere.replace(/^(\n*)/, function(leading) {
+          leadingNewlines = leading;
+          return '';
+        });
+        precedingNonCommentLines = '';
+        hasSeenFirstCommentLine = false;
+        contents = content.split('\n').map(function(line, index) {
+          var comment, leadingWhitespace;
+          if (!(line.indexOf('#') > -1)) {
+            precedingNonCommentLines += `\n${line}`;
+            return;
+          }
+          leadingWhitespace = '';
+          content = line.replace(/^([ |\t]*)#/, function(_, whitespace) {
+            leadingWhitespace = whitespace;
+            return '';
+          });
+          comment = {
+            content,
+            length: '#'.length + content.length,
+            leadingWhitespace: `${!hasSeenFirstCommentLine ? leadingNewlines : ''}${precedingNonCommentLines}${leadingWhitespace}`,
+            precededByBlankLine: !!precedingNonCommentLines
+          };
+          hasSeenFirstCommentLine = true;
+          precedingNonCommentLines = '';
+          return comment;
+        }).filter(function(comment) {
+          return comment;
+        });
       }
+      offsetInChunk = 0;
       commentAttachments = (function() {
         var j, len, results;
         results = [];
         for (i = j = 0, len = contents.length; j < len; i = ++j) {
-          content = contents[i];
-          results.push({
-            content: content,
+          ({content, length, leadingWhitespace, precededByBlankLine} = contents[i]);
+          nonInitial = i !== 0;
+          leadingNewlineOffset = nonInitial ? 1 : 0;
+          offsetInChunk += leadingNewlineOffset + leadingWhitespace.length;
+          commentAttachment = {
+            content,
             here: here != null,
-            newLine: newLine || i !== 0 // Line comments after the first one start new lines, by definition.
-          });
+            newLine: leadingNewline || nonInitial, // Line comments after the first one start new lines, by definition.
+            locationData: this.makeLocationData({offsetInChunk, length}),
+            precededByBlankLine
+          };
+          offsetInChunk += length;
+          results.push(commentAttachment);
         }
         return results;
-      })();
+      }).call(this);
       prev = this.prev();
       if (!prev) {
         // If there’s no previous token, create a placeholder token to attach
         // this comment to; and follow with a newline.
         commentAttachments[0].newLine = true;
-        this.lineToken(this.chunk.slice(comment.length));
+        this.lineToken({
+          chunk: this.chunk.slice(withLeadingWhitespace.length),
+          offset: withLeadingWhitespace.length // Set the indent.
+        });
         placeholderToken = this.makeToken('JS', '', {
+          offset: withLeadingWhitespace.length,
           generated: true
         });
         placeholderToken.comments = commentAttachments;
         this.tokens.push(placeholderToken);
-        this.newlineToken(0);
+        this.newlineToken(withLeadingWhitespace.length);
       } else {
         attachCommentsToNode(commentAttachments, prev);
       }
-      return comment.length;
+      return withLeadingWhitespace.length;
     }
 
     // Matches JavaScript interpolated directly into the source via backticks.
@@ -605,7 +647,7 @@
 
     // Keeps track of the level of indentation, because a single outdent token
     // can close multiple indents, so we need to know how far in we happen to be.
-    lineToken(chunk = this.chunk) {
+    lineToken({chunk = this.chunk, offset = 0} = {}) {
       var backslash, diff, indent, match, minLiteralLength, newIndentLiteral, noNewlines, prev, size;
       if (!(match = MULTI_DENT.exec(chunk))) {
         return 0;
@@ -642,7 +684,7 @@
         if (noNewlines) {
           this.suppressNewlines();
         } else {
-          this.newlineToken(0);
+          this.newlineToken(offset);
         }
         return indent.length;
       }
@@ -661,7 +703,7 @@
         }
         diff = size - this.indent + this.outdebt;
         this.token('INDENT', diff, {
-          offset: indent.length - size,
+          offset: offset + indent.length - size,
           length: size
         });
         this.indents.push(diff);
@@ -673,18 +715,23 @@
         this.indentLiteral = newIndentLiteral;
       } else if (size < this.baseIndent) {
         this.error('missing indentation', {
-          offset: indent.length
+          offset: offset + indent.length
         });
       } else {
         this.indebt = 0;
-        this.outdentToken(this.indent - size, noNewlines, indent.length);
+        this.outdentToken({
+          moveOut: this.indent - size,
+          noNewlines,
+          outdentLength: indent.length,
+          offset
+        });
       }
       return indent.length;
     }
 
     // Record an outdent token or multiple tokens, if we happen to be moving back
     // inwards past several recorded indents. Sets new @indent value.
-    outdentToken(moveOut, noNewlines, outdentLength) {
+    outdentToken({moveOut, noNewlines, outdentLength = 0, offset = 0}) {
       var decreasedIndent, dent, lastIndent, ref;
       decreasedIndent = this.indent - moveOut;
       while (moveOut > 0) {
@@ -715,7 +762,7 @@
       this.suppressSemicolons();
       if (!(this.tag() === 'TERMINATOR' || noNewlines)) {
         this.token('TERMINATOR', '\n', {
-          offset: outdentLength,
+          offset: offset + outdentLength,
           length: 0
         });
       }
@@ -1115,7 +1162,9 @@
 
     // Close up all remaining open blocks at the end of the file.
     closeIndentation() {
-      return this.outdentToken(this.indent);
+      return this.outdentToken({
+        moveOut: this.indent
+      });
     }
 
     // Match the contents of a delimited token and expand variables and expressions
@@ -1345,7 +1394,10 @@
         //       el.hide())
 
         ref1 = this.indents, [lastIndent] = slice.call(ref1, -1);
-        this.outdentToken(lastIndent, true);
+        this.outdentToken({
+          moveOut: lastIndent,
+          noNewlines: true
+        });
         return this.pair(tag);
       }
       return this.ends.pop();
@@ -1618,7 +1670,7 @@
 
   WHITESPACE = /^[^\n\S]+/;
 
-  COMMENT = /^\s*###([^#][\s\S]*?)(?:###[^\n\S]*|###$)|^(?:\s*#(?!##[^#]).*)+/;
+  COMMENT = /^(\s*)###([^#][\s\S]*?)(?:###([^\n\S]*)|###$)|^((?:\s*#(?!##[^#]).*)+)/;
 
   CODE = /^[-=]>/;
 

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -399,16 +399,16 @@
     // stream and saved for later, to be reinserted into the output after
     // everything has been parsed and the JavaScript code generated.
     commentToken(chunk = this.chunk) {
-      var commentAttachment, commentAttachments, content, contents, hasSeenFirstCommentLine, here, hereLeadingWhitespace, hereTrailingWhitespace, i, leadingNewline, leadingNewlineOffset, leadingNewlines, leadingWhitespace, length, match, matchIllegal, nonHere, nonInitial, offsetInChunk, placeholderToken, precededByBlankLine, precedingNonCommentLines, prev, withLeadingWhitespace;
+      var commentAttachment, commentAttachments, commentWithSurroundingWhitespace, content, contents, hasSeenFirstCommentLine, hereComment, hereLeadingWhitespace, hereTrailingWhitespace, i, leadingNewline, leadingNewlineOffset, leadingNewlines, leadingWhitespace, length, lineComment, match, matchIllegal, nonInitial, offsetInChunk, placeholderToken, precededByBlankLine, precedingNonCommentLines, prev;
       if (!(match = chunk.match(COMMENT))) {
         return 0;
       }
-      [withLeadingWhitespace, hereLeadingWhitespace, here, hereTrailingWhitespace, nonHere] = match;
+      [commentWithSurroundingWhitespace, hereLeadingWhitespace, hereComment, hereTrailingWhitespace, lineComment] = match;
       contents = null;
       // Does this comment follow code on the same line?
-      leadingNewline = /^\s*\n+\s*#/.test(withLeadingWhitespace);
-      if (here) {
-        matchIllegal = HERECOMMENT_ILLEGAL.exec(here);
+      leadingNewline = /^\s*\n+\s*#/.test(commentWithSurroundingWhitespace);
+      if (hereComment) {
+        matchIllegal = HERECOMMENT_ILLEGAL.exec(hereComment);
         if (matchIllegal) {
           this.error(`block comments cannot contain ${matchIllegal[0]}`, {
             offset: '###'.length + matchIllegal.index,
@@ -416,17 +416,17 @@
           });
         }
         // Parse indentation or outdentation as if this block comment didn’t exist.
-        chunk = chunk.replace(`###${here}###`, '');
+        chunk = chunk.replace(`###${hereComment}###`, '');
         // Remove leading newlines, like `Rewriter::removeLeadingNewlines`, to
         // avoid the creation of unwanted `TERMINATOR` tokens.
         chunk = chunk.replace(/^\n+/, '');
         this.lineToken({chunk});
         // Pull out the ###-style comment’s content, and format it.
-        content = here;
+        content = hereComment;
         contents = [
           {
             content,
-            length: withLeadingWhitespace.length - hereLeadingWhitespace.length - hereTrailingWhitespace.length,
+            length: commentWithSurroundingWhitespace.length - hereLeadingWhitespace.length - hereTrailingWhitespace.length,
             leadingWhitespace: hereLeadingWhitespace
           }
         ];
@@ -435,7 +435,7 @@
         // Remove any leading newlines before the first comment, but preserve
         // blank lines between line comments.
         leadingNewlines = '';
-        content = nonHere.replace(/^(\n*)/, function(leading) {
+        content = lineComment.replace(/^(\n*)/, function(leading) {
           leadingNewlines = leading;
           return '';
         });
@@ -476,7 +476,7 @@
           offsetInChunk += leadingNewlineOffset + leadingWhitespace.length;
           commentAttachment = {
             content,
-            here: here != null,
+            here: hereComment != null,
             newLine: leadingNewline || nonInitial, // Line comments after the first one start new lines, by definition.
             locationData: this.makeLocationData({offsetInChunk, length}),
             precededByBlankLine
@@ -492,20 +492,20 @@
         // this comment to; and follow with a newline.
         commentAttachments[0].newLine = true;
         this.lineToken({
-          chunk: this.chunk.slice(withLeadingWhitespace.length),
-          offset: withLeadingWhitespace.length // Set the indent.
+          chunk: this.chunk.slice(commentWithSurroundingWhitespace.length),
+          offset: commentWithSurroundingWhitespace.length // Set the indent.
         });
         placeholderToken = this.makeToken('JS', '', {
-          offset: withLeadingWhitespace.length,
+          offset: commentWithSurroundingWhitespace.length,
           generated: true
         });
         placeholderToken.comments = commentAttachments;
         this.tokens.push(placeholderToken);
-        this.newlineToken(withLeadingWhitespace.length);
+        this.newlineToken(commentWithSurroundingWhitespace.length);
       } else {
         attachCommentsToNode(commentAttachments, prev);
       }
-      return withLeadingWhitespace.length;
+      return commentWithSurroundingWhitespace.length;
     }
 
     // Matches JavaScript interpolated directly into the source via backticks.

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -112,7 +112,7 @@
     // Tokenizers
     // ----------
 
-    // Matches identifying literals: variables, keywords, method names, etc.
+      // Matches identifying literals: variables, keywords, method names, etc.
     // Check to ensure that JavaScript reserved words aren’t being used as
     // identifiers. Because CoffeeScript reserves a handful of keywords that are
     // allowed in JavaScript, we’re careful not to tag them as keywords when
@@ -1114,7 +1114,7 @@
     // Token Manipulators
     // ------------------
 
-    // A source of ambiguity in our grammar used to be parameter lists in function
+      // A source of ambiguity in our grammar used to be parameter lists in function
     // definitions versus argument lists in function calls. Walk backwards, tagging
     // parameters specially in order to make things easier for the parser.
     tagParameters() {
@@ -1406,7 +1406,7 @@
     // Helpers
     // -------
 
-    // Returns the line and column number from an offset into the current chunk.
+      // Returns the line and column number from an offset into the current chunk.
 
     // `offset` is a number of characters into `@chunk`.
     getLineAndColumnFromChunk(offset) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -703,6 +703,10 @@
       return results;
     }
 
+    commentsAst() {
+      return [];
+    }
+
     ast(o) {
       o.level = LEVEL_TOP;
       this.initializeScope(o);
@@ -717,7 +721,7 @@
       this.body.isRootBlock = true;
       return {
         program: Object.assign(this.body.ast(o), this.astLocationData()),
-        comments: []
+        comments: this.commentsAst()
       };
     }
 
@@ -2184,33 +2188,37 @@
     constructor({
         content: content1,
         newLine,
-        unshift
+        unshift,
+        locationData: locationData1
       }) {
       super();
       this.content = content1;
       this.newLine = newLine;
       this.unshift = unshift;
+      this.locationData = locationData1;
     }
 
     compileNode(o) {
-      var fragment, hasLeadingMarks, j, largestIndent, leadingWhitespace, len1, line, multiline, ref1;
+      var fragment, hasLeadingMarks, indent, j, leadingWhitespace, len1, line, multiline, ref1;
       multiline = indexOf.call(this.content, '\n') >= 0;
-      hasLeadingMarks = /\n\s*[#|\*]/.test(this.content);
-      if (hasLeadingMarks) {
-        this.content = this.content.replace(/^([ \t]*)#(?=\s)/gm, ' *');
-      }
       // Unindent multiline comments. They will be reindented later.
       if (multiline) {
-        largestIndent = '';
+        indent = null;
         ref1 = this.content.split('\n');
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           line = ref1[j];
           leadingWhitespace = /^\s*/.exec(line)[0];
-          if (leadingWhitespace.length > largestIndent.length) {
-            largestIndent = leadingWhitespace;
+          if (!indent || leadingWhitespace.length < indent.length) {
+            indent = leadingWhitespace;
           }
         }
-        this.content = this.content.replace(RegExp(`^(${leadingWhitespace})`, "gm"), '');
+        if (indent) {
+          this.content = this.content.replace(RegExp(`\\n${indent}`, "g"), '\n');
+        }
+      }
+      hasLeadingMarks = /\n\s*[#|\*]/.test(this.content);
+      if (hasLeadingMarks) {
+        this.content = this.content.replace(/^([ \t]*)#(?=\s)/gm, ' *');
       }
       this.content = `/*${this.content}${hasLeadingMarks ? ' ' : ''}*/`;
       fragment = this.makeCode(this.content);
@@ -2231,17 +2239,21 @@
     constructor({
         content: content1,
         newLine,
-        unshift
+        unshift,
+        locationData: locationData1,
+        precededByBlankLine
       }) {
       super();
       this.content = content1;
       this.newLine = newLine;
       this.unshift = unshift;
+      this.locationData = locationData1;
+      this.precededByBlankLine = precededByBlankLine;
     }
 
     compileNode(o) {
       var fragment;
-      fragment = this.makeCode(/^\s*$/.test(this.content) ? '' : `//${this.content}`);
+      fragment = this.makeCode(/^\s*$/.test(this.content) ? '' : `${this.precededByBlankLine ? `\n${o.indent}` : ''}//${this.content}`);
       fragment.newLine = this.newLine;
       fragment.unshift = this.unshift;
       fragment.trail = !this.newLine && !this.unshift;

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -704,7 +704,30 @@
     }
 
     commentsAst() {
-      return [];
+      var comment, commentToken, j, len1, ref1, results;
+      if (this.allComments == null) {
+        this.allComments = (function() {
+          var j, len1, ref1, ref2, results;
+          ref2 = (ref1 = this.allCommentTokens) != null ? ref1 : [];
+          results = [];
+          for (j = 0, len1 = ref2.length; j < len1; j++) {
+            commentToken = ref2[j];
+            if (commentToken.here) {
+              results.push(new HereComment(commentToken));
+            } else {
+              results.push(new LineComment(commentToken));
+            }
+          }
+          return results;
+        }).call(this);
+      }
+      ref1 = this.allComments;
+      results = [];
+      for (j = 0, len1 = ref1.length; j < len1; j++) {
+        comment = ref1[j];
+        results.push(comment.ast());
+      }
+      return results;
     }
 
     ast(o) {
@@ -1137,7 +1160,10 @@
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           expression = ref1[j];
           expressionAst = expression.ast(o);
-          if (expression instanceof Directive) {
+          // Ignore generated PassthroughLiteral
+          if (expressionAst == null) {
+            continue;
+          } else if (expression instanceof Directive) {
             directives.push(expressionAst);
           // If an expression is a statement, it can be added to the body as is.
           } else if (expression.isStatementAst(o)) {
@@ -1162,7 +1188,7 @@
         // or `script`, and so if Node figures out a way to do so for `.js` files
         // then CoffeeScript can copy Node’s algorithm.
 
-        // sourceType: 'module'
+          // sourceType: 'module'
         return {body, directives};
       }
 
@@ -1497,6 +1523,20 @@
         // By reducing it to its latter half, we turn '\`' to '`', '\\\`' to '\`', etc.
         return string.slice(-Math.ceil(string.length / 2));
       });
+    }
+
+    ast(o, level) {
+      if (this.generated) {
+        return null;
+      }
+      return super.ast(o, level);
+    }
+
+    astProperties() {
+      return {
+        value: this.value,
+        here: !!this.here
+      };
     }
 
   };
@@ -2230,6 +2270,16 @@
       return fragment;
     }
 
+    astType() {
+      return 'CommentBlock';
+    }
+
+    astProperties() {
+      return {
+        value: this.content
+      };
+    }
+
   };
 
   //### LineComment
@@ -2260,6 +2310,16 @@
       // Don’t rely on `fragment.type`, which can break when the compiler is minified.
       fragment.isComment = fragment.isLineComment = true;
       return fragment;
+    }
+
+    astType() {
+      return 'CommentLine';
+    }
+
+    astProperties() {
+      return {
+        value: this.content
+      };
     }
 
   };
@@ -7104,17 +7164,23 @@
               attachCommentsToNode(salvagedComments, node);
             }
             if ((unwrapped = (ref1 = node.expression) != null ? ref1.unwrapAll() : void 0) instanceof PassthroughLiteral && unwrapped.generated && !this.jsx) {
-              commentPlaceholder = new StringLiteral('').withLocationDataFrom(node);
-              commentPlaceholder.comments = unwrapped.comments;
-              if (node.comments) {
-                (commentPlaceholder.comments != null ? commentPlaceholder.comments : commentPlaceholder.comments = []).push(...node.comments);
+              if (o.compiling) {
+                commentPlaceholder = new StringLiteral('').withLocationDataFrom(node);
+                commentPlaceholder.comments = unwrapped.comments;
+                if (node.comments) {
+                  (commentPlaceholder.comments != null ? commentPlaceholder.comments : commentPlaceholder.comments = []).push(...node.comments);
+                }
+                elements.push(new Value(commentPlaceholder));
+              } else {
+                elements.push(null);
               }
-              elements.push(new Value(commentPlaceholder));
             } else if (node.expression || includeInterpolationWrappers) {
               if (node.comments) {
                 ((ref2 = node.expression) != null ? ref2.comments != null ? ref2.comments : ref2.comments = [] : void 0).push(...node.comments);
               }
               elements.push(includeInterpolationWrappers ? node : node.expression);
+            } else if (!o.compiling) {
+              elements.push(null);
             }
             return false;
           } else if (node.comments) {
@@ -7198,7 +7264,7 @@
       }
 
       astProperties(o) {
-        var element, elements, expressions, index, j, last, len1, quasis;
+        var element, elements, expressions, index, j, last, len1, quasis, ref1;
         elements = this.extractElements(o);
         [last] = slice1.call(elements, -1);
         quasis = [];
@@ -7210,7 +7276,7 @@
               tail: element === last
             }).withLocationDataFrom(element).ast(o));
           } else {
-            expressions.push(element.unwrap().ast(o));
+            expressions.push((ref1 = element != null ? element.unwrap().ast(o) : void 0) != null ? ref1 : null);
           }
         }
         return {expressions, quasis, quote: this.quote};

--- a/lib/coffeescript/sourcemap.js
+++ b/lib/coffeescript/sourcemap.js
@@ -53,10 +53,10 @@
     // SourceMap
     // ---------
 
-    // Maps locations in a single generated JavaScript file back to locations in
+      // Maps locations in a single generated JavaScript file back to locations in
     // the original CoffeeScript source file.
 
-    // This is intentionally agnostic towards how a source map might be represented on
+      // This is intentionally agnostic towards how a source map might be represented on
     // disk. Once the compiler is ready to produce a "v3"-style source map, we can walk
     // through the arrays of line and column buffer to produce it.
     class SourceMap {
@@ -88,7 +88,7 @@
       // V3 SourceMap Generation
       // -----------------------
 
-      // Builds up a V3 source map, returning the generated JSON as a string.
+        // Builds up a V3 source map, returning the generated JSON as a string.
       // `options.sourceRoot` may be used to specify the sourceRoot written to the source
       // map.  Also, `options.sourceFiles` and `options.generatedFile` may be passed to
       // set "sources" and "file", respectively.

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -113,6 +113,7 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
   # which might’ve gotten misaligned from the original source due to the
   # `clean` function in the lexer).
   if options.ast
+    nodes.allCommentsHash = helpers.buildTokenDataDictionary tokens
     sourceCodeNumberOfLines = (code.match(/\r?\n/g) or '').length + 1
     sourceCodeLastLine = /.*$/.exec(code)[0] # `.*` matches all but line break characters.
     ast = nodes.ast options

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -113,7 +113,7 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
   # which might’ve gotten misaligned from the original source due to the
   # `clean` function in the lexer).
   if options.ast
-    nodes.allCommentsHash = helpers.buildTokenDataDictionary tokens
+    nodes.allCommentTokens = helpers.extractAllCommentTokens tokens
     sourceCodeNumberOfLines = (code.match(/\r?\n/g) or '').length + 1
     sourceCodeLastLine = /.*$/.exec(code)[0] # `.*` matches all but line break characters.
     ast = nodes.ast options

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -114,6 +114,17 @@ buildLocationData = (first, last) ->
       last.range[1]
     ]
 
+# Build a list of all comments attached to tokens.
+exports.extractAllCommentTokens = (tokens) ->
+  allCommentsObj = {}
+  for token in tokens when token.comments
+    for comment in token.comments
+      commentKey = comment.locationData.range[0]
+      allCommentsObj[commentKey] = comment
+  sortedKeys = Object.keys(allCommentsObj).sort (a, b) -> a - b
+  for key in sortedKeys
+    allCommentsObj[key]
+
 # Get a lookup hash for a token based on its location data.
 # Multiple tokens might have the same location hash, but using exclusive
 # location data distinguishes e.g. zero-length generated tokens from

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -123,9 +123,9 @@ buildLocationHash = (loc) ->
 
 # Build a dictionary of extra token properties organized by tokens’ locations
 # used as lookup hashes.
-buildTokenDataDictionary = (parserState) ->
+exports.buildTokenDataDictionary = buildTokenDataDictionary = (tokens) ->
   tokenData = {}
-  for token in parserState.parser.tokens when token.comments
+  for token in tokens when token.comments
     tokenHash = buildLocationHash token[2]
     # Multiple tokens might have the same location hash, such as the generated
     # `JS` tokens added at the start or end of the token stream to hold
@@ -153,7 +153,7 @@ exports.addDataToNode = (parserState, firstLocationData, firstValue, lastLocatio
 
     # Add comments, building the dictionary of token data if it hasn’t been
     # built yet.
-    parserState.tokenData ?= buildTokenDataDictionary parserState
+    parserState.tokenData ?= buildTokenDataDictionary parserState.parser.tokens
     if obj.locationData?
       objHash = buildLocationHash obj.locationData
       if parserState.tokenData[objHash]?.comments?

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -43,6 +43,9 @@ testSingleNodeLocationData = (node, expected, path = '') ->
   eq node.loc.end.column, expected.loc.end.column, \
     "Expected #{path}.loc.end.column: #{reset}#{node.loc.end.column}#{red} to equal #{reset}#{expected.loc.end.column}#{red}"
 
+testAstCommentsLocationData = (code, expected) ->
+  testAstNodeLocationData getAstRoot(code).comments, expected
+
 if require?
   {mergeAstLocationData, mergeLocationData} = require './../lib/coffeescript/nodes'
 
@@ -7478,3 +7481,266 @@ test "AST location data as expected for directives", ->
       end:
         line: 3
         column: 7
+
+test "AST location data as expected for PassthroughLiteral node", ->
+  testAstLocationData "`abc`",
+    type: 'PassthroughLiteral'
+    start: 0
+    end: 5
+    range: [0, 5]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 5
+
+  code = '\nconst CONSTANT = "unreassignable!"\n'
+  testAstLocationData """
+    ```
+      abc
+    ```
+  """,
+    type: 'PassthroughLiteral'
+    start: 0
+    end: 13
+    range: [0, 13]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 3
+        column: 3
+
+  testAstLocationData "``",
+    type: 'PassthroughLiteral'
+    start: 0
+    end: 2
+    range: [0, 2]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 2
+
+test "AST as expected for comments", ->
+  testAstCommentsLocationData '''
+    a # simple line comment
+  ''', [
+    start: 2
+    end: 23
+    range: [2, 23]
+    loc:
+      start:
+        line: 1
+        column: 2
+      end:
+        line: 1
+        column: 23
+  ]
+
+  testAstCommentsLocationData '''
+    a ### simple here comment ###
+  ''', [
+    start: 2
+    end: 29
+    range: [2, 29]
+    loc:
+      start:
+        line: 1
+        column: 2
+      end:
+        line: 1
+        column: 29
+  ]
+
+  testAstCommentsLocationData '''
+    # just a line comment
+  ''', [
+    start: 0
+    end: 21
+    range: [0, 21]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 21
+  ]
+
+  testAstCommentsLocationData '''
+    ### just a here comment ###
+  ''', [
+    start: 0
+    end: 27
+    range: [0, 27]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 27
+  ]
+
+  testAstCommentsLocationData '''
+    "#{
+      # empty interpolation line comment
+     }"
+  ''', [
+    start: 6
+    end: 40
+    range: [6, 40]
+    loc:
+      start:
+        line: 2
+        column: 2
+      end:
+        line: 2
+        column: 36
+  ]
+
+  testAstCommentsLocationData '''
+    "#{
+      ### empty interpolation block comment ###
+     }"
+  ''', [
+    start: 6
+    end: 47
+    range: [6, 47]
+    loc:
+      start:
+        line: 2
+        column: 2
+      end:
+        line: 2
+        column: 43
+  ]
+
+  testAstCommentsLocationData '''
+    # multiple line comments
+    # on consecutive lines
+  ''', [
+    start: 0
+    end: 24
+    range: [0, 24]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 24
+  ,
+    start: 25
+    end: 47
+    range: [25, 47]
+    loc:
+      start:
+        line: 2
+        column: 0
+      end:
+        line: 2
+        column: 22
+  ]
+
+  testAstCommentsLocationData '''
+    # multiple line comments
+
+    # with blank line
+  ''', [
+    start: 0
+    end: 24
+    range: [0, 24]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 24
+  ,
+    start: 26
+    end: 43
+    range: [26, 43]
+    loc:
+      start:
+        line: 3
+        column: 0
+      end:
+        line: 3
+        column: 17
+  ]
+
+  testAstCommentsLocationData '''
+    #no whitespace line comment
+  ''', [
+    start: 0
+    end: 27
+    range: [0, 27]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 27
+  ]
+
+  testAstCommentsLocationData '''
+    ###no whitespace here comment###
+  ''', [
+    start: 0
+    end: 32
+    range: [0, 32]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 32
+  ]
+
+  testAstCommentsLocationData '''
+    ###
+    # multiline
+    # here comment
+    ###
+  ''', [
+    start: 0
+    end: 34
+    range: [0, 34]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 4
+        column: 3
+  ]
+
+  testAstCommentsLocationData '''
+    if b
+      ###
+      # multiline
+      # indented here comment
+      ###
+      c
+  ''', [
+    start: 7
+    end: 56
+    range: [7, 56]
+    loc:
+      start:
+        line: 2
+        column: 2
+      end:
+        line: 5
+        column: 5
+  ]


### PR DESCRIPTION
@GeoffreyBooth PR for basic AST for comments and for PassthroughLiteral nodes

As discussed, the initial target for comments AST is a single top-level `comments` array on the root `File` AST node (since that is what both Prettier and ESLint expect)

Per our discussion, used a variation of the token-comment-dictionary technique to pass the list of all comments from the tokens -> node class tree