### PR TITLE
AST: object colon location data

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -277,8 +277,7 @@
       if (colon) {
         colonOffset = input.lastIndexOf(inJSXTag ? '=' : ':');
         colonToken = this.token(':', ':', {
-          offset: colonOffset,
-          length: colon.length
+          offset: colonOffset
         });
         if (inJSXTag) { // used by rewriter
           colonToken.jsxColon = true;

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -370,10 +370,26 @@
       // We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
       // as closely as possible, for improved interoperability with other tools.
       ast(o, level) {
+        var ast;
         o = Object.assign({}, o);
         if (level != null) {
           o.level = level;
         }
+        if (this.isStatement(o) && o.level !== LEVEL_TOP && (o.scope != null)) {
+          this.makeReturn(null, true);
+        }
+        ast = this.astNode(o);
+        if (ast == null) {
+          return ast;
+        }
+        if (this.canBeReturned) {
+          // Mark AST nodes that correspond to expressions that (implicitly) return.
+          ast.returns = true;
+        }
+        return ast;
+      }
+
+      astNode(o) {
         // Every abstract syntax tree node object has four categories of properties:
         // - type, stored in the `type` field and a string like `NumberLiteral`.
         // - location data, stored in the `loc`, `start`, `end` and `range` fields.
@@ -1150,11 +1166,11 @@
         return new Block(nodes);
       }
 
-      ast(o, level) {
-        if (((level != null) && level !== LEVEL_TOP) && this.expressions.length) {
-          return (new Sequence(this.expressions).withLocationDataFrom(this)).ast(o, level);
+      astNode(o) {
+        if (((o.level != null) && o.level !== LEVEL_TOP) && this.expressions.length) {
+          return (new Sequence(this.expressions).withLocationDataFrom(this)).ast(o);
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -1476,11 +1492,11 @@
       return this.isFromHeredoc();
     }
 
-    ast(o, level) {
+    astNode(o) {
       if (this.shouldGenerateTemplateLiteral()) {
         return StringWithInterpolations.fromStringLiteral(this).ast(o);
       }
-      return super.ast(o, level);
+      return super.astNode(o);
     }
 
     astProperties() {
@@ -1570,11 +1586,11 @@
       });
     }
 
-    ast(o, level) {
+    astNode(o) {
       if (this.generated) {
         return null;
       }
-      return super.ast(o, level);
+      return super.astNode(o);
     }
 
     astProperties() {
@@ -1645,8 +1661,8 @@
       return [this.makeCode('['), ...this.value.compileToFragments(o, LEVEL_LIST), this.makeCode(']')];
     }
 
-    ast(o, level) {
-      return this.value.ast(o, level);
+    astNode(o) {
+      return this.value.ast(o);
     }
 
   };
@@ -1863,11 +1879,11 @@
         }
       }
 
-      ast(o, level) {
+      astNode(o) {
         this.checkScope(o);
         return new Op(this.keyword, new Return(this.expression).withLocationDataFrom(this.expression != null ? {
           locationData: mergeLocationData(this.returnKeyword.locationData, this.expression.locationData)
-        } : this.returnKeyword)).withLocationDataFrom(this).ast(o, level);
+        } : this.returnKeyword)).withLocationDataFrom(this).ast(o);
       }
 
     };
@@ -2189,15 +2205,15 @@
         return false;
       }
 
-      ast(o, level) {
+      astNode(o) {
         if (!this.hasProperties()) {
           // If the `Value` has no properties, the AST node is just whatever this
           // node’s `base` is.
-          return this.base.ast(o, level);
+          return this.base.ast(o);
         }
         // Otherwise, call `Base::ast` which in turn calls the `astType` and
         // `astProperties` methods below.
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -2577,7 +2593,7 @@
         return fragments;
       }
 
-      ast(o) {
+      astNode(o) {
         var attribute, j, len1, ref1, results1;
         ref1 = this.attributes;
         results1 = [];
@@ -2662,7 +2678,7 @@
         return !this.tagName.base.value.length;
       }
 
-      ast(o, level) {
+      astNode(o) {
         var tagName;
         // The location data spanning the opening element < ... > is captured by
         // the generated Arr which contains the element's attributes
@@ -2672,7 +2688,7 @@
         if (this.content != null) {
           this.closingElementLocationData = mergeAstLocationData(jisonLocationDataToAstLocationData(tagName.closingTagOpeningBracketLocationData), jisonLocationDataToAstLocationData(tagName.closingTagClosingBracketLocationData));
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -3136,12 +3152,12 @@
         return fragments;
       }
 
-      ast(o, level) {
+      astNode(o) {
         var ref1;
         if (this.accessor != null) {
-          return (new Value(new Super().withLocationDataFrom((ref1 = this.superLiteral) != null ? ref1 : this), [this.accessor]).withLocationDataFrom(this)).ast(o, level);
+          return (new Value(new Super().withLocationDataFrom((ref1 = this.superLiteral) != null ? ref1 : this), [this.accessor]).withLocationDataFrom(this)).ast(o);
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
     };
@@ -3281,11 +3297,11 @@
         }
       }
 
-      ast(o, level) {
+      astNode(o) {
         // Babel doesn’t have an AST node for `Access`, but rather just includes
         // this Access node’s child `name` Identifier node as the `property` of
         // the `MemberExpression` node.
-        return this.name.ast(o, level);
+        return this.name.ast(o);
       }
 
     };
@@ -3316,13 +3332,13 @@
         return this.index.shouldCache();
       }
 
-      ast(o, level) {
+      astNode(o) {
         // Babel doesn’t have an AST node for `Index`, but rather just includes
         // this Index node’s child `index` Identifier node as the `property` of
         // the `MemberExpression` node. The fact that the `MemberExpression`’s
         // `property` is an Index means that `computed` is `true` for the
         // `MemberExpression`.
-        return this.index.ast(o, level);
+        return this.index.ast(o);
       }
 
     };
@@ -3505,8 +3521,8 @@
         return [this.makeCode(`.slice(${fragmentsToText(fromCompiled)}${toStr || ''})`)];
       }
 
-      ast(o, level) {
-        return this.range.ast(o, level);
+      astNode(o) {
+        return this.range.ast(o);
       }
 
     };
@@ -4411,7 +4427,8 @@
         return true;
       }
 
-      ast(o, level) {
+      astNode(o) {
+        var ref1;
         this.declareName(o);
         this.name = this.determineName();
         this.body.isClassBody = true;
@@ -4420,7 +4437,10 @@
         }
         this.walkBody(o);
         sniffDirectives(this.body.expressions);
-        return super.ast(o, level);
+        if ((ref1 = this.ctor) != null) {
+          ref1.noReturn = true;
+        }
+        return super.astNode(o);
       }
 
       astType(o) {
@@ -4753,7 +4773,7 @@
         return code;
       }
 
-      ast(o) {
+      astNode(o) {
         var ref1, ref2;
         // The AST for `ImportClause` is the non-nested list of import specifiers
         // that will be the `specifiers` property of an `ImportDeclaration` AST
@@ -4875,7 +4895,7 @@
         return code;
       }
 
-      ast(o) {
+      astNode(o) {
         var j, len1, ref1, results1, specifier;
         ref1 = this.specifiers;
         results1 = [];
@@ -5530,11 +5550,11 @@
         return this.variable.base.propagateLhs(true);
       }
 
-      ast(o, level) {
+      astNode(o) {
         this.addScopeVariables(o, {
           checkAssignability: false
         });
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -6028,9 +6048,12 @@
         return results1;
       }
 
-      ast(o, level) {
+      astNode(o) {
         this.updateOptions(o);
-        return super.ast(o, level);
+        if (!(this.body.isEmpty() || this.noReturn)) {
+          this.body.makeReturn(null, true);
+        }
+        return super.astNode(o);
       }
 
       astType() {
@@ -6419,7 +6442,7 @@
 
       eachName(iterator) {}
 
-      ast() {
+      astNode() {
         return null;
       }
 
@@ -6842,11 +6865,11 @@
         return super.toString(idt, this.constructor.name + ' ' + this.operator);
       }
 
-      ast(o, level) {
+      astNode(o) {
         if (this.isYield() || this.isAwait()) {
           this.checkContinuation(o);
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -7165,7 +7188,7 @@
         return [].concat(this.makeCode(" catch ("), placeholder.compileToFragments(o), this.makeCode(") {\n"), this.recovery.compileToFragments(o, LEVEL_TOP), this.makeCode(`\n${this.tab}}`));
       }
 
-      ast(o, level) {
+      astNode(o) {
         var ref1;
         if ((ref1 = this.errorVariable) != null) {
           ref1.eachName(function(name) {
@@ -7174,7 +7197,7 @@
             return name.isDeclaration = !alreadyDeclared;
           });
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -7364,7 +7387,7 @@
         }
       }
 
-      ast(o) {
+      astNode(o) {
         return this.body.unwrap().ast(o, LEVEL_PAREN);
       }
 
@@ -7863,7 +7886,7 @@
         return fragments;
       }
 
-      ast(o, level) {
+      astNode(o) {
         var addToScope, ref1, ref2;
         addToScope = function(name) {
           var alreadyDeclared;
@@ -7876,7 +7899,7 @@
         if ((ref2 = this.index) != null) {
           ref2.eachName(addToScope);
         }
-        return super.ast(o, level);
+        return super.astNode(o);
       }
 
       astType() {
@@ -8294,11 +8317,11 @@
         this.expressions = expressions1;
       }
 
-      ast(o, level) {
+      astNode(o) {
         if (this.expressions.length === 1) {
-          return this.expressions[0].ast(o, level);
+          return this.expressions[0].ast(o);
         }
-        return super.ast(o);
+        return super.astNode(o);
       }
 
       astType() {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -6063,8 +6063,22 @@
         return results1;
       }
 
+      astAddParamsToScope(o) {
+        var j, len1, param, ref1, results1;
+        ref1 = this.params;
+        results1 = [];
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          param = ref1[j];
+          results1.push(param.eachName(function(name) {
+            return o.scope.add(name, 'param');
+          }));
+        }
+        return results1;
+      }
+
       astNode(o) {
         this.updateOptions(o);
+        this.astAddParamsToScope(o);
         if (!(this.body.isEmpty() || this.noReturn)) {
           this.body.makeReturn(null, true);
         }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -372,17 +372,8 @@
       // **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
       // Only override the component `ast*` methods as needed.
       ast(o, level) {
-        var ast;
         o = this.astInitialize(o, level);
-        ast = this.astNode(o);
-        if (ast == null) {
-          return ast;
-        }
-        if (this.canBeReturned) {
-          // Mark AST nodes that correspond to expressions that (implicitly) return.
-          ast.returns = true;
-        }
-        return ast;
+        return this.astAddReturns(this.astNode(o));
       }
 
       astInitialize(o, level) {
@@ -427,6 +418,17 @@
       // mutated into the structure that the Babel spec uses.
       astLocationData() {
         return jisonLocationDataToAstLocationData(this.locationData);
+      }
+
+      // Mark AST nodes that correspond to expressions that (implicitly) return.
+      astAddReturns(ast) {
+        if (ast == null) {
+          return ast;
+        }
+        if (this.canBeReturned) {
+          ast.returns = true;
+        }
+        return ast;
       }
 
       // Determines whether an AST node needs an `ExpressionStatement` wrapper.

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -372,8 +372,10 @@
       // **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
       // Only override the component `ast*` methods as needed.
       ast(o, level) {
+        var astNode;
         o = this.astInitialize(o, level);
-        return this.astAddReturns(this.astNode(o));
+        astNode = this.astNode(o);
+        return this.astAddReturns(astNode);
       }
 
       astInitialize(o, level) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4332,7 +4332,7 @@
 
       // Returns a configured class initializer method
       addInitializerMethod(assign) {
-        var method, methodName, operatorToken, variable;
+        var isConstructor, method, methodName, operatorToken, variable;
         ({
           variable,
           value: method,
@@ -4346,7 +4346,8 @@
           methodName = variable.base;
           method.name = new (methodName.shouldCache() ? Index : Access)(methodName);
           method.name.updateLocationDataIfMissing(methodName.locationData);
-          if (methodName.value === 'constructor') {
+          isConstructor = methodName instanceof StringLiteral ? methodName.originalValue === 'constructor' : methodName.value === 'constructor';
+          if (isConstructor) {
             method.ctor = (this.parent ? 'derived' : 'base');
           }
           if (method.bound && method.ctor) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -369,6 +369,8 @@
       // as JSON. This is what the `ast` option in the Node API returns.
       // We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
       // as closely as possible, for improved interoperability with other tools.
+      // **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
+      // Only override the component `ast*` methods as needed.
       ast(o, level) {
         var ast;
         o = Object.assign({}, o);
@@ -376,6 +378,9 @@
           o.level = level;
         }
         if (this.isStatement(o) && o.level !== LEVEL_TOP && (o.scope != null)) {
+          // `@makeReturn` must be called before `astProperties`, because the latter may call
+          // `.ast()` for child nodes and those nodes would need the return logic from `makeReturn`
+          // already executed by then.
           this.makeReturn(null, true);
         }
         ast = this.astNode(o);

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -373,6 +373,19 @@
       // Only override the component `ast*` methods as needed.
       ast(o, level) {
         var ast;
+        o = this.astInitialize(o, level);
+        ast = this.astNode(o);
+        if (ast == null) {
+          return ast;
+        }
+        if (this.canBeReturned) {
+          // Mark AST nodes that correspond to expressions that (implicitly) return.
+          ast.returns = true;
+        }
+        return ast;
+      }
+
+      astInitialize(o, level) {
         o = Object.assign({}, o);
         if (level != null) {
           o.level = level;
@@ -383,15 +396,7 @@
           // already executed by then.
           this.makeReturn(null, true);
         }
-        ast = this.astNode(o);
-        if (ast == null) {
-          return ast;
-        }
-        if (this.canBeReturned) {
-          // Mark AST nodes that correspond to expressions that (implicitly) return.
-          ast.returns = true;
-        }
-        return ast;
+        return o;
       }
 
       astNode(o) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -754,10 +754,10 @@
       return results1;
     }
 
-    ast(o) {
+    astNode(o) {
       o.level = LEVEL_TOP;
       this.initializeScope(o);
-      return super.ast(o);
+      return super.astNode(o);
     }
 
     astType() {
@@ -1343,11 +1343,11 @@
       return [this.makeCode('2e308')];
     }
 
-    ast(o, level) {
+    astNode(o) {
       if (this.originalValue !== 'Infinity') {
-        return new NumberLiteral(this.value).withLocationDataFrom(this).ast(o, level);
+        return new NumberLiteral(this.value).withLocationDataFrom(this).ast(o);
       }
-      return super.ast(o, level);
+      return super.astNode(o);
     }
 
     astType() {

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -246,7 +246,7 @@ exports.Lexer = class Lexer
         [poppedToken[2].first_line, poppedToken[2].first_column, poppedToken[2].range[0]]
     if colon
       colonOffset = input.lastIndexOf if inJSXTag then '=' else ':'
-      colonToken = @token ':', ':', offset: colonOffset, length: colon.length
+      colonToken = @token ':', ':', offset: colonOffset
       colonToken.jsxColon = yes if inJSXTag # used by rewriter
     if inJSXTag and tag is 'IDENTIFIER' and prev[0] isnt ':'
       @token ',', ',', length: 0, origin: tagToken

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -279,7 +279,8 @@ exports.Base = class Base
   # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
     o = @astInitialize o, level
-    @astAddReturns @astNode o
+    astNode = @astNode o
+    @astAddReturns astNode
 
   astInitialize: (o, level) ->
     o = Object.assign {}, o

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -523,7 +523,7 @@ exports.Root = class Root extends Base
           new LineComment commentToken
     comment.ast() for comment in @allComments
 
-  ast: (o) ->
+  astNode: (o) ->
     o.level = LEVEL_TOP
     @initializeScope o
     super o
@@ -938,10 +938,10 @@ exports.InfinityLiteral = class InfinityLiteral extends NumberLiteral
   compileNode: ->
     [@makeCode '2e308']
 
-  ast: (o, level) ->
+  astNode: (o) ->
     unless @originalValue is 'Infinity'
-      return new NumberLiteral(@value).withLocationDataFrom(@).ast o, level
-    super o, level
+      return new NumberLiteral(@value).withLocationDataFrom(@).ast o
+    super o
 
   astType: -> 'Identifier'
 

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -279,11 +279,7 @@ exports.Base = class Base
   # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
     o = @astInitialize o, level
-    ast = @astNode o
-    return ast unless ast?
-    # Mark AST nodes that correspond to expressions that (implicitly) return.
-    ast.returns = yes if @canBeReturned
-    ast
+    @astAddReturns @astNode o
 
   astInitialize: (o, level) ->
     o = Object.assign {}, o
@@ -315,6 +311,12 @@ exports.Base = class Base
   # mutated into the structure that the Babel spec uses.
   astLocationData: ->
     jisonLocationDataToAstLocationData @locationData
+
+  # Mark AST nodes that correspond to expressions that (implicitly) return.
+  astAddReturns: (ast) ->
+    return ast unless ast?
+    ast.returns = yes if @canBeReturned
+    ast
 
   # Determines whether an AST node needs an `ExpressionStatement` wrapper.
   # Typically matches our `isStatement()` logic but this allows overriding.

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -278,18 +278,21 @@ exports.Base = class Base
   # **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
   # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
+    o = @astInitialize o, level
+    ast = @astNode o
+    return ast unless ast?
+    # Mark AST nodes that correspond to expressions that (implicitly) return.
+    ast.returns = yes if @canBeReturned
+    ast
+
+  astInitialize: (o, level) ->
     o = Object.assign {}, o
     o.level = level if level?
     # `@makeReturn` must be called before `astProperties`, because the latter may call
     # `.ast()` for child nodes and those nodes would need the return logic from `makeReturn`
     # already executed by then.
     @makeReturn null, yes if @isStatement(o) and o.level isnt LEVEL_TOP and o.scope?
-
-    ast = @astNode o
-    return ast unless ast?
-    # Mark AST nodes that correspond to expressions that (implicitly) return.
-    ast.returns = yes if @canBeReturned
-    ast
+    o
 
   astNode: (o) ->
     # Every abstract syntax tree node object has four categories of properties:

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2900,7 +2900,12 @@ exports.Class = class Class extends Base
       methodName  = variable.base
       method.name = new (if methodName.shouldCache() then Index else Access) methodName
       method.name.updateLocationDataIfMissing methodName.locationData
-      method.ctor = (if @parent then 'derived' else 'base') if methodName.value is 'constructor'
+      isConstructor =
+        if methodName instanceof StringLiteral
+          methodName.originalValue is 'constructor'
+        else
+          methodName.value is 'constructor'
+      method.ctor = (if @parent then 'derived' else 'base') if isConstructor
       method.error 'Cannot define a constructor as a bound (fat arrow) function' if method.bound and method.ctor
 
     method.operatorToken = operatorToken

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -275,9 +275,14 @@ exports.Base = class Base
   # as JSON. This is what the `ast` option in the Node API returns.
   # We try to follow the [Babel AST spec](https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md)
   # as closely as possible, for improved interoperability with other tools.
+  # **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
+  # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
     o = Object.assign {}, o
     o.level = level if level?
+    # `@makeReturn` must be called before `astProperties`, because the latter may call
+    # `.ast()` for child nodes and those nodes would need the return logic from `makeReturn`
+    # already executed by then.
     @makeReturn null, yes if @isStatement(o) and o.level isnt LEVEL_TOP and o.scope?
 
     ast = @astNode o

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -278,6 +278,15 @@ exports.Base = class Base
   ast: (o, level) ->
     o = Object.assign {}, o
     o.level = level if level?
+    @makeReturn null, yes if @isStatement(o) and o.level isnt LEVEL_TOP and o.scope?
+
+    ast = @astNode o
+    return ast unless ast?
+    # Mark AST nodes that correspond to expressions that (implicitly) return.
+    ast.returns = yes if @canBeReturned
+    ast
+
+  astNode: (o) ->
     # Every abstract syntax tree node object has four categories of properties:
     # - type, stored in the `type` field and a string like `NumberLiteral`.
     # - location data, stored in the `loc`, `start`, `end` and `range` fields.
@@ -807,11 +816,11 @@ exports.Block = class Block extends Base
     return nodes[0] if nodes.length is 1 and nodes[0] instanceof Block
     new Block nodes
 
-  ast: (o, level) ->
-    if (level? and level isnt LEVEL_TOP) and @expressions.length
-      return (new Sequence(@expressions).withLocationDataFrom @).ast o, level
+  astNode: (o) ->
+    if (o.level? and o.level isnt LEVEL_TOP) and @expressions.length
+      return (new Sequence(@expressions).withLocationDataFrom @).ast o
 
-    super o, level
+    super o
 
   astType: ->
     if @isRootBlock
@@ -1047,9 +1056,9 @@ exports.StringLiteral = class StringLiteral extends Literal
   shouldGenerateTemplateLiteral: ->
     @isFromHeredoc()
 
-  ast: (o, level) ->
+  astNode: (o) ->
     return StringWithInterpolations.fromStringLiteral(@).ast o if @shouldGenerateTemplateLiteral()
-    super o, level
+    super o
 
   astProperties: ->
     return
@@ -1098,9 +1107,9 @@ exports.PassthroughLiteral = class PassthroughLiteral extends Literal
       # By reducing it to its latter half, we turn '\`' to '`', '\\\`' to '\`', etc.
       string[-Math.ceil(string.length / 2)..]
 
-  ast: (o, level) ->
+  astNode: (o) ->
     return null if @generated
-    super o, level
+    super o
 
   astProperties: ->
     return {
@@ -1143,8 +1152,8 @@ exports.ComputedPropertyName = class ComputedPropertyName extends PropertyName
   compileNode: (o) ->
     [@makeCode('['), @value.compileToFragments(o, LEVEL_LIST)..., @makeCode(']')]
 
-  ast: (o, level) ->
-    @value.ast o, level
+  astNode: (o) ->
+    @value.ast o
 
 exports.StatementLiteral = class StatementLiteral extends Literal
   isStatement: YES
@@ -1272,7 +1281,7 @@ exports.FuncDirectiveReturn = class FuncDirectiveReturn extends Return
 
   isStatementAst: NO
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @checkScope o
 
     new Op @keyword,
@@ -1284,7 +1293,7 @@ exports.FuncDirectiveReturn = class FuncDirectiveReturn extends Return
           @returnKeyword
       )
     .withLocationDataFrom @
-    .ast o, level
+    .ast o
 
 # `yield return` works exactly like `return`, except that it turns the function
 # into a generator.
@@ -1476,13 +1485,13 @@ exports.Value = class Value extends Base
 
     no
 
-  ast: (o, level) ->
+  astNode: (o) ->
     # If the `Value` has no properties, the AST node is just whatever this
     # node’s `base` is.
-    return @base.ast o, level unless @hasProperties()
+    return @base.ast o unless @hasProperties()
     # Otherwise, call `Base::ast` which in turn calls the `astType` and
     # `astProperties` methods below.
-    super o, level
+    super o
 
   astType: ->
     if @isJSXTag()
@@ -1729,7 +1738,7 @@ exports.JSXAttributes = class JSXAttributes extends Base
       fragments.push attribute.compileToFragments(o, LEVEL_TOP)...
     fragments
 
-  ast: (o) ->
+  astNode: (o) ->
     attribute.ast(o) for attribute in @attributes
 
 exports.JSXNamespacedName = class JSXNamespacedName extends Base
@@ -1770,7 +1779,7 @@ exports.JSXElement = class JSXElement extends Base
   isFragment: ->
     !@tagName.base.value.length
 
-  ast: (o, level) ->
+  astNode: (o) ->
     # The location data spanning the opening element < ... > is captured by
     # the generated Arr which contains the element's attributes
     @openingElementLocationData = jisonLocationDataToAstLocationData @attributes.locationData
@@ -1783,7 +1792,7 @@ exports.JSXElement = class JSXElement extends Base
         jisonLocationDataToAstLocationData tagName.closingTagClosingBracketLocationData
       )
 
-    super o, level
+    super o
 
   astType: ->
     if @isFragment()
@@ -2110,16 +2119,16 @@ exports.Super = class Super extends Base
     attachCommentsToNode salvagedComments, @accessor.name if salvagedComments
     fragments
 
-  ast: (o, level) ->
+  astNode: (o) ->
     if @accessor?
       return (
         new Value(
           new Super().withLocationDataFrom (@superLiteral ? @)
           [@accessor]
         ).withLocationDataFrom @
-      ).ast o, level
+      ).ast o
 
-    super o, level
+    super o
 
 #### RegexWithInterpolations
 
@@ -2198,11 +2207,11 @@ exports.Access = class Access extends Base
 
   shouldCache: NO
 
-  ast: (o, level) ->
+  astNode: (o) ->
     # Babel doesn’t have an AST node for `Access`, but rather just includes
     # this Access node’s child `name` Identifier node as the `property` of
     # the `MemberExpression` node.
-    @name.ast o, level
+    @name.ast o
 
 #### Index
 
@@ -2219,13 +2228,13 @@ exports.Index = class Index extends Base
   shouldCache: ->
     @index.shouldCache()
 
-  ast: (o, level) ->
+  astNode: (o) ->
     # Babel doesn’t have an AST node for `Index`, but rather just includes
     # this Index node’s child `index` Identifier node as the `property` of
     # the `MemberExpression` node. The fact that the `MemberExpression`’s
     # `property` is an Index means that `computed` is `true` for the
     # `MemberExpression`.
-    @index.ast o, level
+    @index.ast o
 
 #### Range
 
@@ -2382,8 +2391,8 @@ exports.Slice = class Slice extends Base
           "+#{fragmentsToText compiled} + 1 || 9e9"
     [@makeCode ".slice(#{ fragmentsToText fromCompiled }#{ toStr or '' })"]
 
-  ast: (o, level) ->
-    @range.ast(o, level)
+  astNode: (o) ->
+    @range.ast o
 
 #### Obj
 
@@ -2943,15 +2952,16 @@ exports.Class = class Class extends Base
 
   isStatementAst: -> yes
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @declareName o
     @name = @determineName()
     @body.isClassBody = yes
     @body.locationData = zeroWidthLocationDataFromEndLocation @locationData if @hasGeneratedBody
     @walkBody o
     sniffDirectives @body.expressions
+    @ctor?.noReturn = yes
 
-    super o, level
+    super o
 
   astType: (o) ->
     if o.level is LEVEL_TOP
@@ -3174,7 +3184,7 @@ exports.ImportClause = class ImportClause extends Base
 
     code
 
-  ast: (o) ->
+  astNode: (o) ->
     # The AST for `ImportClause` is the non-nested list of import specifiers
     # that will be the `specifiers` property of an `ImportDeclaration` AST
     compact flatten [
@@ -3254,7 +3264,7 @@ exports.ModuleSpecifierList = class ModuleSpecifierList extends Base
       code.push @makeCode '{}'
     code
 
-  ast: (o) ->
+  astNode: (o) ->
     specifier.ast(o) for specifier in @specifiers
 
 exports.ImportSpecifierList = class ImportSpecifierList extends ModuleSpecifierList
@@ -3685,9 +3695,9 @@ exports.Assign = class Assign extends Base
 
   isStatementAst: NO
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @addScopeVariables o, checkAssignability: no
-    super o, level
+    super o
 
   astType: ->
     if @isDefaultAssignment()
@@ -4033,9 +4043,11 @@ exports.Code = class Code extends Base
     for {name} in @params when name instanceof Arr or name instanceof Obj
       name.propagateLhs yes
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @updateOptions o
-    super o, level
+    @body.makeReturn null, yes unless @body.isEmpty() or @noReturn
+
+    super o
 
   astType: ->
     if @isMethod
@@ -4290,7 +4302,7 @@ exports.Elision = class Elision extends Base
 
   eachName: (iterator) ->
 
-  ast: ->
+  astNode: ->
     null
 
 #### While
@@ -4582,9 +4594,9 @@ exports.Op = class Op extends Base
   toString: (idt) ->
     super idt, @constructor.name + ' ' + @operator
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @checkContinuation o if @isYield() or @isAwait()
-    super o, level
+    super o
 
   astType: ->
     return 'AwaitExpression' if @isAwait()
@@ -4772,12 +4784,12 @@ exports.Catch = class Catch extends Base
     [].concat @makeCode(" catch ("), placeholder.compileToFragments(o), @makeCode(") {\n"),
       @recovery.compileToFragments(o, LEVEL_TOP), @makeCode("\n#{@tab}}")
 
-  ast: (o, level) ->
+  astNode: (o) ->
     @errorVariable?.eachName (name) ->
       alreadyDeclared = o.scope.find name.value
       name.isDeclaration = not alreadyDeclared
 
-    super o, level
+    super o
 
   astType: -> 'CatchClause'
 
@@ -4901,7 +4913,7 @@ exports.Parens = class Parens extends Base
     return @wrapInBraces fragments if @jsxAttribute
     if bare then fragments else @wrapInParentheses fragments
 
-  ast: (o) -> @body.unwrap().ast o, LEVEL_PAREN
+  astNode: (o) -> @body.unwrap().ast o, LEVEL_PAREN
 
 #### StringWithInterpolations
 
@@ -5215,13 +5227,13 @@ exports.For = class For extends While
     fragments.push @makeCode(returnResult) if returnResult
     fragments
 
-  ast: (o, level) ->
+  astNode: (o) ->
     addToScope = (name) ->
       alreadyDeclared = o.scope.find name.value
       name.isDeclaration = not alreadyDeclared
     @name?.eachName addToScope
     @index?.eachName addToScope
-    super o, level
+    super o
 
   astType: -> 'For'
 
@@ -5465,8 +5477,8 @@ exports.Sequence = class Sequence extends Base
   constructor: (@expressions) ->
     super()
 
-  ast: (o, level) ->
-    return @expressions[0].ast(o, level) if @expressions.length is 1
+  astNode: (o) ->
+    return @expressions[0].ast(o) if @expressions.length is 1
     super o
 
   astType: -> 'SequenceExpression'

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -4059,8 +4059,14 @@ exports.Code = class Code extends Base
     for {name} in @params when name instanceof Arr or name instanceof Obj
       name.propagateLhs yes
 
+  astAddParamsToScope: (o) ->
+    for param in @params
+      param.eachName (name) ->
+        o.scope.add name, 'param'
+
   astNode: (o) ->
     @updateOptions o
+    @astAddParamsToScope o
     @body.makeReturn null, yes unless @body.isEmpty() or @noReturn
 
     super o

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1872,6 +1872,29 @@ test "AST as expected for Class node", ->
       object: ID 'A', declaration: no
       property: ID 'b', declaration: no
 
+  testStatement '''
+    class A
+      'constructor': ->
+  ''',
+    type: 'ClassDeclaration'
+    body:
+      type: 'ClassBody'
+      body: [
+        type: 'ClassMethod'
+        static: no
+        key:
+          type: 'StringLiteral'
+        computed: no
+        kind: 'constructor'
+        id: null
+        generator: no
+        async: no
+        params: []
+        body: EMPTY_BLOCK
+        bound: no
+      ]
+
+
 test "AST as expected for ModuleDeclaration node", ->
   testStatement 'export {X}',
     type: 'ExportNamedDeclaration'

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2565,6 +2565,84 @@ test "AST as expected for Code node", ->
     async: no
     id: null
 
+  testExpression '(a) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+
+  testExpression '(...a) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+
+  testExpression '({a}) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+
+  testExpression '([a]) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+
+  testExpression '(a = 1) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+    generator: no
+    async: no
+    id: null
+
+  testExpression '({a} = 1) -> a = 1',
+    type: 'FunctionExpression'
+    body:
+      type: 'BlockStatement'
+      body: [
+        type: 'ExpressionStatement'
+        expression:
+          type: 'AssignmentExpression'
+          left:
+            ID 'a', declaration: no
+      ]
+    generator: no
+    async: no
+    id: null
+
 test "AST as expected for Splat node", ->
   testExpression '[a...]',
     type: 'ArrayExpression'

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -775,6 +775,7 @@ test "AST as expected for Call node", ->
     arguments: []
     optional: no
     implicit: no
+    returns: undefined
 
   testExpression 'new Date()',
     type: 'NewExpression'
@@ -1575,7 +1576,7 @@ test "AST as expected for Class node", ->
       type: 'ClassBody'
       body: []
 
-  testStatement 'class Klass then constructor: ->',
+  testStatement 'class Klass then constructor: -> @a = 1',
     type: 'ClassDeclaration'
     id: ID 'Klass', declaration: yes
     superClass: null
@@ -1591,7 +1592,14 @@ test "AST as expected for Class node", ->
         generator: no
         async: no
         params: []
-        body: EMPTY_BLOCK
+        body:
+          type: 'BlockStatement'
+          body: [
+            type: 'ExpressionStatement'
+            expression:
+              type: 'AssignmentExpression'
+              returns: undefined
+          ]
         bound: no
       ]
 
@@ -1623,7 +1631,7 @@ test "AST as expected for Class node", ->
             type: 'BlockStatement'
             body: [
               type: 'ExpressionStatement'
-              expression: ID 'c'
+              expression: ID 'c', returns: yes
             ]
           operator: ':'
           bound: no
@@ -2283,6 +2291,7 @@ test "AST as expected for Code node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: yes
       ]
       directives: []
     generator: no
@@ -2478,7 +2487,7 @@ test "AST as expected for Code node", ->
       type: 'BlockStatement'
       body: [
         type: 'ExpressionStatement'
-        expression: ID 'a'
+        expression: ID 'a', returns: yes
       ]
     generator: no
     async: no
@@ -2495,6 +2504,7 @@ test "AST as expected for Code node", ->
         expression:
           type: 'AwaitExpression'
           argument: NUMBER 3
+          returns: yes
       ]
     generator: no
     async: yes
@@ -2663,6 +2673,7 @@ test "AST as expected for While node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: undefined
       ]
     guard: null
     inverted: yes
@@ -2726,6 +2737,21 @@ test "AST as expected for While node", ->
     inverted: no
     postfix: no
     loop: yes
+
+  testExpression '''
+    x = (z() while y)
+  ''',
+    type: 'AssignmentExpression'
+    right:
+      type: 'WhileStatement'
+      body:
+        type: 'BlockStatement'
+        body: [
+          type: 'ExpressionStatement'
+          expression:
+            type: 'CallExpression'
+            returns: yes
+        ]
 
 test "AST as expected for Op node", ->
   testExpression 'a <= 2',
@@ -3282,7 +3308,7 @@ test "AST as expected for For node", ->
         type: 'BlockStatement'
         body: [
           type: 'ExpressionStatement'
-          expression: ID 'x', declaration: no
+          expression: ID 'x', declaration: no, returns: yes
         ]
       source: ID 'y', declaration: no
       guard: null
@@ -3300,7 +3326,7 @@ test "AST as expected for For node", ->
       type: 'BlockStatement'
       body: [
         type: 'ExpressionStatement'
-        expression: ID 'x', declaration: no
+        expression: ID 'x', declaration: no, returns: undefined
       ]
     source:
       type: 'Range'
@@ -3325,9 +3351,10 @@ test "AST as expected for For node", ->
         type: 'ExpressionStatement'
         expression:
           type: 'CallExpression'
+          returns: undefined
       ,
         type: 'ExpressionStatement'
-        expression: ID 'd', declaration: no
+        expression: ID 'd', declaration: no, returns: undefined
       ]
     source: ID 'z', declaration: no
     guard: null
@@ -3353,7 +3380,7 @@ test "AST as expected for For node", ->
           type: 'BlockStatement'
           body: [
             type: 'ExpressionStatement'
-            expression: ID 'z', declaration: no
+            expression: ID 'z', declaration: no, returns: yes
           ]
         source: ID 'y', declaration: no
         guard: null

--- a/test/location.coffee
+++ b/test/location.coffee
@@ -803,3 +803,16 @@ test "Verify carriage returns are accounted for in location data", ->
   eq minusToken[2].last_column_exclusive, 4
   eq minusToken[2].range[0], 7
   eq minusToken[2].range[1], 8
+
+test "Verify object colon location data", ->
+  source = '''
+    a : b
+  '''
+  [implicitBraceToken, aToken, colonToken] = CoffeeScript.tokens source
+  eq colonToken[2].first_line, 0
+  eq colonToken[2].first_column, 2
+  eq colonToken[2].last_line, 0
+  eq colonToken[2].last_column, 2
+  eq colonToken[2].last_column_exclusive, 3
+  eq colonToken[2].range[0], 2
+  eq colonToken[2].range[1], 3


### PR DESCRIPTION
@GeoffreyBooth PR ensuring the correct location data gets assigned to `:` tokens in object literals

This was causing tests to fail for ESLint rules like [`key-spacing`](https://eslint.org/docs/rules/key-spacing)

Based on `ast-add-params-to-scope`, [here](https://github.com/helixbass/copheescript/compare/ast-add-params-to-scope...ast-object-colon-location-data) is just the diff against that branch