### PR TITLE
AST: OptionalMemberExpression/OptionalCallExpression

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2078,6 +2078,24 @@
         return object;
       }
 
+      containsSoak() {
+        var j, len1, property, ref1;
+        if (!this.hasProperties()) {
+          return false;
+        }
+        ref1 = this.properties;
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          property = ref1[j];
+          if (property.soak) {
+            return true;
+          }
+        }
+        if (this.base instanceof Call && this.base.soak) {
+          return true;
+        }
+        return false;
+      }
+
       ast(o, level) {
         if (!this.hasProperties()) {
           // If the `Value` has no properties, the AST node is just whatever this
@@ -2092,6 +2110,8 @@
       astType() {
         if (this.isJSXTag()) {
           return 'JSXMemberExpression';
+        } else if (this.containsSoak()) {
+          return 'OptionalMemberExpression';
         } else {
           return 'MemberExpression';
         }
@@ -2829,9 +2849,22 @@
         return fragments;
       }
 
+      containsSoak() {
+        var ref1;
+        if (this.soak) {
+          return true;
+        }
+        if ((ref1 = this.variable) != null ? typeof ref1.containsSoak === "function" ? ref1.containsSoak() : void 0 : void 0) {
+          return true;
+        }
+        return false;
+      }
+
       astType() {
         if (this.isNew) {
           return 'NewExpression';
+        } else if (this.containsSoak()) {
+          return 'OptionalCallExpression';
         } else {
           return 'CallExpression';
         }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1414,6 +1414,16 @@ exports.Value = class Value extends Base
         mergeLocationData @base.locationData, initialProperties[initialProperties.length - 1].locationData
     object
 
+  containsSoak: ->
+    return no unless @hasProperties()
+
+    for property in @properties when property.soak
+      return yes
+
+    return yes if @base instanceof Call and @base.soak
+
+    no
+
   ast: (o, level) ->
     # If the `Value` has no properties, the AST node is just whatever this
     # node’s `base` is.
@@ -1425,6 +1435,8 @@ exports.Value = class Value extends Base
   astType: ->
     if @isJSXTag()
       'JSXMemberExpression'
+    else if @containsSoak()
+      'OptionalMemberExpression'
     else
       'MemberExpression'
 
@@ -1935,9 +1947,16 @@ exports.Call = class Call extends Base
     fragments.push @makeCode('('), compiledArgs..., @makeCode(')')
     fragments
 
+  containsSoak: ->
+    return yes if @soak
+    return yes if @variable?.containsSoak?()
+    no
+
   astType: ->
     if @isNew
       'NewExpression'
+    else if @containsSoak()
+      'OptionalCallExpression'
     else
       'CallExpression'
 

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -701,12 +701,12 @@ test "AST as expected for Call node", ->
     implicit: yes
 
   testExpression 'maybe?()',
-    type: 'CallExpression'
+    type: 'OptionalCallExpression'
     optional: yes
     implicit: no
 
   testExpression 'maybe?(1 + 1)',
-    type: 'CallExpression'
+    type: 'OptionalCallExpression'
     arguments: [
       type: 'BinaryExpression'
     ]
@@ -714,7 +714,7 @@ test "AST as expected for Call node", ->
     implicit: no
 
   testExpression 'maybe? 1 + 1',
-    type: 'CallExpression'
+    type: 'OptionalCallExpression'
     arguments: [
       type: 'BinaryExpression'
     ]
@@ -730,6 +730,60 @@ test "AST as expected for Call node", ->
       name: 'that'
     ]
     implicit: yes
+    optional: no
+
+  testExpression 'a?().b',
+    type: 'OptionalMemberExpression'
+    object:
+      type: 'OptionalCallExpression'
+      optional: yes
+    optional: no
+
+  testExpression 'a?.b.c()',
+    type: 'OptionalCallExpression'
+    callee:
+      type: 'OptionalMemberExpression'
+      object:
+        type: 'OptionalMemberExpression'
+        optional: yes
+      optional: no
+    optional: no
+
+  testExpression 'a?.b?()',
+    type: 'OptionalCallExpression'
+    callee:
+      type: 'OptionalMemberExpression'
+      optional: yes
+    optional: yes
+
+  testExpression 'a?().b?()',
+    type: 'OptionalCallExpression'
+    callee:
+      type: 'OptionalMemberExpression'
+      optional: no
+      object:
+        type: 'OptionalCallExpression'
+        optional: yes
+    optional: yes
+
+  testExpression 'a().b?()',
+    type: 'OptionalCallExpression'
+    callee:
+      type: 'MemberExpression'
+      optional: no
+      object:
+        type: 'CallExpression'
+        optional: no
+    optional: yes
+
+  testExpression 'a?().b()',
+    type: 'OptionalCallExpression'
+    callee:
+      type: 'OptionalMemberExpression'
+      optional: no
+      object:
+        type: 'OptionalCallExpression'
+        optional: yes
     optional: no
 
 # test "AST as expected for SuperCall node", ->
@@ -892,9 +946,7 @@ test "AST as expected for Access node", ->
     shorthand: no
 
   testExpression 'obj?.prop',
-    # TODO: support Babel 7-style OptionalMemberExpression type
-    # type: 'OptionalMemberExpression'
-    type: 'MemberExpression'
+    type: 'OptionalMemberExpression'
     object:
       type: 'Identifier'
       name: 'obj'
@@ -946,9 +998,9 @@ test "AST as expected for Access node", ->
     shorthand: no
 
   testExpression 'a?.b.c',
-    type: 'MemberExpression'
+    type: 'OptionalMemberExpression'
     object:
-      type: 'MemberExpression'
+      type: 'OptionalMemberExpression'
       object:
         type: 'Identifier'
         name: 'a'
@@ -979,7 +1031,7 @@ test "AST as expected for Index node", ->
     shorthand: no
 
   testExpression 'a?[b]',
-    type: 'MemberExpression'
+    type: 'OptionalMemberExpression'
     object:
       type: 'Identifier'
       name: 'a'

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -450,7 +450,7 @@ test "AST location data as expected for Index node", ->
         column: 4
 
   testAstLocationData 'a?[b][3]',
-    type: 'MemberExpression'
+    type: 'OptionalMemberExpression'
     object:
       object:
         start: 0
@@ -777,7 +777,7 @@ test "AST location data as expected for Call node", ->
     ]
 
   testAstLocationData 'maybe? 1 + 1',
-    type: 'CallExpression'
+    type: 'OptionalCallExpression'
     start: 0
     end: 12
     range: [0, 12]


### PR DESCRIPTION
@GeoffreyBooth PR updating `Value`/`Call` AST to use Babel 7-style `OptionalMemberExpression`/`OptionalCallExpression` AST node types