### PR TITLE
AST: declarations

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -1328,7 +1328,8 @@
 
     astProperties() {
       return {
-        name: 'Infinity'
+        name: 'Infinity',
+        declaration: false
       };
     }
 
@@ -1355,7 +1356,8 @@
 
     astProperties() {
       return {
-        name: 'NaN'
+        name: 'NaN',
+        declaration: false
       };
     }
 
@@ -1588,7 +1590,8 @@
 
       astProperties() {
         return {
-          name: this.value
+          name: this.value,
+          declaration: !!this.isDeclaration
         };
       }
 
@@ -1612,7 +1615,8 @@
 
       astProperties() {
         return {
-          name: this.value
+          name: this.value,
+          declaration: false
         };
       }
 
@@ -1710,7 +1714,8 @@
 
     astProperties() {
       return {
-        name: this.value
+        name: this.value,
+        declaration: false
       };
     }
 
@@ -1748,7 +1753,8 @@
 
     astProperties() {
       return {
-        name: 'default'
+        name: 'default',
+        declaration: false
       };
     }
 
@@ -5011,8 +5017,8 @@
         return (o != null ? o.level : void 0) === LEVEL_TOP && (this.context != null) && (this.moduleDeclaration || indexOf.call(this.context, "?") >= 0);
       }
 
-      checkAssignability(o, varBase) {
-        if (Object.prototype.hasOwnProperty.call(o.scope.positions, varBase.value) && o.scope.variables[o.scope.positions[varBase.value]].type === 'import') {
+      checkNameAssignability(o, varBase) {
+        if (o.scope.type(varBase.value) === 'import') {
           return varBase.error(`'${varBase.value}' is read-only`);
         }
       }
@@ -5025,12 +5031,61 @@
         return unfoldSoak(o, this, 'variable');
       }
 
+      addScopeVariables(o, {checkAssignability = true} = {}) {
+        var varBase;
+        if (!(!this.context || this.context === '**=')) {
+          return;
+        }
+        varBase = this.variable.unwrapAll();
+        if (checkAssignability && !varBase.isAssignable()) {
+          this.variable.error(`'${this.variable.compile(o)}' can't be assigned`);
+        }
+        return varBase.eachName((name) => {
+          var alreadyDeclared, commentFragments, commentsNode, message;
+          if (typeof name.hasProperties === "function" ? name.hasProperties() : void 0) {
+            return;
+          }
+          message = isUnassignable(name.value);
+          if (message) {
+            name.error(message);
+          }
+          // `moduleDeclaration` can be `'import'` or `'export'`.
+          this.checkNameAssignability(o, name);
+          if (this.moduleDeclaration) {
+            o.scope.add(name.value, this.moduleDeclaration);
+            return name.isDeclaration = true;
+          } else if (this.param) {
+            return o.scope.add(name.value, this.param === 'alwaysDeclare' ? 'var' : 'param');
+          } else {
+            alreadyDeclared = o.scope.find(name.value);
+            if (name.isDeclaration == null) {
+              name.isDeclaration = !alreadyDeclared;
+            }
+            // If this assignment identifier has one or more herecomments
+            // attached, output them as part of the declarations line (unless
+            // other herecomments are already staged there) for compatibility
+            // with Flow typing. Don’t do this if this assignment is for a
+            // class, e.g. `ClassName = class ClassName {`, as Flow requires
+            // the comment to be between the class name and the `{`.
+            if (name.comments && !o.scope.comments[name.value] && !(this.value instanceof Class) && name.comments.every(function(comment) {
+              return comment.here && !comment.multiline;
+            })) {
+              commentsNode = new IdentifierLiteral(name.value);
+              commentsNode.comments = name.comments;
+              commentFragments = [];
+              this.compileCommentFragments(o, commentsNode, commentFragments);
+              return o.scope.comments[name.value] = commentFragments;
+            }
+          }
+        });
+      }
+
       // Compile an assignment, delegating to `compileDestructuring` or
       // `compileSplice` if appropriate. Keep track of the name of the base object
       // we've been assigned to, for correct internal references. If the variable
       // has not been seen yet within the current scope, declare it.
       compileNode(o) {
-        var answer, compiledName, isValue, name, properties, prototype, ref1, ref2, ref3, ref4, ref5, val, varBase;
+        var answer, compiledName, isValue, name, properties, prototype, ref1, ref2, ref3, ref4, ref5, val;
         isValue = this.variable instanceof Value;
         if (isValue) {
           // If `@variable` is an array or an object, we’re destructuring;
@@ -5056,46 +5111,7 @@
             return this.compileSpecialMath(o);
           }
         }
-        if (!this.context || this.context === '**=') {
-          varBase = this.variable.unwrapAll();
-          if (!varBase.isAssignable()) {
-            this.variable.error(`'${this.variable.compile(o)}' can't be assigned`);
-          }
-          varBase.eachName((name) => {
-            var commentFragments, commentsNode, message;
-            if (typeof name.hasProperties === "function" ? name.hasProperties() : void 0) {
-              return;
-            }
-            message = isUnassignable(name.value);
-            if (message) {
-              name.error(message);
-            }
-            // `moduleDeclaration` can be `'import'` or `'export'`.
-            this.checkAssignability(o, name);
-            if (this.moduleDeclaration) {
-              return o.scope.add(name.value, this.moduleDeclaration);
-            } else if (this.param) {
-              return o.scope.add(name.value, this.param === 'alwaysDeclare' ? 'var' : 'param');
-            } else {
-              o.scope.find(name.value);
-              // If this assignment identifier has one or more herecomments
-              // attached, output them as part of the declarations line (unless
-              // other herecomments are already staged there) for compatibility
-              // with Flow typing. Don’t do this if this assignment is for a
-              // class, e.g. `ClassName = class ClassName {`, as Flow requires
-              // the comment to be between the class name and the `{`.
-              if (name.comments && !o.scope.comments[name.value] && !(this.value instanceof Class) && name.comments.every(function(comment) {
-                return comment.here && !comment.multiline;
-              })) {
-                commentsNode = new IdentifierLiteral(name.value);
-                commentsNode.comments = name.comments;
-                commentFragments = [];
-                this.compileCommentFragments(o, commentsNode, commentFragments);
-                return o.scope.comments[name.value] = commentFragments;
-              }
-            }
-          });
-        }
+        this.addScopeVariables(o);
         if (this.value instanceof Code) {
           if (this.value.isStatic) {
             this.value.name = this.variable.properties[0];
@@ -5488,6 +5504,13 @@
         // know that, so that those nodes know that they’re assignable as
         // destructured variables.
         return this.variable.base.propagateLhs(true);
+      }
+
+      ast(o, level) {
+        this.addScopeVariables(o, {
+          checkAssignability: false
+        });
+        return super.ast(o, level);
       }
 
       astType() {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4386,11 +4386,21 @@
         return null;
       }
 
+      declareName(o) {
+        var alreadyDeclared, name, ref1;
+        if (!((name = (ref1 = this.variable) != null ? ref1.unwrap() : void 0) instanceof IdentifierLiteral)) {
+          return;
+        }
+        alreadyDeclared = o.scope.find(name.value);
+        return name.isDeclaration = !alreadyDeclared;
+      }
+
       isStatementAst() {
         return true;
       }
 
       ast(o, level) {
+        this.declareName(o);
         this.name = this.determineName();
         this.body.isClassBody = true;
         if (this.hasGeneratedBody) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -7133,6 +7133,18 @@
         return [].concat(this.makeCode(" catch ("), placeholder.compileToFragments(o), this.makeCode(") {\n"), this.recovery.compileToFragments(o, LEVEL_TOP), this.makeCode(`\n${this.tab}}`));
       }
 
+      ast(o, level) {
+        var ref1;
+        if ((ref1 = this.errorVariable) != null) {
+          ref1.eachName(function(name) {
+            var alreadyDeclared;
+            alreadyDeclared = o.scope.find(name.value);
+            return name.isDeclaration = !alreadyDeclared;
+          });
+        }
+        return super.ast(o, level);
+      }
+
       astType() {
         return 'CatchClause';
       }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3831,7 +3831,9 @@
       isComputedPropertyName = this.key instanceof Value && this.key.base instanceof ComputedPropertyName;
       keyAst = this.key.ast(o, LEVEL_LIST);
       return {
-        key: keyAst,
+        key: (keyAst != null ? keyAst.declaration : void 0) ? Object.assign({}, keyAst, {
+          declaration: false
+        }) : keyAst,
         value: (ref1 = (ref2 = this.value) != null ? ref2.ast(o, LEVEL_LIST) : void 0) != null ? ref1 : keyAst,
         shorthand: !!this.shorthand,
         computed: !!isComputedPropertyName,
@@ -7805,6 +7807,22 @@
           fragments.push(this.makeCode(returnResult));
         }
         return fragments;
+      }
+
+      ast(o, level) {
+        var addToScope, ref1, ref2;
+        addToScope = function(name) {
+          var alreadyDeclared;
+          alreadyDeclared = o.scope.find(name.value);
+          return name.isDeclaration = !alreadyDeclared;
+        };
+        if ((ref1 = this.name) != null) {
+          ref1.eachName(addToScope);
+        }
+        if ((ref2 = this.index) != null) {
+          ref2.eachName(addToScope);
+        }
+        return super.ast(o, level);
       }
 
       astType() {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2572,7 +2572,11 @@ exports.ObjectProperty = class ObjectProperty extends Base
     keyAst = @key.ast o, LEVEL_LIST
 
     return
-      key: keyAst
+      key:
+        if keyAst?.declaration
+          Object.assign {}, keyAst, declaration: no
+        else
+          keyAst
       value: @value?.ast(o, LEVEL_LIST) ? keyAst
       shorthand: !!@shorthand
       computed: !!isComputedPropertyName
@@ -5182,6 +5186,14 @@ exports.For = class For extends While
       @makeCode(@tab), @makeCode('}')
     fragments.push @makeCode(returnResult) if returnResult
     fragments
+
+  ast: (o, level) ->
+    addToScope = (name) ->
+      alreadyDeclared = o.scope.find name.value
+      name.isDeclaration = not alreadyDeclared
+    @name?.eachName addToScope
+    @index?.eachName addToScope
+    super o, level
 
   astType: -> 'For'
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2928,9 +2928,15 @@ exports.Class = class Class extends Base
 
     null
 
+  declareName: (o) ->
+    return unless (name = @variable?.unwrap()) instanceof IdentifierLiteral
+    alreadyDeclared = o.scope.find name.value
+    name.isDeclaration = not alreadyDeclared
+
   isStatementAst: -> yes
 
   ast: (o, level) ->
+    @declareName o
     @name = @determineName()
     @body.isClassBody = yes
     @body.locationData = zeroWidthLocationDataFromEndLocation @locationData if @hasGeneratedBody

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -4757,6 +4757,13 @@ exports.Catch = class Catch extends Base
     [].concat @makeCode(" catch ("), placeholder.compileToFragments(o), @makeCode(") {\n"),
       @recovery.compileToFragments(o, LEVEL_TOP), @makeCode("\n#{@tab}}")
 
+  ast: (o, level) ->
+    @errorVariable?.eachName (name) ->
+      alreadyDeclared = o.scope.find name.value
+      name.isDeclaration = not alreadyDeclared
+
+    super o, level
+
   astType: -> 'CatchClause'
 
   astProperties: (o) ->

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2952,6 +2952,7 @@ test "AST as expected for Try node", ->
       param:
         type: 'Identifier'
         name: 'e'
+        declaration: yes
       body:
         type: 'BlockStatement'
         body: [
@@ -2999,6 +3000,11 @@ test "AST as expected for Try node", ->
       type: 'CatchClause'
       param:
         type: 'ObjectPattern'
+        properties: [
+          type: 'ObjectProperty'
+          key: ID 'e', declaration: no
+          value: ID 'e', declaration: yes
+        ]
       body:
         type: 'BlockStatement'
         body: [

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2261,11 +2261,13 @@ test "AST as expected for Code node", ->
     params: [
       type: 'Identifier'
       name: 'a'
+      declaration: no
     ,
       type: 'AssignmentPattern'
       left:
         type: 'Identifier'
         name: 'b'
+        declaration: no
       right:
         type: 'NumericLiteral'
         value: 1
@@ -2294,8 +2296,8 @@ test "AST as expected for Code node", ->
       type: 'ObjectPattern'
       properties: [
         type: 'ObjectProperty'
-        key: ID('a')
-        value: ID('a')
+        key: ID 'a', declaration: no
+        value: ID 'a', declaration: no
         shorthand: yes
       ]
     ]
@@ -2309,7 +2311,7 @@ test "AST as expected for Code node", ->
     params: [
       type: 'ArrayPattern'
       elements: [
-        ID('a')
+        ID 'a', declaration: no
       ]
     ]
     body: EMPTY_BLOCK
@@ -2325,10 +2327,10 @@ test "AST as expected for Code node", ->
         type: 'ObjectPattern'
         properties: [
           type: 'ObjectProperty'
-          key: ID('a')
+          key: ID 'a', declaration: no
           value:
             type: 'AssignmentPattern'
-            left: ID('a')
+            left: ID 'a', declaration: no
             right: NUMBER(1)
           shorthand: yes
         ]
@@ -2349,7 +2351,7 @@ test "AST as expected for Code node", ->
         type: 'ArrayPattern'
         elements: [
           type: 'AssignmentPattern'
-          left: ID('a')
+          left: ID 'a', declaration: no
           right: NUMBER(1)
         ]
       right:
@@ -2376,7 +2378,7 @@ test "AST as expected for Code node", ->
       object:
         type: 'ThisExpression'
         shorthand: yes
-      property: ID 'a'
+      property: ID 'a', declaration: no
     ]
     body: EMPTY_BLOCK
     generator: no
@@ -2421,8 +2423,8 @@ test "AST as expected for Code node", ->
       type: 'ObjectPattern'
       properties: [
         type: 'ObjectProperty'
-        key:   ID 'a'
-        value: ID 'a'
+        key:   ID 'a', declaration: no
+        value: ID 'a', declaration: no
         shorthand: yes
         computed: yes
       ]
@@ -2436,7 +2438,7 @@ test "AST as expected for Code node", ->
     type: 'FunctionExpression'
     params: [
       type: 'RestElement'
-      argument: ID 'a'
+      argument: ID 'a', declaration: no
       postfix: no
     ]
     body: EMPTY_BLOCK
@@ -2538,6 +2540,7 @@ test "AST as expected for Splat node", ->
       argument:
         type: 'Identifier'
         name: 'a'
+        declaration: no
       postfix: yes
     ]
 
@@ -2545,21 +2548,15 @@ test "AST as expected for Splat node", ->
     type: 'ArrayExpression'
     elements: [
       name: 'b'
+      declaration: no
     ,
       type: 'SpreadElement'
       argument:
         type: 'Identifier'
         name: 'c'
+        declaration: no
       postfix: no
     ]
-
-  # testExpression '(a...) ->',
-  #   params: [
-  #     type: 'Param'
-  #     splat: yes
-  #     name:
-  #       value: 'a'
-  #   ]
 
 #   # TODO: Test object splats.
 

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2086,9 +2086,11 @@ test "AST as expected for Assign node", ->
     left:
       type: 'Identifier'
       name: 'a'
+      declaration: yes
     right:
       type: 'Identifier'
       name: 'b'
+      declaration: no
     operator: '='
 
   testExpression 'a += b',
@@ -2096,9 +2098,11 @@ test "AST as expected for Assign node", ->
     left:
       type: 'Identifier'
       name: 'a'
+      declaration: no
     right:
       type: 'Identifier'
       name: 'b'
+      declaration: no
     operator: '+='
 
   testExpression '[@a = 2, {b: {c = 3} = {}, d...}, ...e] = f',
@@ -2113,6 +2117,7 @@ test "AST as expected for Assign node", ->
             type: 'ThisExpression'
           property:
             name: 'a'
+            declaration: no
         right:
           type: 'NumericLiteral'
       ,
@@ -2121,6 +2126,7 @@ test "AST as expected for Assign node", ->
           type: 'ObjectProperty'
           key:
             name: 'b'
+            declaration: no
           value:
             type: 'AssignmentPattern'
             left:
@@ -2133,6 +2139,7 @@ test "AST as expected for Assign node", ->
                   type: 'AssignmentPattern'
                   left:
                     name: 'c'
+                    declaration: yes
                   right:
                     value: 3
                 shorthand: yes
@@ -2142,10 +2149,16 @@ test "AST as expected for Assign node", ->
               properties: []
         ,
           type: 'RestElement'
+          argument:
+            name: 'd'
+            declaration: yes
           postfix: yes
         ]
       ,
         type: 'RestElement'
+        argument:
+          name: 'e'
+          declaration: yes
         postfix: no
       ]
     right:
@@ -2159,23 +2172,30 @@ test "AST as expected for Assign node", ->
         type: 'ObjectProperty'
         key:
           name: 'a'
+          declaration: no
         value:
           type: 'ArrayPattern'
           elements: [
             type: 'RestElement'
+            argument:
+              name: 'b'
+              declaration: yes
           ]
       ]
     right:
       name: 'c'
+      declaration: no
 
   testExpression 'a ?= b',
     type: 'AssignmentExpression'
     left:
       type: 'Identifier'
       name: 'a'
+      declaration: no
     right:
       type: 'Identifier'
       name: 'b'
+      declaration: no
     operator: '?='
 
 # # `FuncGlyph` node isn't exported.

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -102,10 +102,11 @@ EMPTY_BLOCK =
   body: []
   directives: []
 
-ID = (name) -> {
-  type: 'Identifier'
-  name
-}
+ID = (name, additionalProperties = {}) ->
+  Object.assign({
+    type: 'Identifier'
+    name
+  }, additionalProperties)
 
 NUMBER = (value) -> {
   type: 'NumericLiteral'
@@ -3166,11 +3167,11 @@ test "AST as expected for StringWithInterpolations node", ->
 test "AST as expected for For node", ->
   testStatement 'for x, i in arr when x? then return',
     type: 'For'
-    name: ID 'x'
-    index: ID 'i'
+    name: ID 'x', declaration: yes
+    index: ID 'i', declaration: yes
     guard:
       type: 'UnaryExpression'
-    source: ID 'arr'
+    source: ID 'arr', declaration: no
     body:
       type: 'BlockStatement'
       body: [
@@ -3184,10 +3185,10 @@ test "AST as expected for For node", ->
 
   testStatement 'for k, v of obj then return',
     type: 'For'
-    name: ID 'v'
-    index: ID 'k'
+    name: ID 'v', declaration: yes
+    index: ID 'k', declaration: yes
     guard: null
-    source: ID 'obj'
+    source: ID 'obj', declaration: no
     body:
       type: 'BlockStatement'
       body: [
@@ -3201,11 +3202,11 @@ test "AST as expected for For node", ->
 
   testStatement 'for x from iterable then',
     type: 'For'
-    name: ID 'x'
+    name: ID 'x', declaration: yes
     index: null
     guard: null
     body: EMPTY_BLOCK
-    source: ID 'iterable'
+    source: ID 'iterable', declaration: no
     style: 'from'
     own: no
     postfix: no
@@ -3214,14 +3215,14 @@ test "AST as expected for For node", ->
 
   testStatement 'for i in [0...42] by step when not (i % 2) then',
     type: 'For'
-    name: ID 'i'
+    name: ID 'i', declaration: yes
     index: null
     body: EMPTY_BLOCK
     source:
       type: 'Range'
     guard:
       type: 'UnaryExpression'
-    step: ID 'step'
+    step: ID 'step', declaration: no
     style: 'in'
     own: no
     postfix: no
@@ -3231,15 +3232,15 @@ test "AST as expected for For node", ->
     type: 'AssignmentExpression'
     right:
       type: 'For'
-      name: ID 'x'
+      name: ID 'x', declaration: yes
       index: null
       body:
         type: 'BlockStatement'
         body: [
           type: 'ExpressionStatement'
-          expression: ID 'x'
+          expression: ID 'x', declaration: no
         ]
-      source: ID 'y'
+      source: ID 'y', declaration: no
       guard: null
       step: null
       style: 'in'
@@ -3255,7 +3256,7 @@ test "AST as expected for For node", ->
       type: 'BlockStatement'
       body: [
         type: 'ExpressionStatement'
-        expression: ID 'x'
+        expression: ID 'x', declaration: no
       ]
     source:
       type: 'Range'
@@ -3272,8 +3273,8 @@ test "AST as expected for For node", ->
       d
   ''',
     type: 'For'
-    name: ID 'y'
-    index: ID 'x'
+    name: ID 'y', declaration: yes
+    index: ID 'x', declaration: yes
     body:
       type: 'BlockStatement'
       body: [
@@ -3282,9 +3283,9 @@ test "AST as expected for For node", ->
           type: 'CallExpression'
       ,
         type: 'ExpressionStatement'
-        expression: ID 'd'
+        expression: ID 'd', declaration: no
       ]
-    source: ID 'z'
+    source: ID 'z', declaration: no
     guard: null
     step: null
     style: 'of'
@@ -3302,15 +3303,15 @@ test "AST as expected for For node", ->
       type: 'BlockStatement'
       body: [
         type: 'For'
-        name: ID 'x'
+        name: ID 'x', declaration: yes
         index: null
         body:
           type: 'BlockStatement'
           body: [
             type: 'ExpressionStatement'
-            expression: ID 'z'
+            expression: ID 'z', declaration: no
           ]
-        source: ID 'y'
+        source: ID 'y', declaration: no
         guard: null
         step: null
         style: 'from'
@@ -3328,8 +3329,8 @@ test "AST as expected for For node", ->
       type: 'ObjectPattern'
       properties: [
         type: 'ObjectProperty'
-        key: ID 'x'
-        value: ID 'x'
+        key: ID 'x', declaration: no
+        value: ID 'x', declaration: yes
         shorthand: yes
         computed: no
       ]
@@ -3355,7 +3356,7 @@ test "AST as expected for For node", ->
     name:
       type: 'ArrayPattern'
       elements: [
-        ID 'x'
+        ID 'x', declaration: yes
       ]
     index: null
     body:

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1561,7 +1561,7 @@ test "AST as expected for Arr node", ->
 test "AST as expected for Class node", ->
   testStatement 'class Klass',
     type: 'ClassDeclaration'
-    id: ID 'Klass'
+    id: ID 'Klass', declaration: yes
     superClass: null
     body:
       type: 'ClassBody'
@@ -1569,22 +1569,22 @@ test "AST as expected for Class node", ->
 
   testStatement 'class child extends parent',
     type: 'ClassDeclaration'
-    id: ID 'child'
-    superClass: ID 'parent'
+    id: ID 'child', declaration: yes
+    superClass: ID 'parent', declaration: no
     body:
       type: 'ClassBody'
       body: []
 
   testStatement 'class Klass then constructor: ->',
     type: 'ClassDeclaration'
-    id: ID 'Klass'
+    id: ID 'Klass', declaration: yes
     superClass: null
     body:
       type: 'ClassBody'
       body: [
         type: 'ClassMethod'
         static: no
-        key: ID 'constructor'
+        key: ID 'constructor', declaration: no
         computed: no
         kind: 'constructor'
         id: null
@@ -1605,7 +1605,7 @@ test "AST as expected for Class node", ->
     type: 'AssignmentExpression'
     right:
       type: 'ClassExpression'
-      id: ID 'A'
+      id: ID 'A', declaration: yes
       superClass: null
       body:
         type: 'ClassBody'
@@ -1660,7 +1660,7 @@ test "AST as expected for Class node", ->
       this.i = 4
   ''',
     type: 'ClassDeclaration'
-    id: ID 'A'
+    id: ID 'A', declaration: yes
     superClass: null
     body:
       type: 'ClassBody'
@@ -1720,7 +1720,7 @@ test "AST as expected for Class node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'AssignmentExpression'
-          left: ID 'j'
+          left: ID 'j', declaration: yes
           right: NUMBER 5
       ,
         type: 'ClassProperty'
@@ -1781,13 +1781,13 @@ test "AST as expected for Class node", ->
       @[f]: 3
   ''',
     type: 'ClassDeclaration'
-    id: ID 'A'
+    id: ID 'A', declaration: yes
     superClass: null
     body:
       type: 'ClassBody'
       body: [
         type: 'ClassPrototypeProperty'
-        key: ID 'b'
+        key: ID 'b', declaration: no
         value: NUMBER 1
         computed: no
       ,
@@ -1854,6 +1854,15 @@ test "AST as expected for Class node", ->
         type: 'ClassProperty'
         computed: yes
       ]
+
+  testStatement '''
+    class A.b
+  ''',
+    type: 'ClassDeclaration'
+    id:
+      type: 'MemberExpression'
+      object: ID 'A', declaration: no
+      property: ID 'b', declaration: no
 
 test "AST as expected for ModuleDeclaration node", ->
   testStatement 'export {X}',

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1873,9 +1873,11 @@ test "AST as expected for ModuleDeclaration node", ->
       local:
         type: 'Identifier'
         name: 'X'
+        declaration: no
       exported:
         type: 'Identifier'
         name: 'X'
+        declaration: no
     ]
     source: null
     exportKind: 'value'
@@ -1887,6 +1889,7 @@ test "AST as expected for ModuleDeclaration node", ->
       local:
         type: 'Identifier'
         name: 'X'
+        declaration: no
     ]
     importKind: 'value'
     source:
@@ -1901,15 +1904,18 @@ test "AST as expected for ImportDeclaration node", ->
       local:
         type: 'Identifier'
         name: 'React'
+        declaration: no
     ,
       type: 'ImportSpecifier'
       imported:
         type: 'Identifier'
         name: 'Component'
+        declaration: no
       importKind: null
       local:
         type: 'Identifier'
         name: 'Component'
+        declaration: no
     ]
     importKind: 'value'
     source:
@@ -1932,6 +1938,7 @@ test "AST as expected for ExportNamedDeclaration node", ->
       type: 'AssignmentExpression'
       left:
         type: 'Identifier'
+        declaration: yes
       right:
         type: 'FunctionExpression'
     specifiers: []
@@ -1948,17 +1955,21 @@ test "AST as expected for ExportNamedDeclaration node", ->
       local:
         type: 'Identifier'
         name: 'x'
+        declaration: no
       exported:
         type: 'Identifier'
         name: 'y'
+        declaration: no
     ,
       type: 'ExportSpecifier'
       local:
         type: 'Identifier'
         name: 'z'
+        declaration: no
       exported:
         type: 'Identifier'
         name: 'default'
+        declaration: no
     ]
     source: null
     exportKind: 'value'
@@ -1971,17 +1982,21 @@ test "AST as expected for ExportNamedDeclaration node", ->
       local:
         type: 'Identifier'
         name: 'default'
+        declaration: no
       exported:
         type: 'Identifier'
         name: 'default'
+        declaration: no
     ,
       type: 'ExportSpecifier'
       local:
         type: 'Identifier'
         name: 'default'
+        declaration: no
       exported:
         type: 'Identifier'
         name: 'b'
+        declaration: no
     ]
     source:
       type: 'StringLiteral'
@@ -1991,10 +2006,10 @@ test "AST as expected for ExportNamedDeclaration node", ->
     exportKind: 'value'
 
 test "AST as expected for ExportDefaultDeclaration node", ->
-  # testStatement 'export default class',
-  #   type: 'ExportDefaultDeclaration'
-  #   clause:
-  #     type: 'Class'
+  testStatement 'export default class',
+    type: 'ExportDefaultDeclaration'
+    declaration:
+      type: 'ClassDeclaration'
 
   testStatement 'export default "abc"',
     type: 'ExportDefaultDeclaration'
@@ -2003,6 +2018,13 @@ test "AST as expected for ExportDefaultDeclaration node", ->
       value: 'abc'
       extra:
         raw: '"abc"'
+
+  testStatement 'export default a = b',
+    type: 'ExportDefaultDeclaration'
+    declaration:
+      type: 'AssignmentExpression'
+      left: ID 'a', declaration: yes
+      right: ID 'b', declaration: no
 
 test "AST as expected for ExportAllDeclaration node", ->
   testStatement 'export * from "module-name"',
@@ -2023,25 +2045,31 @@ test "AST as expected for ExportSpecifierList node", ->
       local:
         type: 'Identifier'
         name: 'a'
+        declaration: no
       exported:
         type: 'Identifier'
         name: 'a'
+        declaration: no
     ,
       type: 'ExportSpecifier'
       local:
         type: 'Identifier'
         name: 'b'
+        declaration: no
       exported:
         type: 'Identifier'
         name: 'b'
+        declaration: no
     ,
       type: 'ExportSpecifier'
       local:
         type: 'Identifier'
         name: 'c'
+        declaration: no
       exported:
         type: 'Identifier'
         name: 'c'
+        declaration: no
     ]
 
 test "AST as expected for ImportDefaultSpecifier node", ->
@@ -2052,6 +2080,7 @@ test "AST as expected for ImportDefaultSpecifier node", ->
       local:
         type: 'Identifier'
         name: 'React'
+        declaration: no
     ]
     importKind: 'value'
     source:
@@ -2066,6 +2095,7 @@ test "AST as expected for ImportNamespaceSpecifier node", ->
       local:
         type: 'Identifier'
         name: 'React'
+        declaration: no
     ]
     importKind: 'value'
     source:
@@ -2079,11 +2109,13 @@ test "AST as expected for ImportNamespaceSpecifier node", ->
       local:
         type: 'Identifier'
         name: 'React'
+        declaration: no
     ,
       type: 'ImportNamespaceSpecifier'
       local:
         type: 'Identifier'
         name: 'ReactStar'
+        declaration: no
     ]
     importKind: 'value'
     source:


### PR DESCRIPTION
@GeoffreyBooth PR exposing whether variable references (ie `Identifier` AST nodes) represent a declaration of that variable or not

This represents one of the big chunks of reconciling with the ESLint plugin, since it enables the usage of variable declaration/scope-awareness-based ESLint rules like [`no-undef`](https://eslint.org/docs/rules/no-undef)/[`no-unused-vars`](https://eslint.org/docs/rules/no-unused-vars), which are probably the single most useful ESLint rules in practice

Based on `ast-with-tokens`, [here](https://github.com/helixbass/copheescript/compare/ast-with-tokens...ast-declaration) is just the diff against that branch