### PR TITLE
Add debugging information to error message test

### DIFF
--- a/test/error_messages.coffee
+++ b/test/error_messages.coffee
@@ -88,7 +88,7 @@ if require?
 
     eq error.message, 'hello world'
     doesNotThrow(-> error.stack)
-    notEqual error.stack.toString().indexOf(filePath), -1
+    notEqual error.stack.toString().indexOf(filePath), -1, "Expected " + filePath + "in stack trace: " + error.stack.toString()
 
   test "#4418: stack traces for compiled files reference the correct line number", ->
     # The browser is already compiling other anonymous scripts (the tests)


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines:
https://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](https://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->

One of the test cases in test/error_messages.coffee fails intermittently
in the Node.js ecosystem-testing tool CITGM. In an effort to help debug
what's going on when this occurs, this adds more information to the
AssertionError message in question.

An example of the types of failures we see is visible at https://ci.nodejs.org/job/citgm-smoker/2061/nodes=rhel72-s390x/testReport/junit/(root)/citgm/coffeescript_v2_4_1/, and reproduced here:

```console
> coffeescript@2.4.1 test /data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript
 > node ./bin/cake test
 [0;31mfailed 1 and passed 1282 tests in 10.06 seconds[0m[0m 
 [0;31m  #3890: Error.prepareStackTrace doesn't throw an error if a compiled file is deleted[0m 
 [0;31m  AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: -1 != -1
     at Function.<anonymous> (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/test/error_messages.coffee:1:1)
     at global.test (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/Cakefile:555:21)
     at Object.<anonymous> (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/test/error_messages.coffee:1:1)
     at Object.<anonymous> (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/test/error_messages.coffee:1:1)
     at Module._compile (internal/modules/cjs/loader.js:956:30)
     at Object.CoffeeScript.run (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/lib/coffeescript/index.js:67:23)
     at runTests (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/Cakefile:626:22)
     at Object.action (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/Cakefile:640:12)
     at invoke (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/lib/coffeescript/cake.js:57:26)
     at Object.exports.run (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/lib/coffeescript/cake.js:87:20)
     at Object.<anonymous> (/data/iojs/tmp/citgm_tmp/98b58812-8150-4dff-b4e1-778ad5b201ca/coffeescript/bin/cake:22:42)
     at Module._compile (internal/modules/cjs/loader.js:956:30)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
     at Module.load (internal/modules/cjs/loader.js:812:32)
     at Function.Module._load (internal/modules/cjs/loader.js:724:14)
     at Function.Module.runMain (internal/modules/cjs/loader.js:1025:10)
     at internal/main/run_main_module.js:17:11
 [0m 
   function() {
       var error, filePath, throwsAnError;
       // Adapted from https://github.com/atom/coffee-cash/blob/master/spec/coffee-cash-spec.coffee
       filePath = path.join(os.tmpdir(), 'PrepareStackTraceTestFile.coffee');
       fs.writeFileSync(filePath, "module.exports = -> throw new Error('hello world')");
       throwsAnError = require(filePath);
       fs.unlinkSync(filePath);
       try {
         throwsAnError();
       } catch (error1) {
         error = error1;
       }
       eq(error.message, 'hello world');
       doesNotThrow(function() {
         return error.stack;
       });
       return notEqual(error.stack.toString().indexOf(filePath), -1);
     }
 Browserslist: caniuse-lite is outdated. Please run next command `npm update`
 npm ERR! Test failed.  See above for more details.
```

Looking at the test itself, I don't see anything that would definitely explain why it would fail on that particular line, but I have some ideas. Perhaps the path is being truncated in the stack trace. Perhaps there is some symlink resolution that happens unexpectedly resulting the paths differing slightly. Maybe there's an oddball character in the path somewhere that gets messed up along the way. Having the extra information here will help confirm or refute hypotheses like this.