### PR TITLE
AST: expose tokens

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -160,10 +160,8 @@
       };
       ast.loc.end.line = ast.program.loc.end.line = sourceCodeNumberOfLines;
       ast.loc.end.column = ast.program.loc.end.column = sourceCodeLastLine.length;
-      if (!options.withTokens) {
-        return ast;
-      }
-      return {ast, tokens};
+      ast.tokens = tokens;
+      return ast;
     }
     fragments = nodes.compileToFragments(options);
     currentLine = 0;

--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -160,7 +160,10 @@
       };
       ast.loc.end.line = ast.program.loc.end.line = sourceCodeNumberOfLines;
       ast.loc.end.column = ast.program.loc.end.column = sourceCodeLastLine.length;
-      return ast;
+      if (!options.withTokens) {
+        return ast;
+      }
+      return {ast, tokens};
     }
     fragments = nodes.compileToFragments(options);
     currentLine = 0;

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -8603,7 +8603,7 @@
   };
 
   // Convert Jison-style node class location data to Babel-style location data
-  jisonLocationDataToAstLocationData = function({first_line, first_column, last_line_exclusive, last_column_exclusive, range}) {
+  exports.jisonLocationDataToAstLocationData = jisonLocationDataToAstLocationData = function({first_line, first_column, last_line_exclusive, last_column_exclusive, range}) {
     return {
       loc: {
         start: {

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -124,8 +124,8 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
     ast.loc.start = ast.program.loc.start = {line: 1, column: 0}
     ast.loc.end.line = ast.program.loc.end.line = sourceCodeNumberOfLines
     ast.loc.end.column = ast.program.loc.end.column = sourceCodeLastLine.length
-    return ast unless options.withTokens
-    return {ast, tokens}
+    ast.tokens = tokens
+    return ast
 
   fragments = nodes.compileToFragments options
 

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -124,7 +124,8 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
     ast.loc.start = ast.program.loc.start = {line: 1, column: 0}
     ast.loc.end.line = ast.program.loc.end.line = sourceCodeNumberOfLines
     ast.loc.end.column = ast.program.loc.end.column = sourceCodeLastLine.length
-    return ast
+    return ast unless options.withTokens
+    return {ast, tokens}
 
   fragments = nodes.compileToFragments options
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -5742,7 +5742,7 @@ exports.mergeAstLocationData = mergeAstLocationData = (nodeA, nodeB, {justLeadin
         greater nodeA.end, nodeB.end
 
 # Convert Jison-style node class location data to Babel-style location data
-jisonLocationDataToAstLocationData = ({first_line, first_column, last_line_exclusive, last_column_exclusive, range}) ->
+exports.jisonLocationDataToAstLocationData = jisonLocationDataToAstLocationData = ({first_line, first_column, last_line_exclusive, last_column_exclusive, range}) ->
   return
     loc:
       start:


### PR DESCRIPTION
@GeoffreyBooth here's a first PR reconciling the `ast` branch with the ESLint plugin

The ESLint custom parser needs access to the Coffeescript tokens in addition to the AST, so this PR optionally exposes the tokens when generating AST