### PR TITLE
AST: handle empty file

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1201,6 +1201,13 @@
         return {body, directives};
       }
 
+      astLocationData() {
+        if (this.isRootBlock && (this.locationData == null)) {
+          return;
+        }
+        return super.astLocationData();
+      }
+
     };
 
     Block.prototype.children = ['expressions'];

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -854,6 +854,10 @@ exports.Block = class Block extends Base
       body, directives
     }
 
+  astLocationData: ->
+    return if @isRootBlock and not @locationData?
+    super()
+
 # A directive e.g. 'use strict'.
 # Currently only used during AST generation.
 exports.Directive = class Directive extends Base

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -147,6 +147,20 @@ test "AST as expected for Block node", ->
       value: ' comment'
     ]
 
+  deepStrictIncludeExpectedProperties CoffeeScript.compile('', ast: yes),
+    type: 'File'
+    program:
+      type: 'Program'
+      body: []
+      directives: []
+
+  deepStrictIncludeExpectedProperties CoffeeScript.compile(' ', ast: yes),
+    type: 'File'
+    program:
+      type: 'Program'
+      body: []
+      directives: []
+
 test "AST as expected for NumberLiteral node", ->
   testExpression '42',
     type: 'NumericLiteral'

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -3964,6 +3964,102 @@ test "AST location data as expected for Root node", ->
         line: 2
         column: 12
 
+  testAstRootLocationData ' \n',
+    type: 'File'
+    program:
+      start: 0
+      end: 2
+      range: [0, 2]
+      loc:
+        start:
+          line: 1
+          column: 0
+        end:
+          line: 2
+          column: 0
+    start: 0
+    end: 2
+    range: [0, 2]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 2
+        column: 0
+
+  testAstRootLocationData '\n',
+    type: 'File'
+    program:
+      start: 0
+      end: 1
+      range: [0, 1]
+      loc:
+        start:
+          line: 1
+          column: 0
+        end:
+          line: 2
+          column: 0
+    start: 0
+    end: 1
+    range: [0, 1]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 2
+        column: 0
+
+  testAstRootLocationData '',
+    type: 'File'
+    program:
+      start: 0
+      end: 0
+      range: [0, 0]
+      loc:
+        start:
+          line: 1
+          column: 0
+        end:
+          line: 1
+          column: 0
+    start: 0
+    end: 0
+    range: [0, 0]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 0
+
+  testAstRootLocationData ' ',
+    type: 'File'
+    program:
+      start: 0
+      end: 1
+      range: [0, 1]
+      loc:
+        start:
+          line: 1
+          column: 0
+        end:
+          line: 1
+          column: 1
+    start: 0
+    end: 1
+    range: [0, 1]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 1
+
 test "AST location data as expected for Switch node", ->
   testAstLocationData '''
     switch x


### PR DESCRIPTION
@GeoffreyBooth I came across the fact that an empty source file was crashing AST generation while working on reconciling the ESLint plugin

So this PR handles AST generation for empty source files