### PR TITLE
AST: implicit returns

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4435,6 +4435,7 @@
       }
 
       astFull(o) {
+        var ref1;
         this.declareName(o);
         this.name = this.determineName();
         this.body.isClassBody = true;
@@ -4443,6 +4444,9 @@
         }
         this.walkBody(o);
         sniffDirectives(this.body.expressions);
+        if ((ref1 = this.ctor) != null) {
+          ref1.noReturn = true;
+        }
         return super.astFull(o);
       }
 

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -310,11 +310,15 @@
       // Construct a node that returns the current node's result.
       // Note that this is overridden for smarter behavior for
       // many statement nodes (e.g. If, For)...
-      makeReturn(res) {
+      makeReturn({accumulator, mark} = {}) {
         var me;
+        if (mark) {
+          this.canBeReturned = true;
+          return;
+        }
         me = this.unwrapAll();
-        if (res) {
-          return new Call(new Literal(`${res}.push`), [me]);
+        if (accumulator) {
+          return new Call(new Literal(`${accumulator}.push`), [me]);
         } else {
           return new Return(me);
         }
@@ -364,10 +368,24 @@
       // We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
       // as closely as possible, for improved interoperability with other tools.
       ast(o, level) {
+        var fullAst;
         o = Object.assign({}, o);
         if (level != null) {
           o.level = level;
         }
+        if (this.isStatement(o) && o.level !== LEVEL_TOP && (o.scope != null)) {
+          this.makeReturn({
+            mark: true
+          });
+        }
+        fullAst = this.astFull(o);
+        if (fullAst == null) {
+          return fullAst;
+        }
+        return Object.assign(fullAst, this.astReturns());
+      }
+
+      astFull(o) {
         // Every abstract syntax tree node object has four categories of properties:
         // - type, stored in the `type` field and a string like `NumberLiteral`.
         // - location data, stored in the `loc`, `start`, `end` and `range` fields.
@@ -395,6 +413,17 @@
       // mutated into the structure that the Babel spec uses.
       astLocationData() {
         return jisonLocationDataToAstLocationData(this.locationData);
+      }
+
+      // Mark AST nodes that correspond to expressions that (implicitly) return.
+      astReturns() {
+        if (this.canBeReturned) {
+          return {
+            returns: true
+          };
+        } else {
+          return {};
+        }
       }
 
       // Determines whether an AST node needs an `ExpressionStatement` wrapper.
@@ -821,8 +850,8 @@
 
       // A Block node does not return its entire body, rather it
       // ensures that the final expression is returned.
-      makeReturn(res) {
-        var expr, expressions, last, lastExp, len, penult, ref1;
+      makeReturn(opts) {
+        var expr, expressions, last, lastExp, len, penult, ref1, ref2;
         len = this.expressions.length;
         ref1 = this.expressions, [lastExp] = slice1.call(ref1, -1);
         lastExp = (lastExp != null ? lastExp.unwrap() : void 0) || false;
@@ -839,9 +868,15 @@
             expressions[expressions.length - 1].error('Adjacent JSX elements must be wrapped in an enclosing tag');
           }
         }
+        if (opts != null ? opts.mark : void 0) {
+          if ((ref2 = this.expressions[len - 1]) != null) {
+            ref2.makeReturn(opts);
+          }
+          return;
+        }
         while (len--) {
           expr = this.expressions[len];
-          this.expressions[len] = expr.makeReturn(res);
+          this.expressions[len] = expr.makeReturn(opts);
           if (expr instanceof Return && !expr.expression) {
             this.expressions.splice(len, 1);
           }
@@ -1138,11 +1173,11 @@
         return new Block(nodes);
       }
 
-      ast(o, level) {
-        if (((level != null) && level !== LEVEL_TOP) && this.expressions.length) {
-          return (new Sequence(this.expressions).withLocationDataFrom(this)).ast(o, level);
+      astFull(o) {
+        if (((o.level != null) && o.level !== LEVEL_TOP) && this.expressions.length) {
+          return (new Sequence(this.expressions).withLocationDataFrom(this)).ast(o);
         }
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
       astType() {
@@ -1464,11 +1499,11 @@
       return this.isFromHeredoc();
     }
 
-    ast(o, level) {
+    astFull(o) {
       if (this.shouldGenerateTemplateLiteral()) {
         return StringWithInterpolations.fromStringLiteral(this).ast(o);
       }
-      return super.ast(o, level);
+      return super.astFull(o);
     }
 
     astProperties() {
@@ -1558,11 +1593,11 @@
       });
     }
 
-    ast(o, level) {
+    astFull(o) {
       if (this.generated) {
         return null;
       }
-      return super.ast(o, level);
+      return super.astFull(o);
     }
 
     astProperties() {
@@ -1633,8 +1668,8 @@
       return [this.makeCode('['), ...this.value.compileToFragments(o, LEVEL_LIST), this.makeCode(']')];
     }
 
-    ast(o, level) {
-      return this.value.ast(o, level);
+    astFull(o) {
+      return this.value.ast(o);
     }
 
   };
@@ -1851,11 +1886,11 @@
         }
       }
 
-      ast(o, level) {
+      astFull(o) {
         this.checkScope(o);
         return new Op(this.keyword, new Return(this.expression).withLocationDataFrom(this.expression != null ? {
           locationData: mergeLocationData(this.returnKeyword.locationData, this.expression.locationData)
-        } : this.returnKeyword)).withLocationDataFrom(this).ast(o, level);
+        } : this.returnKeyword)).withLocationDataFrom(this).astFull(o);
       }
 
     };
@@ -2177,15 +2212,15 @@
         return false;
       }
 
-      ast(o, level) {
+      astFull(o) {
         if (!this.hasProperties()) {
           // If the `Value` has no properties, the AST node is just whatever this
           // node’s `base` is.
-          return this.base.ast(o, level);
+          return this.base.ast(o);
         }
         // Otherwise, call `Base::ast` which in turn calls the `astType` and
         // `astProperties` methods below.
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
       astType() {
@@ -2565,7 +2600,7 @@
         return fragments;
       }
 
-      ast(o) {
+      astFull(o) {
         var attribute, j, len1, ref1, results;
         ref1 = this.attributes;
         results = [];
@@ -2650,7 +2685,7 @@
         return !this.tagName.base.value.length;
       }
 
-      ast(o, level) {
+      astFull(o) {
         var tagName;
         // The location data spanning the opening element < ... > is captured by
         // the generated Arr which contains the element's attributes
@@ -2660,7 +2695,7 @@
         if (this.content != null) {
           this.closingElementLocationData = mergeAstLocationData(jisonLocationDataToAstLocationData(tagName.closingTagOpeningBracketLocationData), jisonLocationDataToAstLocationData(tagName.closingTagClosingBracketLocationData));
         }
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
       astType() {
@@ -3124,12 +3159,12 @@
         return fragments;
       }
 
-      ast(o, level) {
+      astFull(o) {
         var ref1;
         if (this.accessor != null) {
-          return (new Value(new Super().withLocationDataFrom((ref1 = this.superLiteral) != null ? ref1 : this), [this.accessor]).withLocationDataFrom(this)).ast(o, level);
+          return (new Value(new Super().withLocationDataFrom((ref1 = this.superLiteral) != null ? ref1 : this), [this.accessor]).withLocationDataFrom(this)).ast(o);
         }
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
     };
@@ -3269,11 +3304,11 @@
         }
       }
 
-      ast(o, level) {
+      astFull(o) {
         // Babel doesn’t have an AST node for `Access`, but rather just includes
         // this Access node’s child `name` Identifier node as the `property` of
         // the `MemberExpression` node.
-        return this.name.ast(o, level);
+        return this.name.ast(o);
       }
 
     };
@@ -3304,13 +3339,13 @@
         return this.index.shouldCache();
       }
 
-      ast(o, level) {
+      astFull(o) {
         // Babel doesn’t have an AST node for `Index`, but rather just includes
         // this Index node’s child `index` Identifier node as the `property` of
         // the `MemberExpression` node. The fact that the `MemberExpression`’s
         // `property` is an Index means that `computed` is `true` for the
         // `MemberExpression`.
-        return this.index.ast(o, level);
+        return this.index.ast(o);
       }
 
     };
@@ -3493,8 +3528,8 @@
         return [this.makeCode(`.slice(${fragmentsToText(fromCompiled)}${toStr || ''})`)];
       }
 
-      ast(o, level) {
-        return this.range.ast(o, level);
+      astFull(o) {
+        return this.range.ast(o);
       }
 
     };
@@ -4399,7 +4434,7 @@
         return true;
       }
 
-      ast(o, level) {
+      astFull(o) {
         this.declareName(o);
         this.name = this.determineName();
         this.body.isClassBody = true;
@@ -4408,7 +4443,7 @@
         }
         this.walkBody(o);
         sniffDirectives(this.body.expressions);
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
       astType(o) {
@@ -4741,7 +4776,7 @@
         return code;
       }
 
-      ast(o) {
+      astFull(o) {
         var ref1, ref2;
         // The AST for `ImportClause` is the non-nested list of import specifiers
         // that will be the `specifiers` property of an `ImportDeclaration` AST
@@ -4863,7 +4898,7 @@
         return code;
       }
 
-      ast(o) {
+      astFull(o) {
         var j, len1, ref1, results, specifier;
         ref1 = this.specifiers;
         results = [];
@@ -5518,11 +5553,11 @@
         return this.variable.base.propagateLhs(true);
       }
 
-      ast(o, level) {
+      astFull(o) {
         this.addScopeVariables(o, {
           checkAssignability: false
         });
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
       astType() {
@@ -6016,9 +6051,14 @@
         return results;
       }
 
-      ast(o, level) {
+      astFull(o) {
         this.updateOptions(o);
-        return super.ast(o, level);
+        if (!(this.body.isEmpty() || this.noReturn)) {
+          this.body.makeReturn({
+            mark: true
+          });
+        }
+        return super.astFull(o);
       }
 
       astType() {
@@ -6407,7 +6447,7 @@
 
       eachName(iterator) {}
 
-      ast() {
+      astFull() {
         return null;
       }
 
@@ -6436,13 +6476,18 @@
         this.isLoop = isLoop;
       }
 
-      makeReturn(res) {
-        if (res) {
-          return super.makeReturn(res);
-        } else {
-          this.returns = !this.jumps();
-          return this;
+      makeReturn(opts) {
+        if (opts != null ? opts.accumulator : void 0) {
+          return super.makeReturn(opts);
         }
+        this.returns = !this.jumps();
+        if (opts != null ? opts.mark : void 0) {
+          if (this.returns) {
+            this.body.makeReturn(opts);
+          }
+          return;
+        }
+        return this;
       }
 
       addBody(body1) {
@@ -6479,7 +6524,9 @@
           body = this.makeCode('');
         } else {
           if (this.returns) {
-            body.makeReturn(rvar = o.scope.freeVariable('results'));
+            body.makeReturn({
+              accumulator: rvar = o.scope.freeVariable('results')
+            });
             set = `${this.tab}${rvar} = [];\n`;
           }
           if (this.guard) {
@@ -6825,11 +6872,11 @@
         return super.toString(idt, this.constructor.name + ' ' + this.operator);
       }
 
-      ast(o, level) {
+      astFull(o) {
         if (this.isYield() || this.isAwait()) {
           this.checkContinuation(o);
         }
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
       astType() {
@@ -7043,12 +7090,22 @@
         return this.attempt.jumps(o) || ((ref1 = this.catch) != null ? ref1.jumps(o) : void 0);
       }
 
-      makeReturn(res) {
+      makeReturn(opts) {
+        var ref1, ref2;
+        if (opts != null ? opts.mark : void 0) {
+          if ((ref1 = this.attempt) != null) {
+            ref1.makeReturn(opts);
+          }
+          if ((ref2 = this.catch) != null) {
+            ref2.makeReturn(opts);
+          }
+          return;
+        }
         if (this.attempt) {
-          this.attempt = this.attempt.makeReturn(res);
+          this.attempt = this.attempt.makeReturn(opts);
         }
         if (this.catch) {
-          this.catch = this.catch.makeReturn(res);
+          this.catch = this.catch.makeReturn(opts);
         }
         return this;
       }
@@ -7111,8 +7168,13 @@
         return this.recovery.jumps(o);
       }
 
-      makeReturn(res) {
-        this.recovery = this.recovery.makeReturn(res);
+      makeReturn(opts) {
+        var ret;
+        ret = this.recovery.makeReturn(opts);
+        if (opts != null ? opts.mark : void 0) {
+          return;
+        }
+        this.recovery = ret;
         return this;
       }
 
@@ -7133,7 +7195,7 @@
         return [].concat(this.makeCode(" catch ("), placeholder.compileToFragments(o), this.makeCode(") {\n"), this.recovery.compileToFragments(o, LEVEL_TOP), this.makeCode(`\n${this.tab}}`));
       }
 
-      ast(o, level) {
+      astFull(o) {
         var ref1;
         if ((ref1 = this.errorVariable) != null) {
           ref1.eachName(function(name) {
@@ -7142,7 +7204,7 @@
             return name.isDeclaration = !alreadyDeclared;
           });
         }
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
       astType() {
@@ -7332,7 +7394,7 @@
         }
       }
 
-      ast(o) {
+      astFull(o) {
         return this.body.unwrap().ast(o, LEVEL_PAREN);
       }
 
@@ -7782,7 +7844,9 @@
         if (this.returns) {
           resultPart = `${this.tab}${rvar} = [];\n`;
           returnResult = `\n${this.tab}return ${rvar};`;
-          body.makeReturn(rvar);
+          body.makeReturn({
+            accumulator: rvar
+          });
         }
         if (this.guard) {
           if (body.expressions.length > 1) {
@@ -7831,7 +7895,7 @@
         return fragments;
       }
 
-      ast(o, level) {
+      astFull(o) {
         var addToScope, ref1, ref2;
         addToScope = function(name) {
           var alreadyDeclared;
@@ -7844,7 +7908,7 @@
         if ((ref2 = this.index) != null) {
           ref2.eachName(addToScope);
         }
-        return super.ast(o, level);
+        return super.astFull(o);
       }
 
       astType() {
@@ -7912,18 +7976,18 @@
         return (ref2 = this.otherwise) != null ? ref2.jumps(o) : void 0;
       }
 
-      makeReturn(res) {
+      makeReturn(opts) {
         var block, j, len1, ref1, ref2;
         ref1 = this.cases;
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           ({block} = ref1[j]);
-          block.makeReturn(res);
+          block.makeReturn(opts);
         }
-        if (res) {
+        if (opts != null ? opts.accumulator : void 0) {
           this.otherwise || (this.otherwise = new Block([new Literal('void 0')]));
         }
         if ((ref2 = this.otherwise) != null) {
-          ref2.makeReturn(res);
+          ref2.makeReturn(opts);
         }
         return this;
       }
@@ -8141,12 +8205,22 @@
         }
       }
 
-      makeReturn(res) {
-        if (res) {
+      makeReturn(opts) {
+        var ref1, ref2;
+        if (opts != null ? opts.mark : void 0) {
+          if ((ref1 = this.body) != null) {
+            ref1.makeReturn(opts);
+          }
+          if ((ref2 = this.elseBody) != null) {
+            ref2.makeReturn(opts);
+          }
+          return;
+        }
+        if (opts != null ? opts.accumulator : void 0) {
           this.elseBody || (this.elseBody = new Block([new Literal('void 0')]));
         }
-        this.body && (this.body = new Block([this.body.makeReturn(res)]));
-        this.elseBody && (this.elseBody = new Block([this.elseBody.makeReturn(res)]));
+        this.body && (this.body = new Block([this.body.makeReturn(opts)]));
+        this.elseBody && (this.elseBody = new Block([this.elseBody.makeReturn(opts)]));
         return this;
       }
 
@@ -8252,11 +8326,11 @@
         this.expressions = expressions1;
       }
 
-      ast(o, level) {
+      astFull(o) {
         if (this.expressions.length === 1) {
-          return this.expressions[0].ast(o, level);
+          return this.expressions[0].ast(o);
         }
-        return super.ast(o);
+        return super.astFull(o);
       }
 
       astType() {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -378,14 +378,14 @@
             mark: true
           });
         }
-        fullAst = this.astFull(o);
+        fullAst = this.astNode(o);
         if (fullAst == null) {
           return fullAst;
         }
         return Object.assign(fullAst, this.astReturns());
       }
 
-      astFull(o) {
+      astNode(o) {
         // Every abstract syntax tree node object has four categories of properties:
         // - type, stored in the `type` field and a string like `NumberLiteral`.
         // - location data, stored in the `loc`, `start`, `end` and `range` fields.
@@ -1173,11 +1173,11 @@
         return new Block(nodes);
       }
 
-      astFull(o) {
+      astNode(o) {
         if (((o.level != null) && o.level !== LEVEL_TOP) && this.expressions.length) {
           return (new Sequence(this.expressions).withLocationDataFrom(this)).ast(o);
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {
@@ -1499,11 +1499,11 @@
       return this.isFromHeredoc();
     }
 
-    astFull(o) {
+    astNode(o) {
       if (this.shouldGenerateTemplateLiteral()) {
         return StringWithInterpolations.fromStringLiteral(this).ast(o);
       }
-      return super.astFull(o);
+      return super.astNode(o);
     }
 
     astProperties() {
@@ -1593,11 +1593,11 @@
       });
     }
 
-    astFull(o) {
+    astNode(o) {
       if (this.generated) {
         return null;
       }
-      return super.astFull(o);
+      return super.astNode(o);
     }
 
     astProperties() {
@@ -1668,7 +1668,7 @@
       return [this.makeCode('['), ...this.value.compileToFragments(o, LEVEL_LIST), this.makeCode(']')];
     }
 
-    astFull(o) {
+    astNode(o) {
       return this.value.ast(o);
     }
 
@@ -1886,11 +1886,11 @@
         }
       }
 
-      astFull(o) {
+      astNode(o) {
         this.checkScope(o);
         return new Op(this.keyword, new Return(this.expression).withLocationDataFrom(this.expression != null ? {
           locationData: mergeLocationData(this.returnKeyword.locationData, this.expression.locationData)
-        } : this.returnKeyword)).withLocationDataFrom(this).astFull(o);
+        } : this.returnKeyword)).withLocationDataFrom(this).astNode(o);
       }
 
     };
@@ -2212,7 +2212,7 @@
         return false;
       }
 
-      astFull(o) {
+      astNode(o) {
         if (!this.hasProperties()) {
           // If the `Value` has no properties, the AST node is just whatever this
           // node’s `base` is.
@@ -2220,7 +2220,7 @@
         }
         // Otherwise, call `Base::ast` which in turn calls the `astType` and
         // `astProperties` methods below.
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {
@@ -2600,7 +2600,7 @@
         return fragments;
       }
 
-      astFull(o) {
+      astNode(o) {
         var attribute, j, len1, ref1, results;
         ref1 = this.attributes;
         results = [];
@@ -2685,7 +2685,7 @@
         return !this.tagName.base.value.length;
       }
 
-      astFull(o) {
+      astNode(o) {
         var tagName;
         // The location data spanning the opening element < ... > is captured by
         // the generated Arr which contains the element's attributes
@@ -2695,7 +2695,7 @@
         if (this.content != null) {
           this.closingElementLocationData = mergeAstLocationData(jisonLocationDataToAstLocationData(tagName.closingTagOpeningBracketLocationData), jisonLocationDataToAstLocationData(tagName.closingTagClosingBracketLocationData));
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {
@@ -3159,12 +3159,12 @@
         return fragments;
       }
 
-      astFull(o) {
+      astNode(o) {
         var ref1;
         if (this.accessor != null) {
           return (new Value(new Super().withLocationDataFrom((ref1 = this.superLiteral) != null ? ref1 : this), [this.accessor]).withLocationDataFrom(this)).ast(o);
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
     };
@@ -3304,7 +3304,7 @@
         }
       }
 
-      astFull(o) {
+      astNode(o) {
         // Babel doesn’t have an AST node for `Access`, but rather just includes
         // this Access node’s child `name` Identifier node as the `property` of
         // the `MemberExpression` node.
@@ -3339,7 +3339,7 @@
         return this.index.shouldCache();
       }
 
-      astFull(o) {
+      astNode(o) {
         // Babel doesn’t have an AST node for `Index`, but rather just includes
         // this Index node’s child `index` Identifier node as the `property` of
         // the `MemberExpression` node. The fact that the `MemberExpression`’s
@@ -3528,7 +3528,7 @@
         return [this.makeCode(`.slice(${fragmentsToText(fromCompiled)}${toStr || ''})`)];
       }
 
-      astFull(o) {
+      astNode(o) {
         return this.range.ast(o);
       }
 
@@ -4434,7 +4434,7 @@
         return true;
       }
 
-      astFull(o) {
+      astNode(o) {
         var ref1;
         this.declareName(o);
         this.name = this.determineName();
@@ -4447,7 +4447,7 @@
         if ((ref1 = this.ctor) != null) {
           ref1.noReturn = true;
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType(o) {
@@ -4780,7 +4780,7 @@
         return code;
       }
 
-      astFull(o) {
+      astNode(o) {
         var ref1, ref2;
         // The AST for `ImportClause` is the non-nested list of import specifiers
         // that will be the `specifiers` property of an `ImportDeclaration` AST
@@ -4902,7 +4902,7 @@
         return code;
       }
 
-      astFull(o) {
+      astNode(o) {
         var j, len1, ref1, results, specifier;
         ref1 = this.specifiers;
         results = [];
@@ -5557,11 +5557,11 @@
         return this.variable.base.propagateLhs(true);
       }
 
-      astFull(o) {
+      astNode(o) {
         this.addScopeVariables(o, {
           checkAssignability: false
         });
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {
@@ -6055,14 +6055,14 @@
         return results;
       }
 
-      astFull(o) {
+      astNode(o) {
         this.updateOptions(o);
         if (!(this.body.isEmpty() || this.noReturn)) {
           this.body.makeReturn({
             mark: true
           });
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {
@@ -6451,7 +6451,7 @@
 
       eachName(iterator) {}
 
-      astFull() {
+      astNode() {
         return null;
       }
 
@@ -6876,11 +6876,11 @@
         return super.toString(idt, this.constructor.name + ' ' + this.operator);
       }
 
-      astFull(o) {
+      astNode(o) {
         if (this.isYield() || this.isAwait()) {
           this.checkContinuation(o);
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {
@@ -7199,7 +7199,7 @@
         return [].concat(this.makeCode(" catch ("), placeholder.compileToFragments(o), this.makeCode(") {\n"), this.recovery.compileToFragments(o, LEVEL_TOP), this.makeCode(`\n${this.tab}}`));
       }
 
-      astFull(o) {
+      astNode(o) {
         var ref1;
         if ((ref1 = this.errorVariable) != null) {
           ref1.eachName(function(name) {
@@ -7208,7 +7208,7 @@
             return name.isDeclaration = !alreadyDeclared;
           });
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {
@@ -7398,7 +7398,7 @@
         }
       }
 
-      astFull(o) {
+      astNode(o) {
         return this.body.unwrap().ast(o, LEVEL_PAREN);
       }
 
@@ -7899,7 +7899,7 @@
         return fragments;
       }
 
-      astFull(o) {
+      astNode(o) {
         var addToScope, ref1, ref2;
         addToScope = function(name) {
           var alreadyDeclared;
@@ -7912,7 +7912,7 @@
         if ((ref2 = this.index) != null) {
           ref2.eachName(addToScope);
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {
@@ -8330,11 +8330,11 @@
         this.expressions = expressions1;
       }
 
-      astFull(o) {
+      astNode(o) {
         if (this.expressions.length === 1) {
           return this.expressions[0].ast(o);
         }
-        return super.astFull(o);
+        return super.astNode(o);
       }
 
       astType() {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2962,6 +2962,7 @@ exports.Class = class Class extends Base
     @body.locationData = zeroWidthLocationDataFromEndLocation @locationData if @hasGeneratedBody
     @walkBody o
     sniffDirectives @body.expressions
+    @ctor?.noReturn = yes
 
     super o
 

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1576,7 +1576,7 @@ test "AST as expected for Class node", ->
       type: 'ClassBody'
       body: []
 
-  testStatement 'class Klass then constructor: ->',
+  testStatement 'class Klass then constructor: -> @a = 1',
     type: 'ClassDeclaration'
     id: ID 'Klass', declaration: yes
     superClass: null
@@ -1592,7 +1592,14 @@ test "AST as expected for Class node", ->
         generator: no
         async: no
         params: []
-        body: EMPTY_BLOCK
+        body:
+          type: 'BlockStatement'
+          body: [
+            type: 'ExpressionStatement'
+            expression:
+              type: 'AssignmentExpression'
+              returns: undefined
+          ]
         bound: no
       ]
 
@@ -1624,7 +1631,7 @@ test "AST as expected for Class node", ->
             type: 'BlockStatement'
             body: [
               type: 'ExpressionStatement'
-              expression: ID 'c'
+              expression: ID 'c', returns: yes
             ]
           operator: ':'
           bound: no

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -775,6 +775,7 @@ test "AST as expected for Call node", ->
     arguments: []
     optional: no
     implicit: no
+    returns: undefined
 
   testExpression 'new Date()',
     type: 'NewExpression'
@@ -2283,6 +2284,7 @@ test "AST as expected for Code node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: yes
       ]
       directives: []
     generator: no
@@ -2478,7 +2480,7 @@ test "AST as expected for Code node", ->
       type: 'BlockStatement'
       body: [
         type: 'ExpressionStatement'
-        expression: ID 'a'
+        expression: ID 'a', returns: yes
       ]
     generator: no
     async: no
@@ -2495,6 +2497,7 @@ test "AST as expected for Code node", ->
         expression:
           type: 'AwaitExpression'
           argument: NUMBER 3
+          returns: yes
       ]
     generator: no
     async: yes
@@ -2663,6 +2666,7 @@ test "AST as expected for While node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: undefined
       ]
     guard: null
     inverted: yes
@@ -2726,6 +2730,21 @@ test "AST as expected for While node", ->
     inverted: no
     postfix: no
     loop: yes
+
+  testExpression '''
+    x = (z() while y)
+  ''',
+    type: 'AssignmentExpression'
+    right:
+      type: 'WhileStatement'
+      body:
+        type: 'BlockStatement'
+        body: [
+          type: 'ExpressionStatement'
+          expression:
+            type: 'CallExpression'
+            returns: yes
+        ]
 
 test "AST as expected for Op node", ->
   testExpression 'a <= 2',
@@ -3282,7 +3301,7 @@ test "AST as expected for For node", ->
         type: 'BlockStatement'
         body: [
           type: 'ExpressionStatement'
-          expression: ID 'x', declaration: no
+          expression: ID 'x', declaration: no, returns: yes
         ]
       source: ID 'y', declaration: no
       guard: null
@@ -3300,7 +3319,7 @@ test "AST as expected for For node", ->
       type: 'BlockStatement'
       body: [
         type: 'ExpressionStatement'
-        expression: ID 'x', declaration: no
+        expression: ID 'x', declaration: no, returns: undefined
       ]
     source:
       type: 'Range'
@@ -3325,9 +3344,10 @@ test "AST as expected for For node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: undefined
       ,
         type: 'ExpressionStatement'
-        expression: ID 'd', declaration: no
+        expression: ID 'd', declaration: no, returns: undefined
       ]
     source: ID 'z', declaration: no
     guard: null
@@ -3353,7 +3373,7 @@ test "AST as expected for For node", ->
           type: 'BlockStatement'
           body: [
             type: 'ExpressionStatement'
-            expression: ID 'z', declaration: no
+            expression: ID 'z', declaration: no, returns: yes
           ]
         source: ID 'y', declaration: no
         guard: null


### PR DESCRIPTION
@GeoffreyBooth PR exposing implicit returns in the AST

This enables ESLint rules like [`no-unused-expressions`](https://eslint.org/docs/rules/no-unused-expressions) to work since it allows distinguishing expressions that are implicitly returned as being "used"