### PR TITLE
AST: Support marking implicit returns

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -67,13 +67,13 @@
   fragmentsToText = function(fragments) {
     var fragment;
     return ((function() {
-      var j, len1, results;
-      results = [];
+      var j, len1, results1;
+      results1 = [];
       for (j = 0, len1 = fragments.length; j < len1; j++) {
         fragment = fragments[j];
-        results.push(fragment.code);
+        results1.push(fragment.code);
       }
-      return results;
+      return results1;
     })()).join('');
   };
 
@@ -307,16 +307,22 @@
         return [fragmentsToText(cacheValues[0]), fragmentsToText(cacheValues[1])];
       }
 
-      // Construct a node that returns the current node's result.
+      // Construct a node that returns the current node’s result.
       // Note that this is overridden for smarter behavior for
-      // many statement nodes (e.g. If, For)...
-      makeReturn(res) {
-        var me;
-        me = this.unwrapAll();
-        if (res) {
-          return new Call(new Literal(`${res}.push`), [me]);
+      // many statement nodes (e.g. `If`, `For`).
+      makeReturn(results, mark) {
+        var node;
+        if (mark) {
+          // Mark this node as implicitly returned, so that it can be part of the
+          // node metadata returned in the AST.
+          this.canBeReturned = true;
+          return;
+        }
+        node = this.unwrapAll();
+        if (results) {
+          return new Call(new Literal(`${results}.push`), [node]);
         } else {
-          return new Return(me);
+          return new Return(node);
         }
       }
 
@@ -690,46 +696,46 @@
     }
 
     initializeScope(o) {
-      var j, len1, name, ref1, ref2, results;
+      var j, len1, name, ref1, ref2, results1;
       o.scope = new Scope(null, this.body, null, (ref1 = o.referencedVars) != null ? ref1 : []);
       ref2 = o.locals || [];
-      results = [];
+      results1 = [];
       for (j = 0, len1 = ref2.length; j < len1; j++) {
         name = ref2[j];
         // Mark given local variables in the root scope as parameters so they don’t
         // end up being declared on the root block.
-        results.push(o.scope.parameter(name));
+        results1.push(o.scope.parameter(name));
       }
-      return results;
+      return results1;
     }
 
     commentsAst() {
-      var comment, commentToken, j, len1, ref1, results;
+      var comment, commentToken, j, len1, ref1, results1;
       if (this.allComments == null) {
         this.allComments = (function() {
-          var j, len1, ref1, ref2, results;
+          var j, len1, ref1, ref2, results1;
           ref2 = (ref1 = this.allCommentTokens) != null ? ref1 : [];
-          results = [];
+          results1 = [];
           for (j = 0, len1 = ref2.length; j < len1; j++) {
             commentToken = ref2[j];
             if (!commentToken.heregex) {
               if (commentToken.here) {
-                results.push(new HereComment(commentToken));
+                results1.push(new HereComment(commentToken));
               } else {
-                results.push(new LineComment(commentToken));
+                results1.push(new LineComment(commentToken));
               }
             }
           }
-          return results;
+          return results1;
         }).call(this);
       }
       ref1 = this.allComments;
-      results = [];
+      results1 = [];
       for (j = 0, len1 = ref1.length; j < len1; j++) {
         comment = ref1[j];
-        results.push(comment.ast());
+        results1.push(comment.ast());
       }
-      return results;
+      return results1;
     }
 
     ast(o) {
@@ -821,8 +827,8 @@
 
       // A Block node does not return its entire body, rather it
       // ensures that the final expression is returned.
-      makeReturn(res) {
-        var expr, expressions, last, lastExp, len, penult, ref1;
+      makeReturn(results, mark) {
+        var expr, expressions, last, lastExp, len, penult, ref1, ref2;
         len = this.expressions.length;
         ref1 = this.expressions, [lastExp] = slice1.call(ref1, -1);
         lastExp = (lastExp != null ? lastExp.unwrap() : void 0) || false;
@@ -839,9 +845,15 @@
             expressions[expressions.length - 1].error('Adjacent JSX elements must be wrapped in an enclosing tag');
           }
         }
+        if (mark) {
+          if ((ref2 = this.expressions[len - 1]) != null) {
+            ref2.makeReturn(results, mark);
+          }
+          return;
+        }
         while (len--) {
           expr = this.expressions[len];
-          this.expressions[len] = expr.makeReturn(res);
+          this.expressions[len] = expr.makeReturn(results);
           if (expr instanceof Return && !expr.expression) {
             this.expressions.splice(len, 1);
           }
@@ -1008,18 +1020,18 @@
               }
             }
             code = `\n${fragmentIndent}` + ((function() {
-              var l, len2, ref2, results;
+              var l, len2, ref2, results1;
               ref2 = fragment.precedingComments;
-              results = [];
+              results1 = [];
               for (l = 0, len2 = ref2.length; l < len2; l++) {
                 commentFragment = ref2[l];
                 if (commentFragment.isHereComment && commentFragment.multiline) {
-                  results.push(multident(commentFragment.code, fragmentIndent, false));
+                  results1.push(multident(commentFragment.code, fragmentIndent, false));
                 } else {
-                  results.push(commentFragment.code);
+                  results1.push(commentFragment.code);
                 }
               }
-              return results;
+              return results1;
             })()).join(`\n${fragmentIndent}`).replace(/^(\s*)$/gm, '');
             ref2 = fragments.slice(0, (fragmentIndex + 1));
             for (pastFragmentIndex = l = ref2.length - 1; l >= 0; pastFragmentIndex = l += -1) {
@@ -1084,18 +1096,18 @@
             code = fragmentIndex === 1 && /^\s+$/.test(fragments[0].code) ? '' : trail ? ' ' : `\n${fragmentIndent}`;
             // Assemble properly indented comments.
             code += ((function() {
-              var len3, q, ref4, results;
+              var len3, q, ref4, results1;
               ref4 = fragment.followingComments;
-              results = [];
+              results1 = [];
               for (q = 0, len3 = ref4.length; q < len3; q++) {
                 commentFragment = ref4[q];
                 if (commentFragment.isHereComment && commentFragment.multiline) {
-                  results.push(multident(commentFragment.code, fragmentIndent, false));
+                  results1.push(multident(commentFragment.code, fragmentIndent, false));
                 } else {
-                  results.push(commentFragment.code);
+                  results1.push(commentFragment.code);
                 }
               }
-              return results;
+              return results1;
             })()).join(`\n${fragmentIndent}`).replace(/^(\s*)$/gm, '');
             ref4 = fragments.slice(fragmentIndex);
             for (upcomingFragmentIndex = q = 0, len3 = ref4.length; q < len3; upcomingFragmentIndex = ++q) {
@@ -1521,18 +1533,18 @@
             rawValue: void 0
           },
           comments: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.heregexCommentTokens;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               heregexCommentToken = ref1[j];
               if (heregexCommentToken.here) {
-                results.push(new HereComment(heregexCommentToken).ast(o));
+                results1.push(new HereComment(heregexCommentToken).ast(o));
               } else {
-                results.push(new LineComment(heregexCommentToken).ast(o));
+                results1.push(new LineComment(heregexCommentToken).ast(o));
               }
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -2566,14 +2578,14 @@
       }
 
       ast(o) {
-        var attribute, j, len1, ref1, results;
+        var attribute, j, len1, ref1, results1;
         ref1 = this.attributes;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           attribute = ref1[j];
-          results.push(attribute.ast(o));
+          results1.push(attribute.ast(o));
         }
-        return results;
+        return results1;
       }
 
     };
@@ -2740,13 +2752,13 @@
       }
 
       contentAst(o) {
-        var base1, child, children, content, element, emptyExpression, expression, j, len1, results, unwrapped;
+        var base1, child, children, content, element, emptyExpression, expression, j, len1, results1, unwrapped;
         if (!(this.content && !(typeof (base1 = this.content.base).isEmpty === "function" ? base1.isEmpty() : void 0))) {
           return [];
         }
         content = this.content.unwrapAll();
         children = (function() {
-          var j, len1, ref1, results;
+          var j, len1, ref1, results1;
           if (content instanceof StringLiteral) {
             return [new JSXText(content)]; // StringWithInterpolations
           } else {
@@ -2754,11 +2766,11 @@
               includeInterpolationWrappers: true,
               isJsx: true
             });
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               element = ref1[j];
               if (element instanceof StringLiteral) {
-                results.push(new JSXText(element)); // Interpolation
+                results1.push(new JSXText(element)); // Interpolation
               } else {
                 ({expression} = element);
                 if (expression == null) {
@@ -2768,33 +2780,33 @@
                     openingBrace: '{',
                     closingBrace: '}'
                   });
-                  results.push(new JSXExpressionContainer(emptyExpression, {
+                  results1.push(new JSXExpressionContainer(emptyExpression, {
                     locationData: element.locationData
                   }));
                 } else {
                   unwrapped = expression.unwrapAll();
                   // distinguish `<a><b /></a>` from `<a>{<b />}</a>`
                   if (unwrapped instanceof JSXElement && unwrapped.locationData.range[0] === element.locationData.range[0]) {
-                    results.push(unwrapped);
+                    results1.push(unwrapped);
                   } else {
-                    results.push(new JSXExpressionContainer(unwrapped, {
+                    results1.push(new JSXExpressionContainer(unwrapped, {
                       locationData: element.locationData
                     }));
                   }
                 }
               }
             }
-            return results;
+            return results1;
           }
         }).call(this);
-        results = [];
+        results1 = [];
         for (j = 0, len1 = children.length; j < len1; j++) {
           child = children[j];
           if (!(child instanceof JSXText && child.value.length === 0)) {
-            results.push(child.ast(o));
+            results1.push(child.ast(o));
           }
         }
-        return results;
+        return results1;
       }
 
       astProperties(o) {
@@ -2960,16 +2972,16 @@
         // (see issue #4437, https://github.com/jashkenas/coffeescript/issues/4437)
         varAccess = ((ref2 = this.variable) != null ? (ref3 = ref2.properties) != null ? ref3[0] : void 0 : void 0) instanceof Access;
         argCode = (function() {
-          var j, len1, ref4, results;
+          var j, len1, ref4, results1;
           ref4 = this.args || [];
-          results = [];
+          results1 = [];
           for (j = 0, len1 = ref4.length; j < len1; j++) {
             arg = ref4[j];
             if (arg instanceof Code) {
-              results.push(arg);
+              results1.push(arg);
             }
           }
-          return results;
+          return results1;
         }).call(this);
         if (argCode.length > 0 && varAccess && !this.variable.base.cached) {
           [cache] = this.variable.base.cache(o, LEVEL_ACCESS, function() {
@@ -3023,14 +3035,14 @@
         return {
           callee: this.variable.ast(o, LEVEL_ACCESS),
           arguments: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.args;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               arg = ref1[j];
-              results.push(arg.ast(o, LEVEL_LIST));
+              results1.push(arg.ast(o, LEVEL_LIST));
             }
-            return results;
+            return results1;
           }).call(this),
           optional: !!this.soak,
           implicit: !!this.implicit
@@ -3166,18 +3178,18 @@
           interpolatedPattern: this.call.args[0].ast(o),
           flags: (ref1 = (ref2 = this.call.args[1]) != null ? ref2.unwrap().originalValue : void 0) != null ? ref1 : '',
           comments: (function() {
-            var j, len1, ref3, results;
+            var j, len1, ref3, results1;
             ref3 = this.heregexCommentTokens;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref3.length; j < len1; j++) {
               heregexCommentToken = ref3[j];
               if (heregexCommentToken.here) {
-                results.push(new HereComment(heregexCommentToken).ast(o));
+                results1.push(new HereComment(heregexCommentToken).ast(o));
               } else {
-                results.push(new LineComment(heregexCommentToken).ast(o));
+                results1.push(new LineComment(heregexCommentToken).ast(o));
               }
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -3404,9 +3416,9 @@
         known = (this.fromNum != null) && (this.toNum != null);
         if (known && Math.abs(this.fromNum - this.toNum) <= 20) {
           range = (function() {
-            var results = [];
-            for (var j = ref1 = this.fromNum, ref2 = this.toNum; ref1 <= ref2 ? j <= ref2 : j >= ref2; ref1 <= ref2 ? j++ : j--){ results.push(j); }
-            return results;
+            var results1 = [];
+            for (var j = ref1 = this.fromNum, ref2 = this.toNum; ref1 <= ref2 ? j <= ref2 : j >= ref2; ref1 <= ref2 ? j++ : j--){ results1.push(j); }
+            return results1;
           }).apply(this);
           if (this.exclusive) {
             range.pop();
@@ -3459,7 +3471,7 @@
 
   //### Slice
 
-  // An array slice literal. Unlike JavaScript's `Array#slice`, the second parameter
+  // An array slice literal. Unlike JavaScript’s `Array#slice`, the second parameter
   // specifies the index of the end of the slice, just as the first parameter
   // is the index of the beginning.
   exports.Slice = Slice = (function() {
@@ -3560,15 +3572,15 @@
         var i, prop, props, splatProp, splatProps;
         props = this.properties;
         splatProps = (function() {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (i = j = 0, len1 = props.length; j < len1; i = ++j) {
             prop = props[i];
             if (prop instanceof Splat) {
-              results.push(i);
+              results1.push(i);
             }
           }
-          return results;
+          return results1;
         })();
         if ((splatProps != null ? splatProps.length : void 0) > 1) {
           props[splatProps[1]].error("multiple spread elements are disallowed");
@@ -3671,9 +3683,9 @@
       }
 
       eachName(iterator) {
-        var j, len1, prop, ref1, results;
+        var j, len1, prop, ref1, results1;
         ref1 = this.properties;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           prop = ref1[j];
           if (prop instanceof Assign && prop.context === 'object') {
@@ -3681,12 +3693,12 @@
           }
           prop = prop.unwrapAll();
           if (prop.eachName != null) {
-            results.push(prop.eachName(iterator));
+            results1.push(prop.eachName(iterator));
           } else {
-            results.push(void 0);
+            results1.push(void 0);
           }
         }
-        return results;
+        return results1;
       }
 
       // Convert “bare” properties to `ObjectProperty`s (or `Splat`s).
@@ -3722,18 +3734,18 @@
       }
 
       expandProperties() {
-        var j, len1, property, ref1, results;
+        var j, len1, property, ref1, results1;
         ref1 = this.properties;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           property = ref1[j];
-          results.push(this.expandProperty(property));
+          results1.push(this.expandProperty(property));
         }
-        return results;
+        return results1;
       }
 
       propagateLhs(setLhs) {
-        var j, len1, property, ref1, results, unwrappedValue, value;
+        var j, len1, property, ref1, results1, unwrappedValue, value;
         if (setLhs) {
           this.lhs = true;
         }
@@ -3741,29 +3753,29 @@
           return;
         }
         ref1 = this.properties;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           property = ref1[j];
           if (property instanceof Assign && property.context === 'object') {
             ({value} = property);
             unwrappedValue = value.unwrapAll();
             if (unwrappedValue instanceof Arr || unwrappedValue instanceof Obj) {
-              results.push(unwrappedValue.propagateLhs(true));
+              results1.push(unwrappedValue.propagateLhs(true));
             } else if (unwrappedValue instanceof Assign) {
-              results.push(unwrappedValue.nestedLhs = true);
+              results1.push(unwrappedValue.nestedLhs = true);
             } else {
-              results.push(void 0);
+              results1.push(void 0);
             }
           } else if (property instanceof Assign) {
             // Shorthand property with default, e.g. `{a = 1} = b`.
-            results.push(property.nestedLhs = true);
+            results1.push(property.nestedLhs = true);
           } else if (property instanceof Splat) {
-            results.push(property.lhs = true);
+            results1.push(property.lhs = true);
           } else {
-            results.push(void 0);
+            results1.push(void 0);
           }
         }
-        return results;
+        return results1;
       }
 
       astType() {
@@ -3779,14 +3791,14 @@
         return {
           implicit: !!this.generated,
           properties: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.expandProperties();
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               property = ref1[j];
-              results.push(property.ast(o));
+              results1.push(property.ast(o));
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -3914,14 +3926,14 @@
           }
         }
         compiledObjs = (function() {
-          var k, len2, ref2, results;
+          var k, len2, ref2, results1;
           ref2 = this.objects;
-          results = [];
+          results1 = [];
           for (k = 0, len2 = ref2.length; k < len2; k++) {
             obj = ref2[k];
-            results.push(obj.compileToFragments(o, LEVEL_LIST));
+            results1.push(obj.compileToFragments(o, LEVEL_LIST));
           }
-          return results;
+          return results1;
         }).call(this);
         olen = compiledObjs.length;
         // If `compiledObjs` includes newlines, we will output this as a multiline
@@ -3987,21 +3999,21 @@
       }
 
       eachName(iterator) {
-        var j, len1, obj, ref1, results;
+        var j, len1, obj, ref1, results1;
         ref1 = this.objects;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           obj = ref1[j];
           obj = obj.unwrapAll();
-          results.push(obj.eachName(iterator));
+          results1.push(obj.eachName(iterator));
         }
-        return results;
+        return results1;
       }
 
       // If this array is the left-hand side of an assignment, all its children
       // are too.
       propagateLhs(setLhs) {
-        var j, len1, object, ref1, results, unwrappedObject;
+        var j, len1, object, ref1, results1, unwrappedObject;
         if (setLhs) {
           this.lhs = true;
         }
@@ -4009,7 +4021,7 @@
           return;
         }
         ref1 = this.objects;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           object = ref1[j];
           if (object instanceof Splat) {
@@ -4017,14 +4029,14 @@
           }
           unwrappedObject = object.unwrapAll();
           if (unwrappedObject instanceof Arr || unwrappedObject instanceof Obj) {
-            results.push(unwrappedObject.propagateLhs(true));
+            results1.push(unwrappedObject.propagateLhs(true));
           } else if (unwrappedObject instanceof Assign) {
-            results.push(unwrappedObject.nestedLhs = true);
+            results1.push(unwrappedObject.nestedLhs = true);
           } else {
-            results.push(void 0);
+            results1.push(void 0);
           }
         }
-        return results;
+        return results1;
       }
 
       astType() {
@@ -4039,14 +4051,14 @@
         var object;
         return {
           elements: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.objects;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               object = ref1[j];
-              results.push(object.ast(o, LEVEL_LIST));
+              results1.push(object.ast(o, LEVEL_LIST));
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -4236,13 +4248,13 @@
         }
         if (initializer.length !== expressions.length) {
           this.body.expressions = (function() {
-            var l, len3, results;
-            results = [];
+            var l, len3, results1;
+            results1 = [];
             for (l = 0, len3 = initializer.length; l < len3; l++) {
               expression = initializer[l];
-              results.push(expression.hoist());
+              results1.push(expression.hoist());
             }
-            return results;
+            return results1;
           })();
           return new Block(expressions);
         }
@@ -4370,18 +4382,18 @@
       proxyBoundMethods() {
         var method, name;
         this.ctor.thisAssignments = (function() {
-          var j, len1, ref1, results;
+          var j, len1, ref1, results1;
           ref1 = this.boundMethods;
-          results = [];
+          results1 = [];
           for (j = 0, len1 = ref1.length; j < len1; j++) {
             method = ref1[j];
             if (this.parent) {
               method.classVariable = this.variableRef;
             }
             name = new Value(new ThisLiteral(), [method.name]);
-            results.push(new Assign(name, new Call(new Value(name, [new Access(new PropertyName('bind'))]), [new ThisLiteral()])));
+            results1.push(new Assign(name, new Call(new Value(name, [new Access(new PropertyName('bind'))]), [new ThisLiteral()])));
           }
-          return results;
+          return results1;
         }).call(this);
         return null;
       }
@@ -4541,8 +4553,8 @@
       addProperties(assigns) {
         var assign, base, name, prototype, result, value, variable;
         result = (function() {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (j = 0, len1 = assigns.length; j < len1; j++) {
             assign = assigns[j];
             variable = assign.variable;
@@ -4563,9 +4575,9 @@
             } else if (assign.value instanceof Code) {
               assign.value.isStatic = true;
             }
-            results.push(assign);
+            results1.push(assign);
           }
-          return results;
+          return results1;
         }).call(this);
         return compact(result);
       }
@@ -4838,14 +4850,14 @@
         code = [];
         o.indent += TAB;
         compiledList = (function() {
-          var j, len1, ref1, results;
+          var j, len1, ref1, results1;
           ref1 = this.specifiers;
-          results = [];
+          results1 = [];
           for (j = 0, len1 = ref1.length; j < len1; j++) {
             specifier = ref1[j];
-            results.push(specifier.compileToFragments(o, LEVEL_LIST));
+            results1.push(specifier.compileToFragments(o, LEVEL_LIST));
           }
-          return results;
+          return results1;
         }).call(this);
         if (this.specifiers.length !== 0) {
           code.push(this.makeCode(`{\n${o.indent}`));
@@ -4864,14 +4876,14 @@
       }
 
       ast(o) {
-        var j, len1, ref1, results, specifier;
+        var j, len1, ref1, results1, specifier;
         ref1 = this.specifiers;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           specifier = ref1[j];
-          results.push(specifier.ast(o));
+          results1.push(specifier.ast(o));
         }
-        return results;
+        return results1;
       }
 
     };
@@ -5197,27 +5209,27 @@
         }
         // Count all `Splats`: [a, b, c..., d, e]
         splats = (function() {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (i = j = 0, len1 = objects.length; j < len1; i = ++j) {
             obj = objects[i];
             if (obj instanceof Splat) {
-              results.push(i);
+              results1.push(i);
             }
           }
-          return results;
+          return results1;
         })();
         // Count all `Expansions`: [a, b, ..., c, d]
         expans = (function() {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (i = j = 0, len1 = objects.length; j < len1; i = ++j) {
             obj = objects[i];
             if (obj instanceof Expansion) {
-              results.push(i);
+              results1.push(i);
             }
           }
-          return results;
+          return results1;
         })();
         // Combine splats and expansions.
         splatsAndExpans = [...splats, ...expans];
@@ -5277,15 +5289,15 @@
         compSplice = slicer("splice");
         // Check if `objects` array contains any instance of `Assign`, e.g. {a:1}.
         hasObjAssigns = function(objs) {
-          var j, len1, results;
-          results = [];
+          var j, len1, results1;
+          results1 = [];
           for (i = j = 0, len1 = objs.length; j < len1; i = ++j) {
             obj = objs[i];
             if (obj instanceof Assign && obj.context === 'object') {
-              results.push(i);
+              results1.push(i);
             }
           }
-          return results;
+          return results1;
         };
         // Check if `objects` array contains any unassignable object.
         objIsUnassignable = function(objs) {
@@ -5306,8 +5318,8 @@
         // "Complex" `objects` are processed in a loop.
         // Examples: [a, b, {c, r...}, d], [a, ..., {b, r...}, c, d]
         loopObjects = (objs, vvar, vvarTxt) => {
-          var acc, idx, j, len1, message, results, vval;
-          results = [];
+          var acc, idx, j, len1, message, results1, vval;
+          results1 = [];
           for (i = j = 0, len1 = objs.length; j < len1; i = ++j) {
             obj = objs[i];
             if (obj instanceof Elision) {
@@ -5353,9 +5365,9 @@
             if (message) {
               vvar.error(message);
             }
-            results.push(pushAssign(vvar, vval));
+            results1.push(pushAssign(vvar, vval));
           }
-          return results;
+          return results1;
         };
         // "Simple" `objects` can be split and compiled to arrays, [a, b, c] = arr, [a, b, c...] = arr
         assignObjects = (objs, vvar, vvarTxt) => {
@@ -5787,13 +5799,13 @@
             ...((function() {
               var k,
             len2,
-            results;
-              results = [];
+            results1;
+              results1 = [];
               for (k = 0, len2 = paramsAfterSplat.length; k < len2; k++) {
                 param = paramsAfterSplat[k];
-                results.push(param.asReference(o));
+                results1.push(param.asReference(o));
               }
-              return results;
+              return results1;
             })())
           ])), new Value(new IdentifierLiteral(splatParamName))));
         }
@@ -5879,13 +5891,13 @@
           o.scope = methodScope;
         }
         answer = this.joinFragmentArrays((function() {
-          var len4, p, results;
-          results = [];
+          var len4, p, results1;
+          results1 = [];
           for (p = 0, len4 = modifiers.length; p < len4; p++) {
             m = modifiers[p];
-            results.push(this.makeCode(m));
+            results1.push(this.makeCode(m));
           }
-          return results;
+          return results1;
         }).call(this), ' ');
         if (modifiers.length && name) {
           answer.push(this.makeCode(' '));
@@ -5921,14 +5933,14 @@
       }
 
       eachParamName(iterator) {
-        var j, len1, param, ref1, results;
+        var j, len1, param, ref1, results1;
         ref1 = this.params;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           param = ref1[j];
-          results.push(param.eachName(iterator));
+          results1.push(param.eachName(iterator));
         }
-        return results;
+        return results1;
       }
 
       // Short-circuit `traverseChildren` method to prevent it from crossing scope
@@ -6004,16 +6016,16 @@
       }
 
       propagateLhs() {
-        var j, len1, name, ref1, results;
+        var j, len1, name, ref1, results1;
         ref1 = this.params;
-        results = [];
+        results1 = [];
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           ({name} = ref1[j]);
           if (name instanceof Arr || name instanceof Obj) {
-            results.push(name.propagateLhs(true));
+            results1.push(name.propagateLhs(true));
           }
         }
-        return results;
+        return results1;
       }
 
       ast(o, level) {
@@ -6085,14 +6097,14 @@
         var param, ref1;
         return Object.assign({
           params: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.params;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               param = ref1[j];
-              results.push(this.paramForAst(param).ast(o));
+              results1.push(this.paramForAst(param).ast(o));
             }
-            return results;
+            return results1;
           }).call(this),
           body: this.body.ast(Object.assign({}, o, {
             checkForDirectives: true
@@ -6436,13 +6448,18 @@
         this.isLoop = isLoop;
       }
 
-      makeReturn(res) {
-        if (res) {
-          return super.makeReturn(res);
-        } else {
-          this.returns = !this.jumps();
-          return this;
+      makeReturn(results, mark) {
+        if (results) {
+          return super.makeReturn(results, mark);
         }
+        this.returns = !this.jumps();
+        if (mark) {
+          if (this.returns) {
+            this.body.makeReturn(results, mark);
+          }
+          return;
+        }
+        return this;
       }
 
       addBody(body1) {
@@ -6880,13 +6897,13 @@
         return {
           operators,
           operands: (function() {
-            var j, len1, results;
-            results = [];
+            var j, len1, results1;
+            results1 = [];
             for (j = 0, len1 = operands.length; j < len1; j++) {
               operand = operands[j];
-              results.push(operand.ast(o, LEVEL_OP));
+              results1.push(operand.ast(o, LEVEL_OP));
             }
-            return results;
+            return results1;
           })()
         };
       }
@@ -7043,12 +7060,22 @@
         return this.attempt.jumps(o) || ((ref1 = this.catch) != null ? ref1.jumps(o) : void 0);
       }
 
-      makeReturn(res) {
+      makeReturn(results, mark) {
+        var ref1, ref2;
+        if (mark) {
+          if ((ref1 = this.attempt) != null) {
+            ref1.makeReturn(results, mark);
+          }
+          if ((ref2 = this.catch) != null) {
+            ref2.makeReturn(results, mark);
+          }
+          return;
+        }
         if (this.attempt) {
-          this.attempt = this.attempt.makeReturn(res);
+          this.attempt = this.attempt.makeReturn(results);
         }
         if (this.catch) {
-          this.catch = this.catch.makeReturn(res);
+          this.catch = this.catch.makeReturn(results);
         }
         return this;
       }
@@ -7111,8 +7138,13 @@
         return this.recovery.jumps(o);
       }
 
-      makeReturn(res) {
-        this.recovery = this.recovery.makeReturn(res);
+      makeReturn(results, mark) {
+        var ret;
+        ret = this.recovery.makeReturn(results, mark);
+        if (mark) {
+          return;
+        }
+        this.recovery = ret;
         return this;
       }
 
@@ -7912,18 +7944,18 @@
         return (ref2 = this.otherwise) != null ? ref2.jumps(o) : void 0;
       }
 
-      makeReturn(res) {
+      makeReturn(results, mark) {
         var block, j, len1, ref1, ref2;
         ref1 = this.cases;
         for (j = 0, len1 = ref1.length; j < len1; j++) {
           ({block} = ref1[j]);
-          block.makeReturn(res);
+          block.makeReturn(results, mark);
         }
-        if (res) {
+        if (results) {
           this.otherwise || (this.otherwise = new Block([new Literal('void 0')]));
         }
         if ((ref2 = this.otherwise) != null) {
-          ref2.makeReturn(res);
+          ref2.makeReturn(results, mark);
         }
         return this;
       }
@@ -7968,7 +8000,7 @@
       }
 
       casesAst(o) {
-        var caseIndex, caseLocationData, cases, consequent, j, k, kase, l, lastTestIndex, len1, len2, len3, ref1, ref2, results, test, testConsequent, testIndex, tests;
+        var caseIndex, caseLocationData, cases, consequent, j, k, kase, l, lastTestIndex, len1, len2, len3, ref1, ref2, results1, test, testConsequent, testIndex, tests;
         cases = [];
         ref1 = this.cases;
         for (caseIndex = j = 0, len1 = ref1.length; j < len1; caseIndex = ++j) {
@@ -8006,12 +8038,12 @@
         if ((ref2 = this.otherwise) != null ? ref2.expressions.length : void 0) {
           cases.push(new SwitchCase(null, this.otherwise).withLocationDataFrom(this.otherwise));
         }
-        results = [];
+        results1 = [];
         for (l = 0, len3 = cases.length; l < len3; l++) {
           kase = cases[l];
-          results.push(kase.ast(o));
+          results1.push(kase.ast(o));
         }
-        return results;
+        return results1;
       }
 
       astProperties(o) {
@@ -8141,12 +8173,22 @@
         }
       }
 
-      makeReturn(res) {
-        if (res) {
+      makeReturn(results, mark) {
+        var ref1, ref2;
+        if (mark) {
+          if ((ref1 = this.body) != null) {
+            ref1.makeReturn(results, mark);
+          }
+          if ((ref2 = this.elseBody) != null) {
+            ref2.makeReturn(results, mark);
+          }
+          return;
+        }
+        if (results) {
           this.elseBody || (this.elseBody = new Block([new Literal('void 0')]));
         }
-        this.body && (this.body = new Block([this.body.makeReturn(res)]));
-        this.elseBody && (this.elseBody = new Block([this.elseBody.makeReturn(res)]));
+        this.body && (this.body = new Block([this.body.makeReturn(results)]));
+        this.elseBody && (this.elseBody = new Block([this.elseBody.makeReturn(results)]));
         return this;
       }
 
@@ -8267,14 +8309,14 @@
         var expression;
         return {
           expressions: (function() {
-            var j, len1, ref1, results;
+            var j, len1, ref1, results1;
             ref1 = this.expressions;
-            results = [];
+            results1 = [];
             for (j = 0, len1 = ref1.length; j < len1; j++) {
               expression = ref1[j];
-              results.push(expression.ast(o));
+              results1.push(expression.ast(o));
             }
-            return results;
+            return results1;
           }).call(this)
         };
       }
@@ -8526,10 +8568,10 @@
   };
 
   sniffDirectives = function(expressions, {notFinalExpression} = {}) {
-    var expression, index, lastIndex, results, unwrapped;
+    var expression, index, lastIndex, results1, unwrapped;
     index = 0;
     lastIndex = expressions.length - 1;
-    results = [];
+    results1 = [];
     while (index <= lastIndex) {
       if (index === lastIndex && notFinalExpression) {
         break;
@@ -8543,9 +8585,9 @@
         break;
       }
       expressions[index] = new Directive(expression).withLocationDataFrom(expression);
-      results.push(index++);
+      results1.push(index++);
     }
-    return results;
+    return results1;
   };
 
   // Helpers for `mergeLocationData` and `mergeAstLocationData` below.


### PR DESCRIPTION
@GeoffreyBooth here's the "first PR" for supporting marking implicit returns in the AST

It just includes the refactor to `makeReturn()` to accept a second `mark` argument (should match the version from your branch)

The next PR will include actually invoking the new `mark` functionality during AST generation