### PR TITLE
Move sourceMappingURL to last line

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -201,7 +201,7 @@
       encoded = base64encode(JSON.stringify(v3SourceMap));
       sourceMapDataURI = `//# sourceMappingURL=data:application/json;base64,${encoded}`;
       sourceURL = `//# sourceURL=${filename}`;
-      js = `${js}\n${sourceMapDataURI}\n${sourceURL}`;
+      js = `${js}\n${sourceURL}\n${sourceMapDataURI}\n`;
     }
     registerCompiled(filename, code, map);
     if (options.sourceMap) {

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -166,7 +166,7 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
     encoded = base64encode JSON.stringify v3SourceMap
     sourceMapDataURI = "//# sourceMappingURL=data:application/json;base64,#{encoded}"
     sourceURL = "//# sourceURL=#{filename}"
-    js = "#{js}\n#{sourceMapDataURI}\n#{sourceURL}"
+    js = "#{js}\n#{sourceURL}\n#{sourceMapDataURI}\n"
 
   registerCompiled filename, code, map
 


### PR DESCRIPTION
This is more in line with the [spec](https://sourcemaps.info/spec.html) which says "the generated code may include a line at the end of the source, with the following form: `//# sourceMappingURL=<url>`" and "there exists a `//# sourceURL` comment in the generated code". It also looks better since the `sourceMappingURL` is very long. Also, add a trailing newline. This was motivated by mishoo/UglifyJS2#3441.