### PR TITLE
AST: add params to scope

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -370,10 +370,26 @@
       // We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
       // as closely as possible, for improved interoperability with other tools.
       ast(o, level) {
+        var ast;
         o = Object.assign({}, o);
         if (level != null) {
           o.level = level;
         }
+        if (this.isStatement(o) && o.level !== LEVEL_TOP && (o.scope != null)) {
+          this.makeReturn(null, true);
+        }
+        ast = this.astNode(o);
+        if (ast == null) {
+          return ast;
+        }
+        if (this.canBeReturned) {
+          // Mark AST nodes that correspond to expressions that (implicitly) return.
+          ast.returns = true;
+        }
+        return ast;
+      }
+
+      astNode(o) {
         // Every abstract syntax tree node object has four categories of properties:
         // - type, stored in the `type` field and a string like `NumberLiteral`.
         // - location data, stored in the `loc`, `start`, `end` and `range` fields.
@@ -1150,11 +1166,11 @@
         return new Block(nodes);
       }
 
-      ast(o, level) {
-        if (((level != null) && level !== LEVEL_TOP) && this.expressions.length) {
-          return (new Sequence(this.expressions).withLocationDataFrom(this)).ast(o, level);
+      astNode(o) {
+        if (((o.level != null) && o.level !== LEVEL_TOP) && this.expressions.length) {
+          return (new Sequence(this.expressions).withLocationDataFrom(this)).ast(o);
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -1476,11 +1492,11 @@
       return this.isFromHeredoc();
     }
 
-    ast(o, level) {
+    astNode(o) {
       if (this.shouldGenerateTemplateLiteral()) {
         return StringWithInterpolations.fromStringLiteral(this).ast(o);
       }
-      return super.ast(o, level);
+      return super.astNode(o);
     }
 
     astProperties() {
@@ -1570,11 +1586,11 @@
       });
     }
 
-    ast(o, level) {
+    astNode(o) {
       if (this.generated) {
         return null;
       }
-      return super.ast(o, level);
+      return super.astNode(o);
     }
 
     astProperties() {
@@ -1645,8 +1661,8 @@
       return [this.makeCode('['), ...this.value.compileToFragments(o, LEVEL_LIST), this.makeCode(']')];
     }
 
-    ast(o, level) {
-      return this.value.ast(o, level);
+    astNode(o) {
+      return this.value.ast(o);
     }
 
   };
@@ -1863,11 +1879,11 @@
         }
       }
 
-      ast(o, level) {
+      astNode(o) {
         this.checkScope(o);
         return new Op(this.keyword, new Return(this.expression).withLocationDataFrom(this.expression != null ? {
           locationData: mergeLocationData(this.returnKeyword.locationData, this.expression.locationData)
-        } : this.returnKeyword)).withLocationDataFrom(this).ast(o, level);
+        } : this.returnKeyword)).withLocationDataFrom(this).ast(o);
       }
 
     };
@@ -2189,15 +2205,15 @@
         return false;
       }
 
-      ast(o, level) {
+      astNode(o) {
         if (!this.hasProperties()) {
           // If the `Value` has no properties, the AST node is just whatever this
           // node’s `base` is.
-          return this.base.ast(o, level);
+          return this.base.ast(o);
         }
         // Otherwise, call `Base::ast` which in turn calls the `astType` and
         // `astProperties` methods below.
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -2577,7 +2593,7 @@
         return fragments;
       }
 
-      ast(o) {
+      astNode(o) {
         var attribute, j, len1, ref1, results1;
         ref1 = this.attributes;
         results1 = [];
@@ -2662,7 +2678,7 @@
         return !this.tagName.base.value.length;
       }
 
-      ast(o, level) {
+      astNode(o) {
         var tagName;
         // The location data spanning the opening element < ... > is captured by
         // the generated Arr which contains the element's attributes
@@ -2672,7 +2688,7 @@
         if (this.content != null) {
           this.closingElementLocationData = mergeAstLocationData(jisonLocationDataToAstLocationData(tagName.closingTagOpeningBracketLocationData), jisonLocationDataToAstLocationData(tagName.closingTagClosingBracketLocationData));
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -3136,12 +3152,12 @@
         return fragments;
       }
 
-      ast(o, level) {
+      astNode(o) {
         var ref1;
         if (this.accessor != null) {
-          return (new Value(new Super().withLocationDataFrom((ref1 = this.superLiteral) != null ? ref1 : this), [this.accessor]).withLocationDataFrom(this)).ast(o, level);
+          return (new Value(new Super().withLocationDataFrom((ref1 = this.superLiteral) != null ? ref1 : this), [this.accessor]).withLocationDataFrom(this)).ast(o);
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
     };
@@ -3281,11 +3297,11 @@
         }
       }
 
-      ast(o, level) {
+      astNode(o) {
         // Babel doesn’t have an AST node for `Access`, but rather just includes
         // this Access node’s child `name` Identifier node as the `property` of
         // the `MemberExpression` node.
-        return this.name.ast(o, level);
+        return this.name.ast(o);
       }
 
     };
@@ -3316,13 +3332,13 @@
         return this.index.shouldCache();
       }
 
-      ast(o, level) {
+      astNode(o) {
         // Babel doesn’t have an AST node for `Index`, but rather just includes
         // this Index node’s child `index` Identifier node as the `property` of
         // the `MemberExpression` node. The fact that the `MemberExpression`’s
         // `property` is an Index means that `computed` is `true` for the
         // `MemberExpression`.
-        return this.index.ast(o, level);
+        return this.index.ast(o);
       }
 
     };
@@ -3505,8 +3521,8 @@
         return [this.makeCode(`.slice(${fragmentsToText(fromCompiled)}${toStr || ''})`)];
       }
 
-      ast(o, level) {
-        return this.range.ast(o, level);
+      astNode(o) {
+        return this.range.ast(o);
       }
 
     };
@@ -4411,7 +4427,8 @@
         return true;
       }
 
-      ast(o, level) {
+      astNode(o) {
+        var ref1;
         this.declareName(o);
         this.name = this.determineName();
         this.body.isClassBody = true;
@@ -4420,7 +4437,10 @@
         }
         this.walkBody(o);
         sniffDirectives(this.body.expressions);
-        return super.ast(o, level);
+        if ((ref1 = this.ctor) != null) {
+          ref1.noReturn = true;
+        }
+        return super.astNode(o);
       }
 
       astType(o) {
@@ -4753,7 +4773,7 @@
         return code;
       }
 
-      ast(o) {
+      astNode(o) {
         var ref1, ref2;
         // The AST for `ImportClause` is the non-nested list of import specifiers
         // that will be the `specifiers` property of an `ImportDeclaration` AST
@@ -4875,7 +4895,7 @@
         return code;
       }
 
-      ast(o) {
+      astNode(o) {
         var j, len1, ref1, results1, specifier;
         ref1 = this.specifiers;
         results1 = [];
@@ -5530,11 +5550,11 @@
         return this.variable.base.propagateLhs(true);
       }
 
-      ast(o, level) {
+      astNode(o) {
         this.addScopeVariables(o, {
           checkAssignability: false
         });
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -6028,9 +6048,12 @@
         return results1;
       }
 
-      ast(o, level) {
+      astNode(o) {
         this.updateOptions(o);
-        return super.ast(o, level);
+        if (!(this.body.isEmpty() || this.noReturn)) {
+          this.body.makeReturn(null, true);
+        }
+        return super.astNode(o);
       }
 
       astType() {
@@ -6419,7 +6442,7 @@
 
       eachName(iterator) {}
 
-      ast() {
+      astNode() {
         return null;
       }
 
@@ -6842,11 +6865,11 @@
         return super.toString(idt, this.constructor.name + ' ' + this.operator);
       }
 
-      ast(o, level) {
+      astNode(o) {
         if (this.isYield() || this.isAwait()) {
           this.checkContinuation(o);
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -7165,7 +7188,7 @@
         return [].concat(this.makeCode(" catch ("), placeholder.compileToFragments(o), this.makeCode(") {\n"), this.recovery.compileToFragments(o, LEVEL_TOP), this.makeCode(`\n${this.tab}}`));
       }
 
-      ast(o, level) {
+      astNode(o) {
         var ref1;
         if ((ref1 = this.errorVariable) != null) {
           ref1.eachName(function(name) {
@@ -7174,7 +7197,7 @@
             return name.isDeclaration = !alreadyDeclared;
           });
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -7364,7 +7387,7 @@
         }
       }
 
-      ast(o) {
+      astNode(o) {
         return this.body.unwrap().ast(o, LEVEL_PAREN);
       }
 
@@ -7863,7 +7886,7 @@
         return fragments;
       }
 
-      ast(o, level) {
+      astNode(o) {
         var addToScope, ref1, ref2;
         addToScope = function(name) {
           var alreadyDeclared;
@@ -7876,7 +7899,7 @@
         if ((ref2 = this.index) != null) {
           ref2.eachName(addToScope);
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -8294,11 +8317,11 @@
         this.expressions = expressions1;
       }
 
-      ast(o, level) {
+      astNode(o) {
         if (this.expressions.length === 1) {
-          return this.expressions[0].ast(o, level);
+          return this.expressions[0].ast(o);
         }
-        return super.ast(o);
+        return super.astNode(o);
       }
 
       astType() {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -6063,8 +6063,22 @@
         return results1;
       }
 
+      astAddParamsToScope(o) {
+        var j, len1, param, ref1, results1;
+        ref1 = this.params;
+        results1 = [];
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          param = ref1[j];
+          results1.push(param.eachName(function(name) {
+            return o.scope.add(name, 'param');
+          }));
+        }
+        return results1;
+      }
+
       astNode(o) {
         this.updateOptions(o);
+        this.astAddParamsToScope(o);
         if (!(this.body.isEmpty() || this.noReturn)) {
           this.body.makeReturn(null, true);
         }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -67,13 +67,13 @@
   fragmentsToText = function(fragments) {
     var fragment;
     return ((function() {
-      var j, len1, results;
-      results = [];
+      var j, len1, results1;
+      results1 = [];
       for (j = 0, len1 = fragments.length; j < len1; j++) {
         fragment = fragments[j];
-        results.push(fragment.code);
+        results1.push(fragment.code);
       }
-      return results;
+      return results1;
     })()).join('');
   };
 
@@ -307,16 +307,22 @@
         return [fragmentsToText(cacheValues[0]), fragmentsToText(cacheValues[1])];
       }
 
-      // Construct a node that returns the current node's result.
+      // Construct a node that returns the current node’s result.
       // Note that this is overridden for smarter behavior for
-      // many statement nodes (e.g. If, For)...
-      makeReturn(res) {
-        var me;
-        me = this.unwrapAll();
-        if (res) {
-          return new Call(new Literal(`${res}.push`), [me]);
+      // many statement nodes (e.g. `If`, `For`).
+      makeReturn(results, mark) {
+        var node;
+        if (mark) {
+          // Mark this node as implicitly returned, so that it can be part of the
+          // node metadata returned in the AST.
+          this.canBeReturned = true;
+          return;
+        }
+        node = this.unwrapAll();
+        if (results) {
+          return new Call(new Literal(`${results}.push`), [node]);
         } else {
-          return new Return(me);
+          return new Return(node);
         }
       }
 
@@ -690,46 +696,46 @@
     }
 
     initializeScope(o) {
-      var j, len1, name, ref1, ref2, results;
+      var j, len1, name, ref1, ref2, results1;
       o.scope = new Scope(null, this.body, null, (ref1 = o.referencedVars) != null ? ref1 : []);
       ref2 = o.locals || [];
-      results = [];
+      results1 = [];
       for (j = 0, len1 = ref2.length; j < len1; j++) {
         name = ref2[j];
         // Mark given local variables in the root scope as parameters so they don’t
         // end up being declared on the root block.
-        results.push(o.scope.parameter(name));
+        results1.push(o.scope.parameter(name));
       }
-      return results;
+      return results1;
     }
 
     commentsAst() {
-      var comment, commentToken, j, len1, ref1, results;
+      var comment, commentToken, j, len1, ref1, results1;
       if (this.allComments == null) {
         this.allComments = (function() {
-          var j, len1, ref1, ref2, results;
+          var j, len1, ref1, ref2, results1;
           ref2 = (ref1 = this.allCommentTokens) != null ? ref1 : [];
-          results = [];
+          results1 = [];
           for (j = 0, len1 = ref2.length; j < len1; j++) {
             commentToken = ref2[j];
             if (!commentToken.heregex) {
               if (commentToken.here) {
-                results.push(new HereComment(commentToken));
+                results1.push(new HereComment(commentToken));
               } else {
-                results.push(new LineComment(commentToken));
+                results1.push(new LineComment(commentToken));
               }
             }
           }
-          return results;
+          return results1;
         }).call(this);
       }
       ref1 = this.allComments;
-      results = [];
+      results1 = [];
       for (j = 0, len1 = ref1.length; j < len1; j++) {
         comment = ref1[j];
-        results.push(comment.ast());
+        results1.push(comment.ast());
       }
-      return results;
+      return results1;
     }
 
     ast(o) {
@@ -821,8 +827,8 @@
 
       // A Block node does not return its entire body, rather it
       // ensures that the final expression is returned.
-      makeReturn(res) {
-        var expr, expressions, last, lastExp, len, penult, ref1;
+      makeReturn(results, mark) {
+        var expr, expressions, last, lastExp, len, penult, ref1, ref2;
         len = this.expressions.length;
         ref1 = this.expressions, [lastExp] = slice1.call(ref1, -1);
         lastExp = (lastExp != null ? lastExp.unwrap() : void 0) || false;
@@ -839,9 +845,15 @@
             expressions[expressions.length - 1].error('Adjacent JSX elements must be wrapped in an enclosing tag');
           }
         }
+        if (mark) {
+          if ((ref2 = this.expressions[len - 1]) != null) {
+            ref2.makeReturn(results, mark);
+          }
+          return;
+        }
         while (len--) {
           expr = this.expressions[len];
-          this.expressions[len] = expr.makeReturn(res);
+          this.expressions[len] = expr.makeReturn(results);
           if (expr instanceof Return && !expr.expression) {
             this.expressions.splice(len, 1);
           }
@@ -1008,18 +1020,18 @@
               }
             }
             code = `\n${fragmentIndent}` + ((function() {
-              var l, len2, ref2, results;
+              var l, len2, ref2, results1;
               ref2 = fragment.precedingComments;
-              results = [];
+              results1 = [];
               for (l = 0, len2 = ref2.length; l < len2; l++) {
                 commentFragment = ref2[l];
                 if (commentFragment.isHereComment && commentFragment.multiline) {
-                  results.push(multident(commentFragment.code, fragmentIndent, false));
+                  results1.push(multident(commentFragment.code, fragmentIndent, false));
                 } else {
-                  results.push(commentFragment.code);
+                  results1.push(commentFragment.code);
                 }
               }
-              return results;
+              return results1;
             })()).join(`\n${fragmentIndent}`).replace(/^(\s*)$/gm, '');
             ref2 = fragments.slice(0, (fragmentIndex + 1));
             for (pastFragmentIndex = l = ref2.length - 1; l >= 0; pastFragmentIndex = l += -1) {
@@ -1084,18 +1096,18 @@
             code = fragmentIndex === 1 && /^\s+$/.test(fragments[0].code) ? '' : trail ? ' ' : `\n${fragmentIndent}`;
             // Assemble properly indented comments.
             code += ((function() {
-              var len3, q, ref4, results;
+              var len3, q, ref4, results1;
               ref4 = fragment.followingComments;
-              results = [];
+              results1 = [];
               for (q = 0, len3 = ref4.length; q < len3; q++) {
                 commentFragment = ref4[q];
                 if (commentFragment.isHereComment && commentFragment.multiline) {
-                  results.push(multident(commentFragment.code, fragmentIndent, false));
+                  results1.push(multident(commentFragment.code, fragmentIndent, false));
                 } else {
-                  results.push(commentFragment.code);
+                  results1.push(commentFragment.code);
                 }
               }
-              return results;
+              return results1;
             })()).join(`\n${fragmentIndent}`).replace(/^(\s*)$/gm, '');
             ref4 = fragments.slice(fragmentIndex);
             for (upcomingFragmentIndex = q = 0, len3 = ref4.length; q < len3; upcomingFragmentIndex = ++q) {
@@ -1521,18 +1533,18 @@
             rawValue: void 0
           },
           comments: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.heregexCommentTokens;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               heregexCommentToken = ref1[j];
               if (heregexCommentToken.here) {
-                results.push(new HereComment(heregexCommentToken).ast(o));
+                results1.push(new HereComment(heregexCommentToken).ast(o));
               } else {
-                results.push(new LineComment(heregexCommentToken).ast(o));
+                results1.push(new LineComment(heregexCommentToken).ast(o));
               }
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -2566,14 +2578,14 @@
       }
 
       ast(o) {
-        var attribute, j, len1, ref1, results;
+        var attribute, j, len1, ref1, results1;
         ref1 = this.attributes;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           attribute = ref1[j];
-          results.push(attribute.ast(o));
+          results1.push(attribute.ast(o));
         }
-        return results;
+        return results1;
       }
 
     };
@@ -2740,13 +2752,13 @@
       }
 
       contentAst(o) {
-        var base1, child, children, content, element, emptyExpression, expression, j, len1, results, unwrapped;
+        var base1, child, children, content, element, emptyExpression, expression, j, len1, results1, unwrapped;
         if (!(this.content && !(typeof (base1 = this.content.base).isEmpty === "function" ? base1.isEmpty() : void 0))) {
           return [];
         }
         content = this.content.unwrapAll();
         children = (function() {
-          var j, len1, ref1, results;
+          var j, len1, ref1, results1;
           if (content instanceof StringLiteral) {
             return [new JSXText(content)]; // StringWithInterpolations
           } else {
@@ -2754,11 +2766,11 @@
               includeInterpolationWrappers: true,
               isJsx: true
             });
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               element = ref1[j];
               if (element instanceof StringLiteral) {
-                results.push(new JSXText(element)); // Interpolation
+                results1.push(new JSXText(element)); // Interpolation
               } else {
                 ({expression} = element);
                 if (expression == null) {
@@ -2768,33 +2780,33 @@
                     openingBrace: '{',
                     closingBrace: '}'
                   });
-                  results.push(new JSXExpressionContainer(emptyExpression, {
+                  results1.push(new JSXExpressionContainer(emptyExpression, {
                     locationData: element.locationData
                   }));
                 } else {
                   unwrapped = expression.unwrapAll();
                   // distinguish `<a><b /></a>` from `<a>{<b />}</a>`
                   if (unwrapped instanceof JSXElement && unwrapped.locationData.range[0] === element.locationData.range[0]) {
-                    results.push(unwrapped);
+                    results1.push(unwrapped);
                   } else {
-                    results.push(new JSXExpressionContainer(unwrapped, {
+                    results1.push(new JSXExpressionContainer(unwrapped, {
                       locationData: element.locationData
                     }));
                   }
                 }
               }
             }
-            return results;
+            return results1;
           }
         }).call(this);
-        results = [];
+        results1 = [];
         for (j = 0, len1 = children.length; j < len1; j++) {
           child = children[j];
           if (!(child instanceof JSXText && child.value.length === 0)) {
-            results.push(child.ast(o));
+            results1.push(child.ast(o));
           }
         }
-        return results;
+        return results1;
       }
 
       astProperties(o) {
@@ -2960,16 +2972,16 @@
         // (see issue #4437, https://github.com/jashkenas/coffeescript/issues/4437)
         varAccess = ((ref2 = this.variable) != null ? (ref3 = ref2.properties) != null ? ref3[0] : void 0 : void 0) instanceof Access;
         argCode = (function() {
-          var j, len1, ref4, results;
+          var j, len1, ref4, results1;
           ref4 = this.args || [];
-          results = [];
+          results1 = [];
           for (j = 0, len1 = ref4.length; j < len1; j++) {
             arg = ref4[j];
             if (arg instanceof Code) {
-              results.push(arg);
+              results1.push(arg);
             }
           }
-          return results;
+          return results1;
         }).call(this);
         if (argCode.length > 0 && varAccess && !this.variable.base.cached) {
           [cache] = this.variable.base.cache(o, LEVEL_ACCESS, function() {
@@ -3023,14 +3035,14 @@
         return {
           callee: this.variable.ast(o, LEVEL_ACCESS),
           arguments: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.args;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               arg = ref1[j];
-              results.push(arg.ast(o, LEVEL_LIST));
+              results1.push(arg.ast(o, LEVEL_LIST));
             }
-            return results;
+            return results1;
           }).call(this),
           optional: !!this.soak,
           implicit: !!this.implicit
@@ -3166,18 +3178,18 @@
           interpolatedPattern: this.call.args[0].ast(o),
           flags: (ref1 = (ref2 = this.call.args[1]) != null ? ref2.unwrap().originalValue : void 0) != null ? ref1 : '',
           comments: (function() {
-            var j, len1, ref3, results;
+            var j, len1, ref3, results1;
             ref3 = this.heregexCommentTokens;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref3.length; j < len1; j++) {
               heregexCommentToken = ref3[j];
               if (heregexCommentToken.here) {
-                results.push(new HereComment(heregexCommentToken).ast(o));
+                results1.push(new HereComment(heregexCommentToken).ast(o));
               } else {
-                results.push(new LineComment(heregexCommentToken).ast(o));
+                results1.push(new LineComment(heregexCommentToken).ast(o));
               }
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -3404,9 +3416,9 @@
         known = (this.fromNum != null) && (this.toNum != null);
         if (known && Math.abs(this.fromNum - this.toNum) <= 20) {
           range = (function() {
-            var results = [];
-            for (var j = ref1 = this.fromNum, ref2 = this.toNum; ref1 <= ref2 ? j <= ref2 : j >= ref2; ref1 <= ref2 ? j++ : j--){ results.push(j); }
-            return results;
+            var results1 = [];
+            for (var j = ref1 = this.fromNum, ref2 = this.toNum; ref1 <= ref2 ? j <= ref2 : j >= ref2; ref1 <= ref2 ? j++ : j--){ results1.push(j); }
+            return results1;
           }).apply(this);
           if (this.exclusive) {
             range.pop();
@@ -3459,7 +3471,7 @@
 
   //### Slice
 
-  // An array slice literal. Unlike JavaScript's `Array#slice`, the second parameter
+  // An array slice literal. Unlike JavaScript’s `Array#slice`, the second parameter
   // specifies the index of the end of the slice, just as the first parameter
   // is the index of the beginning.
   exports.Slice = Slice = (function() {
@@ -3560,15 +3572,15 @@
         var i, prop, props, splatProp, splatProps;
         props = this.properties;
         splatProps = (function() {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (i = j = 0, len1 = props.length; j < len1; i = ++j) {
             prop = props[i];
             if (prop instanceof Splat) {
-              results.push(i);
+              results1.push(i);
             }
           }
-          return results;
+          return results1;
         })();
         if ((splatProps != null ? splatProps.length : void 0) > 1) {
           props[splatProps[1]].error("multiple spread elements are disallowed");
@@ -3671,9 +3683,9 @@
       }
 
       eachName(iterator) {
-        var j, len1, prop, ref1, results;
+        var j, len1, prop, ref1, results1;
         ref1 = this.properties;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           prop = ref1[j];
           if (prop instanceof Assign && prop.context === 'object') {
@@ -3681,12 +3693,12 @@
           }
           prop = prop.unwrapAll();
           if (prop.eachName != null) {
-            results.push(prop.eachName(iterator));
+            results1.push(prop.eachName(iterator));
           } else {
-            results.push(void 0);
+            results1.push(void 0);
           }
         }
-        return results;
+        return results1;
       }
 
       // Convert “bare” properties to `ObjectProperty`s (or `Splat`s).
@@ -3722,18 +3734,18 @@
       }
 
       expandProperties() {
-        var j, len1, property, ref1, results;
+        var j, len1, property, ref1, results1;
         ref1 = this.properties;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           property = ref1[j];
-          results.push(this.expandProperty(property));
+          results1.push(this.expandProperty(property));
         }
-        return results;
+        return results1;
       }
 
       propagateLhs(setLhs) {
-        var j, len1, property, ref1, results, unwrappedValue, value;
+        var j, len1, property, ref1, results1, unwrappedValue, value;
         if (setLhs) {
           this.lhs = true;
         }
@@ -3741,29 +3753,29 @@
           return;
         }
         ref1 = this.properties;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           property = ref1[j];
           if (property instanceof Assign && property.context === 'object') {
             ({value} = property);
             unwrappedValue = value.unwrapAll();
             if (unwrappedValue instanceof Arr || unwrappedValue instanceof Obj) {
-              results.push(unwrappedValue.propagateLhs(true));
+              results1.push(unwrappedValue.propagateLhs(true));
             } else if (unwrappedValue instanceof Assign) {
-              results.push(unwrappedValue.nestedLhs = true);
+              results1.push(unwrappedValue.nestedLhs = true);
             } else {
-              results.push(void 0);
+              results1.push(void 0);
             }
           } else if (property instanceof Assign) {
             // Shorthand property with default, e.g. `{a = 1} = b`.
-            results.push(property.nestedLhs = true);
+            results1.push(property.nestedLhs = true);
           } else if (property instanceof Splat) {
-            results.push(property.lhs = true);
+            results1.push(property.lhs = true);
           } else {
-            results.push(void 0);
+            results1.push(void 0);
           }
         }
-        return results;
+        return results1;
       }
 
       astType() {
@@ -3779,14 +3791,14 @@
         return {
           implicit: !!this.generated,
           properties: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.expandProperties();
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               property = ref1[j];
-              results.push(property.ast(o));
+              results1.push(property.ast(o));
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -3914,14 +3926,14 @@
           }
         }
         compiledObjs = (function() {
-          var k, len2, ref2, results;
+          var k, len2, ref2, results1;
           ref2 = this.objects;
-          results = [];
+          results1 = [];
           for (k = 0, len2 = ref2.length; k < len2; k++) {
             obj = ref2[k];
-            results.push(obj.compileToFragments(o, LEVEL_LIST));
+            results1.push(obj.compileToFragments(o, LEVEL_LIST));
           }
-          return results;
+          return results1;
         }).call(this);
         olen = compiledObjs.length;
         // If `compiledObjs` includes newlines, we will output this as a multiline
@@ -3987,21 +3999,21 @@
       }
 
       eachName(iterator) {
-        var j, len1, obj, ref1, results;
+        var j, len1, obj, ref1, results1;
         ref1 = this.objects;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           obj = ref1[j];
           obj = obj.unwrapAll();
-          results.push(obj.eachName(iterator));
+          results1.push(obj.eachName(iterator));
         }
-        return results;
+        return results1;
       }
 
       // If this array is the left-hand side of an assignment, all its children
       // are too.
       propagateLhs(setLhs) {
-        var j, len1, object, ref1, results, unwrappedObject;
+        var j, len1, object, ref1, results1, unwrappedObject;
         if (setLhs) {
           this.lhs = true;
         }
@@ -4009,7 +4021,7 @@
           return;
         }
         ref1 = this.objects;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           object = ref1[j];
           if (object instanceof Splat) {
@@ -4017,14 +4029,14 @@
           }
           unwrappedObject = object.unwrapAll();
           if (unwrappedObject instanceof Arr || unwrappedObject instanceof Obj) {
-            results.push(unwrappedObject.propagateLhs(true));
+            results1.push(unwrappedObject.propagateLhs(true));
           } else if (unwrappedObject instanceof Assign) {
-            results.push(unwrappedObject.nestedLhs = true);
+            results1.push(unwrappedObject.nestedLhs = true);
           } else {
-            results.push(void 0);
+            results1.push(void 0);
           }
         }
-        return results;
+        return results1;
       }
 
       astType() {
@@ -4039,14 +4051,14 @@
         var object;
         return {
           elements: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.objects;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               object = ref1[j];
-              results.push(object.ast(o, LEVEL_LIST));
+              results1.push(object.ast(o, LEVEL_LIST));
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -4236,13 +4248,13 @@
         }
         if (initializer.length !== expressions.length) {
           this.body.expressions = (function() {
-            var l, len3, results;
-            results = [];
+            var l, len3, results1;
+            results1 = [];
             for (l = 0, len3 = initializer.length; l < len3; l++) {
               expression = initializer[l];
-              results.push(expression.hoist());
+              results1.push(expression.hoist());
             }
-            return results;
+            return results1;
           })();
           return new Block(expressions);
         }
@@ -4370,18 +4382,18 @@
       proxyBoundMethods() {
         var method, name;
         this.ctor.thisAssignments = (function() {
-          var j, len1, ref1, results;
+          var j, len1, ref1, results1;
           ref1 = this.boundMethods;
-          results = [];
+          results1 = [];
           for (j = 0, len1 = ref1.length; j < len1; j++) {
             method = ref1[j];
             if (this.parent) {
               method.classVariable = this.variableRef;
             }
             name = new Value(new ThisLiteral(), [method.name]);
-            results.push(new Assign(name, new Call(new Value(name, [new Access(new PropertyName('bind'))]), [new ThisLiteral()])));
+            results1.push(new Assign(name, new Call(new Value(name, [new Access(new PropertyName('bind'))]), [new ThisLiteral()])));
           }
-          return results;
+          return results1;
         }).call(this);
         return null;
       }
@@ -4541,8 +4553,8 @@
       addProperties(assigns) {
         var assign, base, name, prototype, result, value, variable;
         result = (function() {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (j = 0, len1 = assigns.length; j < len1; j++) {
             assign = assigns[j];
             variable = assign.variable;
@@ -4563,9 +4575,9 @@
             } else if (assign.value instanceof Code) {
               assign.value.isStatic = true;
             }
-            results.push(assign);
+            results1.push(assign);
           }
-          return results;
+          return results1;
         }).call(this);
         return compact(result);
       }
@@ -4838,14 +4850,14 @@
         code = [];
         o.indent += TAB;
         compiledList = (function() {
-          var j, len1, ref1, results;
+          var j, len1, ref1, results1;
           ref1 = this.specifiers;
-          results = [];
+          results1 = [];
           for (j = 0, len1 = ref1.length; j < len1; j++) {
             specifier = ref1[j];
-            results.push(specifier.compileToFragments(o, LEVEL_LIST));
+            results1.push(specifier.compileToFragments(o, LEVEL_LIST));
           }
-          return results;
+          return results1;
         }).call(this);
         if (this.specifiers.length !== 0) {
           code.push(this.makeCode(`{\n${o.indent}`));
@@ -4864,14 +4876,14 @@
       }
 
       ast(o) {
-        var j, len1, ref1, results, specifier;
+        var j, len1, ref1, results1, specifier;
         ref1 = this.specifiers;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           specifier = ref1[j];
-          results.push(specifier.ast(o));
+          results1.push(specifier.ast(o));
         }
-        return results;
+        return results1;
       }
 
     };
@@ -5197,27 +5209,27 @@
         }
         // Count all `Splats`: [a, b, c..., d, e]
         splats = (function() {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (i = j = 0, len1 = objects.length; j < len1; i = ++j) {
             obj = objects[i];
             if (obj instanceof Splat) {
-              results.push(i);
+              results1.push(i);
             }
           }
-          return results;
+          return results1;
         })();
         // Count all `Expansions`: [a, b, ..., c, d]
         expans = (function() {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (i = j = 0, len1 = objects.length; j < len1; i = ++j) {
             obj = objects[i];
             if (obj instanceof Expansion) {
-              results.push(i);
+              results1.push(i);
             }
           }
-          return results;
+          return results1;
         })();
         // Combine splats and expansions.
         splatsAndExpans = [...splats, ...expans];
@@ -5277,15 +5289,15 @@
         compSplice = slicer("splice");
         // Check if `objects` array contains any instance of `Assign`, e.g. {a:1}.
         hasObjAssigns = function(objs) {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (i = j = 0, len1 = objs.length; j < len1; i = ++j) {
             obj = objs[i];
             if (obj instanceof Assign && obj.context === 'object') {
-              results.push(i);
+              results1.push(i);
             }
           }
-          return results;
+          return results1;
         };
         // Check if `objects` array contains any unassignable object.
         objIsUnassignable = function(objs) {
@@ -5306,8 +5318,8 @@
         // "Complex" `objects` are processed in a loop.
         // Examples: [a, b, {c, r...}, d], [a, ..., {b, r...}, c, d]
         loopObjects = (objs, vvar, vvarTxt) => {
-          var acc, idx, j, len1, message, results, vval;
-          results = [];
+          var acc, idx, j, len1, message, results1, vval;
+          results1 = [];
           for (i = j = 0, len1 = objs.length; j < len1; i = ++j) {
             obj = objs[i];
             if (obj instanceof Elision) {
@@ -5353,9 +5365,9 @@
             if (message) {
               vvar.error(message);
             }
-            results.push(pushAssign(vvar, vval));
+            results1.push(pushAssign(vvar, vval));
           }
-          return results;
+          return results1;
         };
         // "Simple" `objects` can be split and compiled to arrays, [a, b, c] = arr, [a, b, c...] = arr
         assignObjects = (objs, vvar, vvarTxt) => {
@@ -5787,13 +5799,13 @@
             ...((function() {
               var k,
             len2,
-            results;
-              results = [];
+            results1;
+              results1 = [];
               for (k = 0, len2 = paramsAfterSplat.length; k < len2; k++) {
                 param = paramsAfterSplat[k];
-                results.push(param.asReference(o));
+                results1.push(param.asReference(o));
               }
-              return results;
+              return results1;
             })())
           ])), new Value(new IdentifierLiteral(splatParamName))));
         }
@@ -5879,13 +5891,13 @@
           o.scope = methodScope;
         }
         answer = this.joinFragmentArrays((function() {
-          var len4, p, results;
-          results = [];
+          var len4, p, results1;
+          results1 = [];
           for (p = 0, len4 = modifiers.length; p < len4; p++) {
             m = modifiers[p];
-            results.push(this.makeCode(m));
+            results1.push(this.makeCode(m));
           }
-          return results;
+          return results1;
         }).call(this), ' ');
         if (modifiers.length && name) {
           answer.push(this.makeCode(' '));
@@ -5921,14 +5933,14 @@
       }
 
       eachParamName(iterator) {
-        var j, len1, param, ref1, results;
+        var j, len1, param, ref1, results1;
         ref1 = this.params;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           param = ref1[j];
-          results.push(param.eachName(iterator));
+          results1.push(param.eachName(iterator));
         }
-        return results;
+        return results1;
       }
 
       // Short-circuit `traverseChildren` method to prevent it from crossing scope
@@ -6004,16 +6016,16 @@
       }
 
       propagateLhs() {
-        var j, len1, name, ref1, results;
+        var j, len1, name, ref1, results1;
         ref1 = this.params;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           ({name} = ref1[j]);
           if (name instanceof Arr || name instanceof Obj) {
-            results.push(name.propagateLhs(true));
+            results1.push(name.propagateLhs(true));
           }
         }
-        return results;
+        return results1;
       }
 
       ast(o, level) {
@@ -6085,14 +6097,14 @@
         var param, ref1;
         return Object.assign({
           params: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.params;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               param = ref1[j];
-              results.push(this.paramForAst(param).ast(o));
+              results1.push(this.paramForAst(param).ast(o));
             }
-            return results;
+            return results1;
           }).call(this),
           body: this.body.ast(Object.assign({}, o, {
             checkForDirectives: true
@@ -6436,13 +6448,18 @@
         this.isLoop = isLoop;
       }
 
-      makeReturn(res) {
-        if (res) {
-          return super.makeReturn(res);
-        } else {
-          this.returns = !this.jumps();
-          return this;
+      makeReturn(results, mark) {
+        if (results) {
+          return super.makeReturn(results, mark);
         }
+        this.returns = !this.jumps();
+        if (mark) {
+          if (this.returns) {
+            this.body.makeReturn(results, mark);
+          }
+          return;
+        }
+        return this;
       }
 
       addBody(body1) {
@@ -6880,13 +6897,13 @@
         return {
           operators,
           operands: (function() {
-            var j, len1, results;
-            results = [];
+            var j, len1, results1;
+            results1 = [];
             for (j = 0, len1 = operands.length; j < len1; j++) {
               operand = operands[j];
-              results.push(operand.ast(o, LEVEL_OP));
+              results1.push(operand.ast(o, LEVEL_OP));
             }
-            return results;
+            return results1;
           })()
         };
       }
@@ -7043,12 +7060,22 @@
         return this.attempt.jumps(o) || ((ref1 = this.catch) != null ? ref1.jumps(o) : void 0);
       }
 
-      makeReturn(res) {
+      makeReturn(results, mark) {
+        var ref1, ref2;
+        if (mark) {
+          if ((ref1 = this.attempt) != null) {
+            ref1.makeReturn(results, mark);
+          }
+          if ((ref2 = this.catch) != null) {
+            ref2.makeReturn(results, mark);
+          }
+          return;
+        }
         if (this.attempt) {
-          this.attempt = this.attempt.makeReturn(res);
+          this.attempt = this.attempt.makeReturn(results);
         }
         if (this.catch) {
-          this.catch = this.catch.makeReturn(res);
+          this.catch = this.catch.makeReturn(results);
         }
         return this;
       }
@@ -7111,8 +7138,13 @@
         return this.recovery.jumps(o);
       }
 
-      makeReturn(res) {
-        this.recovery = this.recovery.makeReturn(res);
+      makeReturn(results, mark) {
+        var ret;
+        ret = this.recovery.makeReturn(results, mark);
+        if (mark) {
+          return;
+        }
+        this.recovery = ret;
         return this;
       }
 
@@ -7912,18 +7944,18 @@
         return (ref2 = this.otherwise) != null ? ref2.jumps(o) : void 0;
       }
 
-      makeReturn(res) {
+      makeReturn(results, mark) {
         var block, j, len1, ref1, ref2;
         ref1 = this.cases;
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           ({block} = ref1[j]);
-          block.makeReturn(res);
+          block.makeReturn(results, mark);
         }
-        if (res) {
+        if (results) {
           this.otherwise || (this.otherwise = new Block([new Literal('void 0')]));
         }
         if ((ref2 = this.otherwise) != null) {
-          ref2.makeReturn(res);
+          ref2.makeReturn(results, mark);
         }
         return this;
       }
@@ -7968,7 +8000,7 @@
       }
 
       casesAst(o) {
-        var caseIndex, caseLocationData, cases, consequent, j, k, kase, l, lastTestIndex, len1, len2, len3, ref1, ref2, results, test, testConsequent, testIndex, tests;
+        var caseIndex, caseLocationData, cases, consequent, j, k, kase, l, lastTestIndex, len1, len2, len3, ref1, ref2, results1, test, testConsequent, testIndex, tests;
         cases = [];
         ref1 = this.cases;
         for (caseIndex = j = 0, len1 = ref1.length; j < len1; caseIndex = ++j) {
@@ -8006,12 +8038,12 @@
         if ((ref2 = this.otherwise) != null ? ref2.expressions.length : void 0) {
           cases.push(new SwitchCase(null, this.otherwise).withLocationDataFrom(this.otherwise));
         }
-        results = [];
+        results1 = [];
         for (l = 0, len3 = cases.length; l < len3; l++) {
           kase = cases[l];
-          results.push(kase.ast(o));
+          results1.push(kase.ast(o));
         }
-        return results;
+        return results1;
       }
 
       astProperties(o) {
@@ -8141,12 +8173,22 @@
         }
       }
 
-      makeReturn(res) {
-        if (res) {
+      makeReturn(results, mark) {
+        var ref1, ref2;
+        if (mark) {
+          if ((ref1 = this.body) != null) {
+            ref1.makeReturn(results, mark);
+          }
+          if ((ref2 = this.elseBody) != null) {
+            ref2.makeReturn(results, mark);
+          }
+          return;
+        }
+        if (results) {
           this.elseBody || (this.elseBody = new Block([new Literal('void 0')]));
         }
-        this.body && (this.body = new Block([this.body.makeReturn(res)]));
-        this.elseBody && (this.elseBody = new Block([this.elseBody.makeReturn(res)]));
+        this.body && (this.body = new Block([this.body.makeReturn(results)]));
+        this.elseBody && (this.elseBody = new Block([this.elseBody.makeReturn(results)]));
         return this;
       }
 
@@ -8267,14 +8309,14 @@
         var expression;
         return {
           expressions: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.expressions;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               expression = ref1[j];
-              results.push(expression.ast(o));
+              results1.push(expression.ast(o));
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -8526,10 +8568,10 @@
   };
 
   sniffDirectives = function(expressions, {notFinalExpression} = {}) {
-    var expression, index, lastIndex, results, unwrapped;
+    var expression, index, lastIndex, results1, unwrapped;
     index = 0;
     lastIndex = expressions.length - 1;
-    results = [];
+    results1 = [];
     while (index <= lastIndex) {
       if (index === lastIndex && notFinalExpression) {
         break;
@@ -8543,9 +8585,9 @@
         break;
       }
       expressions[index] = new Directive(expression).withLocationDataFrom(expression);
-      results.push(index++);
+      results1.push(index++);
     }
-    return results;
+    return results1;
   };
 
   // Helpers for `mergeLocationData` and `mergeAstLocationData` below.

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -372,17 +372,8 @@
       // **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
       // Only override the component `ast*` methods as needed.
       ast(o, level) {
-        var ast;
         o = this.astInitialize(o, level);
-        ast = this.astNode(o);
-        if (ast == null) {
-          return ast;
-        }
-        if (this.canBeReturned) {
-          // Mark AST nodes that correspond to expressions that (implicitly) return.
-          ast.returns = true;
-        }
-        return ast;
+        return this.astAddReturns(this.astNode(o));
       }
 
       astInitialize(o, level) {
@@ -427,6 +418,17 @@
       // mutated into the structure that the Babel spec uses.
       astLocationData() {
         return jisonLocationDataToAstLocationData(this.locationData);
+      }
+
+      // Mark AST nodes that correspond to expressions that (implicitly) return.
+      astAddReturns(ast) {
+        if (ast == null) {
+          return ast;
+        }
+        if (this.canBeReturned) {
+          ast.returns = true;
+        }
+        return ast;
       }
 
       // Determines whether an AST node needs an `ExpressionStatement` wrapper.

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -372,8 +372,10 @@
       // **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
       // Only override the component `ast*` methods as needed.
       ast(o, level) {
+        var astNode;
         o = this.astInitialize(o, level);
-        return this.astAddReturns(this.astNode(o));
+        astNode = this.astNode(o);
+        return this.astAddReturns(astNode);
       }
 
       astInitialize(o, level) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4332,7 +4332,7 @@
 
       // Returns a configured class initializer method
       addInitializerMethod(assign) {
-        var method, methodName, operatorToken, variable;
+        var isConstructor, method, methodName, operatorToken, variable;
         ({
           variable,
           value: method,
@@ -4346,7 +4346,8 @@
           methodName = variable.base;
           method.name = new (methodName.shouldCache() ? Index : Access)(methodName);
           method.name.updateLocationDataIfMissing(methodName.locationData);
-          if (methodName.value === 'constructor') {
+          isConstructor = methodName instanceof StringLiteral ? methodName.originalValue === 'constructor' : methodName.value === 'constructor';
+          if (isConstructor) {
             method.ctor = (this.parent ? 'derived' : 'base');
           }
           if (method.bound && method.ctor) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -369,6 +369,8 @@
       // as JSON. This is what the `ast` option in the Node API returns.
       // We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
       // as closely as possible, for improved interoperability with other tools.
+      // **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
+      // Only override the component `ast*` methods as needed.
       ast(o, level) {
         var ast;
         o = Object.assign({}, o);
@@ -376,6 +378,9 @@
           o.level = level;
         }
         if (this.isStatement(o) && o.level !== LEVEL_TOP && (o.scope != null)) {
+          // `@makeReturn` must be called before `astProperties`, because the latter may call
+          // `.ast()` for child nodes and those nodes would need the return logic from `makeReturn`
+          // already executed by then.
           this.makeReturn(null, true);
         }
         ast = this.astNode(o);

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -373,6 +373,19 @@
       // Only override the component `ast*` methods as needed.
       ast(o, level) {
         var ast;
+        o = this.astInitialize(o, level);
+        ast = this.astNode(o);
+        if (ast == null) {
+          return ast;
+        }
+        if (this.canBeReturned) {
+          // Mark AST nodes that correspond to expressions that (implicitly) return.
+          ast.returns = true;
+        }
+        return ast;
+      }
+
+      astInitialize(o, level) {
         o = Object.assign({}, o);
         if (level != null) {
           o.level = level;
@@ -383,15 +396,7 @@
           // already executed by then.
           this.makeReturn(null, true);
         }
-        ast = this.astNode(o);
-        if (ast == null) {
-          return ast;
-        }
-        if (this.canBeReturned) {
-          // Mark AST nodes that correspond to expressions that (implicitly) return.
-          ast.returns = true;
-        }
-        return ast;
+        return o;
       }
 
       astNode(o) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -754,10 +754,10 @@
       return results1;
     }
 
-    ast(o) {
+    astNode(o) {
       o.level = LEVEL_TOP;
       this.initializeScope(o);
-      return super.ast(o);
+      return super.astNode(o);
     }
 
     astType() {
@@ -1343,11 +1343,11 @@
       return [this.makeCode('2e308')];
     }
 
-    ast(o, level) {
+    astNode(o) {
       if (this.originalValue !== 'Infinity') {
-        return new NumberLiteral(this.value).withLocationDataFrom(this).ast(o, level);
+        return new NumberLiteral(this.value).withLocationDataFrom(this).ast(o);
       }
-      return super.ast(o, level);
+      return super.astNode(o);
     }
 
     astType() {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -279,7 +279,8 @@ exports.Base = class Base
   # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
     o = @astInitialize o, level
-    @astAddReturns @astNode o
+    astNode = @astNode o
+    @astAddReturns astNode
 
   astInitialize: (o, level) ->
     o = Object.assign {}, o

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -523,7 +523,7 @@ exports.Root = class Root extends Base
           new LineComment commentToken
     comment.ast() for comment in @allComments
 
-  ast: (o) ->
+  astNode: (o) ->
     o.level = LEVEL_TOP
     @initializeScope o
     super o
@@ -938,10 +938,10 @@ exports.InfinityLiteral = class InfinityLiteral extends NumberLiteral
   compileNode: ->
     [@makeCode '2e308']
 
-  ast: (o, level) ->
+  astNode: (o) ->
     unless @originalValue is 'Infinity'
-      return new NumberLiteral(@value).withLocationDataFrom(@).ast o, level
-    super o, level
+      return new NumberLiteral(@value).withLocationDataFrom(@).ast o
+    super o
 
   astType: -> 'Identifier'
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -279,11 +279,7 @@ exports.Base = class Base
   # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
     o = @astInitialize o, level
-    ast = @astNode o
-    return ast unless ast?
-    # Mark AST nodes that correspond to expressions that (implicitly) return.
-    ast.returns = yes if @canBeReturned
-    ast
+    @astAddReturns @astNode o
 
   astInitialize: (o, level) ->
     o = Object.assign {}, o
@@ -315,6 +311,12 @@ exports.Base = class Base
   # mutated into the structure that the Babel spec uses.
   astLocationData: ->
     jisonLocationDataToAstLocationData @locationData
+
+  # Mark AST nodes that correspond to expressions that (implicitly) return.
+  astAddReturns: (ast) ->
+    return ast unless ast?
+    ast.returns = yes if @canBeReturned
+    ast
 
   # Determines whether an AST node needs an `ExpressionStatement` wrapper.
   # Typically matches our `isStatement()` logic but this allows overriding.

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -278,18 +278,21 @@ exports.Base = class Base
   # **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
   # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
+    o = @astInitialize o, level
+    ast = @astNode o
+    return ast unless ast?
+    # Mark AST nodes that correspond to expressions that (implicitly) return.
+    ast.returns = yes if @canBeReturned
+    ast
+
+  astInitialize: (o, level) ->
     o = Object.assign {}, o
     o.level = level if level?
     # `@makeReturn` must be called before `astProperties`, because the latter may call
     # `.ast()` for child nodes and those nodes would need the return logic from `makeReturn`
     # already executed by then.
     @makeReturn null, yes if @isStatement(o) and o.level isnt LEVEL_TOP and o.scope?
-
-    ast = @astNode o
-    return ast unless ast?
-    # Mark AST nodes that correspond to expressions that (implicitly) return.
-    ast.returns = yes if @canBeReturned
-    ast
+    o
 
   astNode: (o) ->
     # Every abstract syntax tree node object has four categories of properties:

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2900,7 +2900,12 @@ exports.Class = class Class extends Base
       methodName  = variable.base
       method.name = new (if methodName.shouldCache() then Index else Access) methodName
       method.name.updateLocationDataIfMissing methodName.locationData
-      method.ctor = (if @parent then 'derived' else 'base') if methodName.value is 'constructor'
+      isConstructor =
+        if methodName instanceof StringLiteral
+          methodName.originalValue is 'constructor'
+        else
+          methodName.value is 'constructor'
+      method.ctor = (if @parent then 'derived' else 'base') if isConstructor
       method.error 'Cannot define a constructor as a bound (fat arrow) function' if method.bound and method.ctor
 
     method.operatorToken = operatorToken

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -275,9 +275,14 @@ exports.Base = class Base
   # as JSON. This is what the `ast` option in the Node API returns.
   # We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
   # as closely as possible, for improved interoperability with other tools.
+  # **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
+  # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
     o = Object.assign {}, o
     o.level = level if level?
+    # `@makeReturn` must be called before `astProperties`, because the latter may call
+    # `.ast()` for child nodes and those nodes would need the return logic from `makeReturn`
+    # already executed by then.
     @makeReturn null, yes if @isStatement(o) and o.level isnt LEVEL_TOP and o.scope?
 
     ast = @astNode o

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -278,6 +278,15 @@ exports.Base = class Base
   ast: (o, level) ->
     o = Object.assign {}, o
     o.level = level if level?
+    @makeReturn null, yes if @isStatement(o) and o.level isnt LEVEL_TOP and o.scope?
+
+    ast = @astNode o
+    return ast unless ast?
+    # Mark AST nodes that correspond to expressions that (implicitly) return.
+    ast.returns = yes if @canBeReturned
+    ast
+
+  astNode: (o) ->
     # Every abstract syntax tree node object has four categories of properties:
     # - type, stored in the `type` field and a string like `NumberLiteral`.
     # - location data, stored in the `loc`, `start`, `end` and `range` fields.
@@ -807,11 +816,11 @@ exports.Block = class Block extends Base
     return nodes[0] if nodes.length is 1 and nodes[0] instanceof Block
     new Block nodes
 
-  ast: (o, level) ->
-    if (level? and level isnt LEVEL_TOP) and @expressions.length
-      return (new Sequence(@expressions).withLocationDataFrom @).ast o, level
+  astNode: (o) ->
+    if (o.level? and o.level isnt LEVEL_TOP) and @expressions.length
+      return (new Sequence(@expressions).withLocationDataFrom @).ast o
 
-    super o, level
+    super o
 
   astType: ->
     if @isRootBlock
@@ -1047,9 +1056,9 @@ exports.StringLiteral = class StringLiteral extends Literal
   shouldGenerateTemplateLiteral: ->
     @isFromHeredoc()
 
-  ast: (o, level) ->
+  astNode: (o) ->
     return StringWithInterpolations.fromStringLiteral(@).ast o if @shouldGenerateTemplateLiteral()
-    super o, level
+    super o
 
   astProperties: ->
     return
@@ -1098,9 +1107,9 @@ exports.PassthroughLiteral = class PassthroughLiteral extends Literal
       # By reducing it to its latter half, we turn '\`' to '`', '\\\`' to '\`', etc.
       string[-Math.ceil(string.length / 2)..]
 
-  ast: (o, level) ->
+  astNode: (o) ->
     return null if @generated
-    super o, level
+    super o
 
   astProperties: ->
     return {
@@ -1143,8 +1152,8 @@ exports.ComputedPropertyName = class ComputedPropertyName extends PropertyName
   compileNode: (o) ->
     [@makeCode('['), @value.compileToFragments(o, LEVEL_LIST)..., @makeCode(']')]
 
-  ast: (o, level) ->
-    @value.ast o, level
+  astNode: (o) ->
+    @value.ast o
 
 exports.StatementLiteral = class StatementLiteral extends Literal
   isStatement: YES
@@ -1272,7 +1281,7 @@ exports.FuncDirectiveReturn = class FuncDirectiveReturn extends Return
 
   isStatementAst: NO
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @checkScope o
 
     new Op @keyword,
@@ -1284,7 +1293,7 @@ exports.FuncDirectiveReturn = class FuncDirectiveReturn extends Return
           @returnKeyword
       )
     .withLocationDataFrom @
-    .ast o, level
+    .ast o
 
 # `yield return` works exactly like `return`, except that it turns the function
 # into a generator.
@@ -1476,13 +1485,13 @@ exports.Value = class Value extends Base
 
     no
 
-  ast: (o, level) ->
+  astNode: (o) ->
     # If the `Value` has no properties, the AST node is just whatever this
     # node’s `base` is.
-    return @base.ast o, level unless @hasProperties()
+    return @base.ast o unless @hasProperties()
     # Otherwise, call `Base::ast` which in turn calls the `astType` and
     # `astProperties` methods below.
-    super o, level
+    super o
 
   astType: ->
     if @isJSXTag()
@@ -1729,7 +1738,7 @@ exports.JSXAttributes = class JSXAttributes extends Base
       fragments.push attribute.compileToFragments(o, LEVEL_TOP)...
     fragments
 
-  ast: (o) ->
+  astNode: (o) ->
     attribute.ast(o) for attribute in @attributes
 
 exports.JSXNamespacedName = class JSXNamespacedName extends Base
@@ -1770,7 +1779,7 @@ exports.JSXElement = class JSXElement extends Base
   isFragment: ->
     !@tagName.base.value.length
 
-  ast: (o, level) ->
+  astNode: (o) ->
     # The location data spanning the opening element < ... > is captured by
     # the generated Arr which contains the element's attributes
     @openingElementLocationData = jisonLocationDataToAstLocationData @attributes.locationData
@@ -1783,7 +1792,7 @@ exports.JSXElement = class JSXElement extends Base
         jisonLocationDataToAstLocationData tagName.closingTagClosingBracketLocationData
       )
 
-    super o, level
+    super o
 
   astType: ->
     if @isFragment()
@@ -2110,16 +2119,16 @@ exports.Super = class Super extends Base
     attachCommentsToNode salvagedComments, @accessor.name if salvagedComments
     fragments
 
-  ast: (o, level) ->
+  astNode: (o) ->
     if @accessor?
       return (
         new Value(
           new Super().withLocationDataFrom (@superLiteral ? @)
           [@accessor]
         ).withLocationDataFrom @
-      ).ast o, level
+      ).ast o
 
-    super o, level
+    super o
 
 #### RegexWithInterpolations
 
@@ -2198,11 +2207,11 @@ exports.Access = class Access extends Base
 
   shouldCache: NO
 
-  ast: (o, level) ->
+  astNode: (o) ->
     # Babel doesn’t have an AST node for `Access`, but rather just includes
     # this Access node’s child `name` Identifier node as the `property` of
     # the `MemberExpression` node.
-    @name.ast o, level
+    @name.ast o
 
 #### Index
 
@@ -2219,13 +2228,13 @@ exports.Index = class Index extends Base
   shouldCache: ->
     @index.shouldCache()
 
-  ast: (o, level) ->
+  astNode: (o) ->
     # Babel doesn’t have an AST node for `Index`, but rather just includes
     # this Index node’s child `index` Identifier node as the `property` of
     # the `MemberExpression` node. The fact that the `MemberExpression`’s
     # `property` is an Index means that `computed` is `true` for the
     # `MemberExpression`.
-    @index.ast o, level
+    @index.ast o
 
 #### Range
 
@@ -2382,8 +2391,8 @@ exports.Slice = class Slice extends Base
           "+#{fragmentsToText compiled} + 1 || 9e9"
     [@makeCode ".slice(#{ fragmentsToText fromCompiled }#{ toStr or '' })"]
 
-  ast: (o, level) ->
-    @range.ast(o, level)
+  astNode: (o) ->
+    @range.ast o
 
 #### Obj
 
@@ -2943,15 +2952,16 @@ exports.Class = class Class extends Base
 
   isStatementAst: -> yes
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @declareName o
     @name = @determineName()
     @body.isClassBody = yes
     @body.locationData = zeroWidthLocationDataFromEndLocation @locationData if @hasGeneratedBody
     @walkBody o
     sniffDirectives @body.expressions
+    @ctor?.noReturn = yes
 
-    super o, level
+    super o
 
   astType: (o) ->
     if o.level is LEVEL_TOP
@@ -3174,7 +3184,7 @@ exports.ImportClause = class ImportClause extends Base
 
     code
 
-  ast: (o) ->
+  astNode: (o) ->
     # The AST for `ImportClause` is the non-nested list of import specifiers
     # that will be the `specifiers` property of an `ImportDeclaration` AST
     compact flatten [
@@ -3254,7 +3264,7 @@ exports.ModuleSpecifierList = class ModuleSpecifierList extends Base
       code.push @makeCode '{}'
     code
 
-  ast: (o) ->
+  astNode: (o) ->
     specifier.ast(o) for specifier in @specifiers
 
 exports.ImportSpecifierList = class ImportSpecifierList extends ModuleSpecifierList
@@ -3685,9 +3695,9 @@ exports.Assign = class Assign extends Base
 
   isStatementAst: NO
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @addScopeVariables o, checkAssignability: no
-    super o, level
+    super o
 
   astType: ->
     if @isDefaultAssignment()
@@ -4033,9 +4043,11 @@ exports.Code = class Code extends Base
     for {name} in @params when name instanceof Arr or name instanceof Obj
       name.propagateLhs yes
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @updateOptions o
-    super o, level
+    @body.makeReturn null, yes unless @body.isEmpty() or @noReturn
+
+    super o
 
   astType: ->
     if @isMethod
@@ -4290,7 +4302,7 @@ exports.Elision = class Elision extends Base
 
   eachName: (iterator) ->
 
-  ast: ->
+  astNode: ->
     null
 
 #### While
@@ -4582,9 +4594,9 @@ exports.Op = class Op extends Base
   toString: (idt) ->
     super idt, @constructor.name + ' ' + @operator
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @checkContinuation o if @isYield() or @isAwait()
-    super o, level
+    super o
 
   astType: ->
     return 'AwaitExpression' if @isAwait()
@@ -4772,12 +4784,12 @@ exports.Catch = class Catch extends Base
     [].concat @makeCode(" catch ("), placeholder.compileToFragments(o), @makeCode(") {\n"),
       @recovery.compileToFragments(o, LEVEL_TOP), @makeCode("\n#{@tab}}")
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @errorVariable?.eachName (name) ->
       alreadyDeclared = o.scope.find name.value
       name.isDeclaration = not alreadyDeclared
 
-    super o, level
+    super o
 
   astType: -> 'CatchClause'
 
@@ -4901,7 +4913,7 @@ exports.Parens = class Parens extends Base
     return @wrapInBraces fragments if @jsxAttribute
     if bare then fragments else @wrapInParentheses fragments
 
-  ast: (o) -> @body.unwrap().ast o, LEVEL_PAREN
+  astNode: (o) -> @body.unwrap().ast o, LEVEL_PAREN
 
 #### StringWithInterpolations
 
@@ -5215,13 +5227,13 @@ exports.For = class For extends While
     fragments.push @makeCode(returnResult) if returnResult
     fragments
 
-  ast: (o, level) ->
+  astNode: (o) ->
     addToScope = (name) ->
       alreadyDeclared = o.scope.find name.value
       name.isDeclaration = not alreadyDeclared
     @name?.eachName addToScope
     @index?.eachName addToScope
-    super o, level
+    super o
 
   astType: -> 'For'
 
@@ -5465,8 +5477,8 @@ exports.Sequence = class Sequence extends Base
   constructor: (@expressions) ->
     super()
 
-  ast: (o, level) ->
-    return @expressions[0].ast(o, level) if @expressions.length is 1
+  astNode: (o) ->
+    return @expressions[0].ast(o) if @expressions.length is 1
     super o
 
   astType: -> 'SequenceExpression'

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -4059,8 +4059,14 @@ exports.Code = class Code extends Base
     for {name} in @params when name instanceof Arr or name instanceof Obj
       name.propagateLhs yes
 
+  astAddParamsToScope: (o) ->
+    for param in @params
+      param.eachName (name) ->
+        o.scope.add name, 'param'
+
   astNode: (o) ->
     @updateOptions o
+    @astAddParamsToScope o
     @body.makeReturn null, yes unless @body.isEmpty() or @noReturn
 
     super o

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1872,6 +1872,29 @@ test "AST as expected for Class node", ->
       object: ID 'A', declaration: no
       property: ID 'b', declaration: no
 
+  testStatement '''
+    class A
+      'constructor': ->
+  ''',
+    type: 'ClassDeclaration'
+    body:
+      type: 'ClassBody'
+      body: [
+        type: 'ClassMethod'
+        static: no
+        key:
+          type: 'StringLiteral'
+        computed: no
+        kind: 'constructor'
+        id: null
+        generator: no
+        async: no
+        params: []
+        body: EMPTY_BLOCK
+        bound: no
+      ]
+
+
 test "AST as expected for ModuleDeclaration node", ->
   testStatement 'export {X}',
     type: 'ExportNamedDeclaration'

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2565,6 +2565,84 @@ test "AST as expected for Code node", ->
     async: no
     id: null
 
+  testExpression '(a) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+
+  testExpression '(...a) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+
+  testExpression '({a}) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+
+  testExpression '([a]) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+
+  testExpression '(a = 1) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+    generator: no
+    async: no
+    id: null
+
+  testExpression '({a} = 1) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+    generator: no
+    async: no
+    id: null
+
 test "AST as expected for Splat node", ->
   testExpression '[a...]',
     type: 'ArrayExpression'

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -775,6 +775,7 @@ test "AST as expected for Call node", ->
     arguments: []
     optional: no
     implicit: no
+    returns: undefined
 
   testExpression 'new Date()',
     type: 'NewExpression'
@@ -1575,7 +1576,7 @@ test "AST as expected for Class node", ->
       type: 'ClassBody'
       body: []
 
-  testStatement 'class Klass then constructor: ->',
+  testStatement 'class Klass then constructor: -> @a = 1',
     type: 'ClassDeclaration'
     id: ID 'Klass', declaration: yes
     superClass: null
@@ -1591,7 +1592,14 @@ test "AST as expected for Class node", ->
         generator: no
         async: no
         params: []
-        body: EMPTY_BLOCK
+        body:
+          type: 'BlockStatement'
+          body: [
+            type: 'ExpressionStatement'
+            expression:
+              type: 'AssignmentExpression'
+              returns: undefined
+          ]
         bound: no
       ]
 
@@ -1623,7 +1631,7 @@ test "AST as expected for Class node", ->
             type: 'BlockStatement'
             body: [
               type: 'ExpressionStatement'
-              expression: ID 'c'
+              expression: ID 'c', returns: yes
             ]
           operator: ':'
           bound: no
@@ -2283,6 +2291,7 @@ test "AST as expected for Code node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: yes
       ]
       directives: []
     generator: no
@@ -2478,7 +2487,7 @@ test "AST as expected for Code node", ->
       type: 'BlockStatement'
       body: [
         type: 'ExpressionStatement'
-        expression: ID 'a'
+        expression: ID 'a', returns: yes
       ]
     generator: no
     async: no
@@ -2495,6 +2504,7 @@ test "AST as expected for Code node", ->
         expression:
           type: 'AwaitExpression'
           argument: NUMBER 3
+          returns: yes
       ]
     generator: no
     async: yes
@@ -2663,6 +2673,7 @@ test "AST as expected for While node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: undefined
       ]
     guard: null
     inverted: yes
@@ -2726,6 +2737,21 @@ test "AST as expected for While node", ->
     inverted: no
     postfix: no
     loop: yes
+
+  testExpression '''
+    x = (z() while y)
+  ''',
+    type: 'AssignmentExpression'
+    right:
+      type: 'WhileStatement'
+      body:
+        type: 'BlockStatement'
+        body: [
+          type: 'ExpressionStatement'
+          expression:
+            type: 'CallExpression'
+            returns: yes
+        ]
 
 test "AST as expected for Op node", ->
   testExpression 'a <= 2',
@@ -3282,7 +3308,7 @@ test "AST as expected for For node", ->
         type: 'BlockStatement'
         body: [
           type: 'ExpressionStatement'
-          expression: ID 'x', declaration: no
+          expression: ID 'x', declaration: no, returns: yes
         ]
       source: ID 'y', declaration: no
       guard: null
@@ -3300,7 +3326,7 @@ test "AST as expected for For node", ->
       type: 'BlockStatement'
       body: [
         type: 'ExpressionStatement'
-        expression: ID 'x', declaration: no
+        expression: ID 'x', declaration: no, returns: undefined
       ]
     source:
       type: 'Range'
@@ -3325,9 +3351,10 @@ test "AST as expected for For node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: undefined
       ,
         type: 'ExpressionStatement'
-        expression: ID 'd', declaration: no
+        expression: ID 'd', declaration: no, returns: undefined
       ]
     source: ID 'z', declaration: no
     guard: null
@@ -3353,7 +3380,7 @@ test "AST as expected for For node", ->
           type: 'BlockStatement'
           body: [
             type: 'ExpressionStatement'
-            expression: ID 'z', declaration: no
+            expression: ID 'z', declaration: no, returns: yes
           ]
         source: ID 'y', declaration: no
         guard: null


### PR DESCRIPTION
@GeoffreyBooth PR ensuring that function params get declared on the scope during AST generation. Basically in order for `declaration` (#5247) to always be accurate, everything needs to get added to the scope

Based on `ast-quoted-constructor`, [here](https://github.com/helixbass/copheescript/compare/ast-quoted-constructor...ast-add-params-to-scope) is just the diff against that branch