### PR TITLE
Reconcile ast branch with Prettier plugin: part 2

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1140,7 +1140,7 @@
         if (((level != null) && level !== LEVEL_TOP) && this.expressions.length) {
           return (new Sequence(this.expressions).withLocationDataFrom(this)).ast(o, level);
         }
-        return super.ast(o);
+        return super.ast(o, level);
       }
 
       astType() {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4546,7 +4546,7 @@
           key: this.name.ast(o, LEVEL_LIST),
           value: this.value.ast(o, LEVEL_LIST),
           static: !!this.isStatic,
-          computed: this.name instanceof ComputedPropertyName,
+          computed: this.name instanceof Index || this.name instanceof ComputedPropertyName,
           operator: (ref1 = (ref2 = this.operatorToken) != null ? ref2.value : void 0) != null ? ref1 : '=',
           staticClassName: (ref3 = (ref4 = this.staticClassName) != null ? ref4.ast(o) : void 0) != null ? ref3 : null
         };
@@ -4969,9 +4969,6 @@
       }
 
       isStatement(o) {
-        if (!o.compiling) {
-          return false;
-        }
         return (o != null ? o.level : void 0) === LEVEL_TOP && (this.context != null) && (this.moduleDeclaration || indexOf.call(this.context, "?") >= 0);
       }
 
@@ -5480,6 +5477,8 @@
 
     Assign.prototype.isAssignable = YES;
 
+    Assign.prototype.isStatementAst = NO;
+
     return Assign;
 
   }).call(this);
@@ -5981,11 +5980,26 @@
       }
 
       methodAstProperties(o) {
-        var ref1, ref2, ref3, ref4;
+        var getIsComputed, ref1, ref2, ref3, ref4;
+        getIsComputed = () => {
+          if (this.name instanceof Index) {
+            if (this.name.index instanceof StringWithInterpolations) {
+              return false;
+            }
+            return true;
+          }
+          if (this.name instanceof ComputedPropertyName) {
+            return true;
+          }
+          if (this.name.name instanceof ComputedPropertyName) {
+            return true;
+          }
+          return false;
+        };
         return {
           static: !!this.isStatic,
           key: this.name.ast(o),
-          computed: this.name instanceof ComputedPropertyName || this.name.name instanceof ComputedPropertyName,
+          computed: getIsComputed(),
           kind: this.ctor ? 'constructor' : 'method',
           operator: (ref1 = (ref2 = this.operatorToken) != null ? ref2.value : void 0) != null ? ref1 : '=',
           staticClassName: (ref3 = (ref4 = this.isStatic.staticClassName) != null ? ref4.ast(o) : void 0) != null ? ref3 : null,

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1541,7 +1541,7 @@
 
     astProperties() {
       return {
-        value: this.value,
+        value: this.originalValue,
         here: !!this.here
       };
     }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4969,6 +4969,9 @@
       }
 
       isStatement(o) {
+        if (!o.compiling) {
+          return false;
+        }
         return (o != null ? o.level : void 0) === LEVEL_TOP && (this.context != null) && (this.moduleDeclaration || indexOf.call(this.context, "?") >= 0);
       }
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1084,7 +1084,7 @@ exports.PassthroughLiteral = class PassthroughLiteral extends Literal
 
   astProperties: ->
     return {
-      @value
+      value: @originalValue
       here: !!@here
     }
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3309,6 +3309,7 @@ exports.Assign = class Assign extends Base
   isAssignable: YES
 
   isStatement: (o) ->
+    return no unless o.compiling
     o?.level is LEVEL_TOP and @context? and (@moduleDeclaration or "?" in @context)
 
   checkAssignability: (o, varBase) ->

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -803,7 +803,7 @@ exports.Block = class Block extends Base
     if (level? and level isnt LEVEL_TOP) and @expressions.length
       return (new Sequence(@expressions).withLocationDataFrom @).ast o, level
 
-    super o
+    super o, level
 
   astType: ->
     if @isRootBlock

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2096,6 +2096,16 @@ test "AST as expected for Assign node", ->
     right:
       name: 'c'
 
+  testExpression 'a ?= b',
+    type: 'AssignmentExpression'
+    left:
+      type: 'Identifier'
+      name: 'a'
+    right:
+      type: 'Identifier'
+      name: 'b'
+    operator: '?='
+
 # # `FuncGlyph` node isn't exported.
 
 test "AST as expected for Code node", ->

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -229,6 +229,12 @@ test "AST as expected for PassthroughLiteral node", ->
     value: ''
     here: no
 
+  # escaped backticks
+  testExpression "`\\`abc\\``",
+    type: 'PassthroughLiteral'
+    value: '\\`abc\\`'
+    here: no
+
 test "AST as expected for IdentifierLiteral node", ->
   testExpression 'id',
     type: 'Identifier'

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1788,6 +1788,25 @@ test "AST as expected for Class node", ->
           shorthand: yes
       ]
 
+  testStatement '''
+    class A
+      @[b] = ->
+      "#{c}": ->
+      @[d] = 1
+  ''',
+    type: 'ClassDeclaration'
+    body:
+      body: [
+        type: 'ClassMethod'
+        computed: yes
+      ,
+        type: 'ClassMethod'
+        computed: no
+      ,
+        type: 'ClassProperty'
+        computed: yes
+      ]
+
 test "AST as expected for ModuleDeclaration node", ->
   testStatement 'export {X}',
     type: 'ExportNamedDeclaration'


### PR DESCRIPTION
@GeoffreyBooth PR for reconciling remaining failing tests in the Prettier plugin when swapping in the `ast` branch as its Coffeescript dependency

Between this PR and #5233, it looks like at that point the `ast` branch could successfully be used as the Coffeescript dependency for the Prettier plugin

So then next step will be to do the same thing for the ESLint plugin