### PR TITLE
Location data: compensate for stripped characters

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -63,6 +63,7 @@
       this.chunkLine = opts.line || 0; // The start line for the current @chunk.
       this.chunkColumn = opts.column || 0; // The start column of the current @chunk.
       this.chunkOffset = opts.offset || 0; // The start offset for the current @chunk.
+      this.locationDataCompensations = opts.locationDataCompensations || {};
       code = this.clean(code); // The stripped, cleaned original source code.
       
       // At every position, run through this list of attempted matches,
@@ -95,14 +96,25 @@
     // returns, etc. If we’re lexing literate CoffeeScript, strip external Markdown
     // by removing all lines that aren’t indented by at least four spaces or a tab.
     clean(code) {
+      var base, thusFar;
+      thusFar = 0;
       if (code.charCodeAt(0) === BOM) {
         code = code.slice(1);
+        this.locationDataCompensations[0] = 1;
+        thusFar += 1;
       }
-      code = code.replace(/\r/g, '').replace(TRAILING_SPACES, '');
       if (WHITESPACE.test(code)) {
         code = `\n${code}`;
         this.chunkLine--;
+        if ((base = this.locationDataCompensations)[0] == null) {
+          base[0] = 0;
+        }
+        this.locationDataCompensations[0] -= 1;
       }
+      code = code.replace(/\r/g, (match, offset) => {
+        this.locationDataCompensations[thusFar + offset] = 1;
+        return '';
+      }).replace(TRAILING_SPACES, '');
       if (this.literate) {
         code = invertLiterate(code);
       }
@@ -1273,7 +1285,8 @@
           line,
           column,
           offset,
-          untilBalanced: true
+          untilBalanced: true,
+          locationDataCompensations: this.locationDataCompensations
         }));
         // Account for the `#` in `#{`.
         index += interpolationOffset;
@@ -1458,13 +1471,33 @@
     // Helpers
     // -------
 
-      // Returns the line and column number from an offset into the current chunk.
+      // Compensate for the things we strip out initially (e.g. carriage returns)
+    // so that location data stays accurate with respect to the original source file.
+    getLocationDataCompensation(start, end) {
+      var compensation, index, initialEnd, length, ref;
+      compensation = 0;
+      initialEnd = end;
+      ref = this.locationDataCompensations;
+      for (index in ref) {
+        length = ref[index];
+        index = parseInt(index, 10);
+        if (!(start <= index && (index < end || index === end && start === initialEnd))) {
+          continue;
+        }
+        compensation += length;
+        end += length;
+      }
+      return compensation;
+    }
+
+    // Returns the line and column number from an offset into the current chunk.
 
     // `offset` is a number of characters into `@chunk`.
     getLineAndColumnFromChunk(offset) {
-      var column, lastLine, lineCount, ref, string;
+      var column, columnCompensation, compensation, lastLine, lineCount, ref, string;
+      compensation = this.getLocationDataCompensation(this.chunkOffset, this.chunkOffset + offset);
       if (offset === 0) {
-        return [this.chunkLine, this.chunkColumn, this.chunkOffset];
+        return [this.chunkLine, this.chunkColumn + compensation, this.chunkOffset + compensation];
       }
       if (offset >= this.chunk.length) {
         string = this.chunk;
@@ -1476,10 +1509,12 @@
       if (lineCount > 0) {
         ref = string.split('\n'), [lastLine] = slice.call(ref, -1);
         column = lastLine.length;
+        columnCompensation = this.getLocationDataCompensation(this.chunkOffset + offset - column, this.chunkOffset + offset);
       } else {
         column += string.length;
+        columnCompensation = compensation;
       }
-      return [this.chunkLine + lineCount, column, this.chunkOffset + offset];
+      return [this.chunkLine + lineCount, column + columnCompensation, this.chunkOffset + offset + compensation];
     }
 
     makeLocationData({offsetInChunk, length}) {

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1494,7 +1494,7 @@
 
     // `offset` is a number of characters into `@chunk`.
     getLineAndColumnFromChunk(offset) {
-      var column, columnCompensation, compensation, lastLine, lineCount, ref, string;
+      var column, columnCompensation, compensation, lastLine, lineCount, previousLinesCompensation, ref, string;
       compensation = this.getLocationDataCompensation(this.chunkOffset, this.chunkOffset + offset);
       if (offset === 0) {
         return [this.chunkLine, this.chunkColumn + compensation, this.chunkOffset + compensation];
@@ -1509,7 +1509,12 @@
       if (lineCount > 0) {
         ref = string.split('\n'), [lastLine] = slice.call(ref, -1);
         column = lastLine.length;
-        columnCompensation = this.getLocationDataCompensation(this.chunkOffset + offset - column, this.chunkOffset + offset);
+        previousLinesCompensation = this.getLocationDataCompensation(this.chunkOffset, this.chunkOffset + offset - column);
+        if (previousLinesCompensation < 0) {
+          // Don't recompensate for initially inserted newline.
+          previousLinesCompensation = 0;
+        }
+        columnCompensation = this.getLocationDataCompensation(this.chunkOffset + offset + previousLinesCompensation - column, this.chunkOffset + offset + previousLinesCompensation);
       } else {
         column += string.length;
         columnCompensation = compensation;

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1055,7 +1055,13 @@ exports.Lexer = class Lexer
     if lineCount > 0
       [..., lastLine] = string.split '\n'
       column = lastLine.length
-      columnCompensation = @getLocationDataCompensation @chunkOffset + offset - column, @chunkOffset + offset
+      previousLinesCompensation = @getLocationDataCompensation @chunkOffset, @chunkOffset + offset - column
+      # Don't recompensate for initially inserted newline.
+      previousLinesCompensation = 0 if previousLinesCompensation < 0
+      columnCompensation = @getLocationDataCompensation(
+        @chunkOffset + offset + previousLinesCompensation - column
+        @chunkOffset + offset + previousLinesCompensation
+      )
     else
       column += string.length
       columnCompensation = compensation

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -58,6 +58,8 @@ exports.Lexer = class Lexer
       opts.column or 0           # The start column of the current @chunk.
     @chunkOffset =
       opts.offset or 0           # The start offset for the current @chunk.
+    @locationDataCompensations =
+      opts.locationDataCompensations or {} # The location data compensations for the current @chunk.
     code = @clean code           # The stripped, cleaned original source code.
 
     # At every position, run through this list of attempted matches,
@@ -93,11 +95,21 @@ exports.Lexer = class Lexer
   # returns, etc. If we’re lexing literate CoffeeScript, strip external Markdown
   # by removing all lines that aren’t indented by at least four spaces or a tab.
   clean: (code) ->
-    code = code.slice(1) if code.charCodeAt(0) is BOM
-    code = code.replace(/\r/g, '').replace TRAILING_SPACES, ''
+    thusFar = 0
+    if code.charCodeAt(0) is BOM
+      code = code.slice 1
+      @locationDataCompensations[0] = 1
+      thusFar += 1
     if WHITESPACE.test code
       code = "\n#{code}"
       @chunkLine--
+      @locationDataCompensations[0] ?= 0
+      @locationDataCompensations[0] -= 1
+    code = code
+      .replace /\r/g, (match, offset) =>
+        @locationDataCompensations[thusFar + offset] = 1
+        ''
+      .replace TRAILING_SPACES, ''
     code = invertLiterate code if @literate
     code
 
@@ -877,7 +889,7 @@ exports.Lexer = class Lexer
       [line, column, offset] = @getLineAndColumnFromChunk offsetInChunk + interpolationOffset
       rest = str[interpolationOffset..]
       {tokens: nested, index} =
-        new Lexer().tokenize rest, {line, column, offset, untilBalanced: on}
+        new Lexer().tokenize rest, {line, column, offset, untilBalanced: on, @locationDataCompensations}
       # Account for the `#` in `#{`.
       index += interpolationOffset
 
@@ -1011,12 +1023,26 @@ exports.Lexer = class Lexer
   # Helpers
   # -------
 
+  # Compensate for the things we strip out initially (e.g. carriage returns)
+  # so that location data stays accurate with respect to the original source file.
+  getLocationDataCompensation: (start, end) ->
+    compensation = 0
+    initialEnd = end
+    for index, length of @locationDataCompensations
+      index = parseInt index, 10
+      continue unless start <= index and (index < end or index is end and start is initialEnd)
+      compensation += length
+      end += length
+    compensation
+
   # Returns the line and column number from an offset into the current chunk.
   #
   # `offset` is a number of characters into `@chunk`.
   getLineAndColumnFromChunk: (offset) ->
+    compensation = @getLocationDataCompensation @chunkOffset, @chunkOffset + offset
+
     if offset is 0
-      return [@chunkLine, @chunkColumn, @chunkOffset]
+      return [@chunkLine, @chunkColumn + compensation, @chunkOffset + compensation]
 
     if offset >= @chunk.length
       string = @chunk
@@ -1029,10 +1055,12 @@ exports.Lexer = class Lexer
     if lineCount > 0
       [..., lastLine] = string.split '\n'
       column = lastLine.length
+      columnCompensation = @getLocationDataCompensation @chunkOffset + offset - column, @chunkOffset + offset
     else
       column += string.length
+      columnCompensation = compensation
 
-    [@chunkLine + lineCount, column, @chunkOffset + offset]
+    [@chunkLine + lineCount, column + columnCompensation, @chunkOffset + offset + compensation]
 
   makeLocationData: ({ offsetInChunk, length }) ->
     locationData = range: []

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -9224,3 +9224,70 @@ test "AST location data as expected for heregex comments", ->
         column: 3
 
   eq getAstRoot(code).comments.length, 0
+
+test "AST location data as expected with carriage returns", ->
+  code = '''
+    a =\r
+    "#{\r
+      b\r
+    }"
+  '''
+
+  testAstLocationData code,
+    type: 'AssignmentExpression'
+    right:
+      expressions: [
+        start: 12
+        end: 13
+        range: [12, 13]
+        loc:
+          start:
+            line: 3
+            column: 2
+          end:
+            line: 3
+            column: 3
+      ]
+      quasis: [
+        start: 6
+        end: 6
+        range: [6, 6]
+        loc:
+          start:
+            line: 2
+            column: 1
+          end:
+            line: 2
+            column: 1
+      ,
+        start: 16
+        end: 16
+        range: [16, 16]
+        loc:
+          start:
+            line: 4
+            column: 1
+          end:
+            line: 4
+            column: 1
+      ]
+      start: 5
+      end: 17
+      range: [5, 17]
+      loc:
+        start:
+          line: 2
+          column: 0
+        end:
+          line: 4
+          column: 2
+    start: 0
+    end: 17
+    range: [0, 17]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 4
+        column: 2

--- a/test/location.coffee
+++ b/test/location.coffee
@@ -46,6 +46,8 @@ test "Verify location of generated tokens (with indented first line)", ->
   eq aToken[2].first_column, 2
   eq aToken[2].last_line, 0
   eq aToken[2].last_column, 2
+  eq aToken[2].range[0], 2
+  eq aToken[2].range[1], 3
 
   eq equalsToken[2].first_line, 0
   eq equalsToken[2].first_column, 4
@@ -731,6 +733,8 @@ test "Verify compound assignment operators have the right position", ->
   eq operatorToken[2].last_line, 0
   eq operatorToken[2].last_column, 4
   eq operatorToken[2].last_column_exclusive, 5
+  eq operatorToken[2].range[0], 2
+  eq operatorToken[2].range[1], 5
 
   source = '''
     a and= b
@@ -741,3 +745,61 @@ test "Verify compound assignment operators have the right position", ->
   eq operatorToken[2].last_line, 0
   eq operatorToken[2].last_column, 5
   eq operatorToken[2].last_column_exclusive, 6
+  eq operatorToken[2].range[0], 2
+  eq operatorToken[2].range[1], 6
+
+test "Verify BOM is accounted for in location data", ->
+  source = '''
+    \ufeffa
+    b
+  '''
+  [aToken, terminator, bToken] = CoffeeScript.tokens source
+  eq aToken[2].first_line, 0
+  eq aToken[2].first_column, 1
+  eq aToken[2].last_line, 0
+  eq aToken[2].last_column, 1
+  eq aToken[2].last_column_exclusive, 2
+  eq aToken[2].range[0], 1
+  eq aToken[2].range[1], 2
+  eq bToken[2].first_line, 1
+  eq bToken[2].first_column, 0
+  eq bToken[2].last_line, 1
+  eq bToken[2].last_column, 0
+  eq bToken[2].last_column_exclusive, 1
+  eq bToken[2].range[0], 3
+  eq bToken[2].range[1], 4
+
+test "Verify carriage returns are accounted for in location data", ->
+  source = '''
+    a\r+
+    b\r\r- c
+  '''
+  [aToken, plusToken, bToken, minusToken] = CoffeeScript.tokens source
+  eq aToken[2].first_line, 0
+  eq aToken[2].first_column, 0
+  eq aToken[2].last_line, 0
+  eq aToken[2].last_column, 0
+  eq aToken[2].last_column_exclusive, 1
+  eq aToken[2].range[0], 0
+  eq aToken[2].range[1], 1
+  eq plusToken[2].first_line, 0
+  eq plusToken[2].first_column, 2
+  eq plusToken[2].last_line, 0
+  eq plusToken[2].last_column, 2
+  eq plusToken[2].last_column_exclusive, 3
+  eq plusToken[2].range[0], 2
+  eq plusToken[2].range[1], 3
+  eq bToken[2].first_line, 1
+  eq bToken[2].first_column, 0
+  eq bToken[2].last_line, 1
+  eq bToken[2].last_column, 0
+  eq bToken[2].last_column_exclusive, 1
+  eq bToken[2].range[0], 4
+  eq bToken[2].range[1], 5
+  eq minusToken[2].first_line, 1
+  eq minusToken[2].first_column, 3
+  eq minusToken[2].last_line, 1
+  eq minusToken[2].last_column, 3
+  eq minusToken[2].last_column_exclusive, 4
+  eq minusToken[2].range[0], 7
+  eq minusToken[2].range[1], 8


### PR DESCRIPTION
@GeoffreyBooth PR making location data correct when "stripped" characters (BOM, carriage returns) are included in the source

Based on `compound-assign-location-data`, [here](https://github.com/helixbass/copheescript/compare/compound-assign-location-data...location-data-compensations) is just the diff against that branch