### PR TITLE
AST: reconcile Prettier plugin

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -4,7 +4,7 @@
   // nodes are created as the result of actions in the [grammar](grammar.html),
   // but some are created by other nodes as a method of code generation. To convert
   // the syntax tree into a string of JavaScript code, call `compile()` on the root.
-  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, Call, Catch, Class, ClassProperty, ClassPrototypeProperty, Code, CodeFragment, ComputedPropertyName, DefaultLiteral, Directive, DynamicImport, DynamicImportCall, Elision, EmptyInterpolation, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncDirectiveReturn, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JSXAttribute, JSXAttributes, JSXElement, JSXEmptyExpression, JSXExpressionContainer, JSXIdentifier, JSXNamespacedName, JSXTag, JSXText, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, MetaProperty, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, ObjectProperty, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, Root, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Sequence, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, SwitchCase, SwitchWhen, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, TemplateElement, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, attachCommentsToNode, compact, del, emptyExpressionLocationData, ends, extend, extractSameLineLocationDataFirst, extractSameLineLocationDataLast, flatten, fragmentsToText, greater, hasLineComments, indentInitial, isAstLocGreater, isFunction, isLiteralArguments, isLiteralThis, isLocationDataEndGreater, isLocationDataStartGreater, isNumber, isPlainObject, isUnassignable, jisonLocationDataToAstLocationData, lesser, locationDataToString, makeDelimitedLiteral, merge, mergeAstLocationData, mergeLocationData, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, sniffDirectives, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility, zeroWidthLocationDataFromEndLocation,
+  var Access, Arr, Assign, AwaitReturn, Base, Block, BooleanLiteral, Call, Catch, Class, ClassProperty, ClassPrototypeProperty, Code, CodeFragment, ComputedPropertyName, DefaultLiteral, Directive, DynamicImport, DynamicImportCall, Elision, EmptyInterpolation, ExecutableClassBody, Existence, Expansion, ExportAllDeclaration, ExportDeclaration, ExportDefaultDeclaration, ExportNamedDeclaration, ExportSpecifier, ExportSpecifierList, Extends, For, FuncDirectiveReturn, FuncGlyph, HEREGEX_OMIT, HereComment, HoistTarget, IdentifierLiteral, If, ImportClause, ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier, ImportSpecifier, ImportSpecifierList, In, Index, InfinityLiteral, Interpolation, JSXAttribute, JSXAttributes, JSXElement, JSXEmptyExpression, JSXExpressionContainer, JSXIdentifier, JSXNamespacedName, JSXTag, JSXText, JS_FORBIDDEN, LEADING_BLANK_LINE, LEVEL_ACCESS, LEVEL_COND, LEVEL_LIST, LEVEL_OP, LEVEL_PAREN, LEVEL_TOP, LineComment, Literal, MetaProperty, ModuleDeclaration, ModuleSpecifier, ModuleSpecifierList, NEGATE, NO, NaNLiteral, NullLiteral, NumberLiteral, Obj, ObjectProperty, Op, Param, Parens, PassthroughLiteral, PropertyName, Range, RegexLiteral, RegexWithInterpolations, Return, Root, SIMPLENUM, SIMPLE_STRING_OMIT, STRING_OMIT, Scope, Sequence, Slice, Splat, StatementLiteral, StringLiteral, StringWithInterpolations, Super, SuperCall, Switch, SwitchCase, SwitchWhen, TAB, THIS, TRAILING_BLANK_LINE, TaggedTemplateCall, TemplateElement, ThisLiteral, Throw, Try, UTILITIES, UndefinedLiteral, Value, While, YES, YieldReturn, addDataToNode, astAsBlockIfNeeded, attachCommentsToNode, compact, del, emptyExpressionLocationData, ends, extend, extractSameLineLocationDataFirst, extractSameLineLocationDataLast, flatten, fragmentsToText, greater, hasLineComments, indentInitial, isAstLocGreater, isFunction, isLiteralArguments, isLiteralThis, isLocationDataEndGreater, isLocationDataStartGreater, isNumber, isPlainObject, isUnassignable, jisonLocationDataToAstLocationData, lesser, locationDataToString, makeDelimitedLiteral, merge, mergeAstLocationData, mergeLocationData, moveComments, multident, replaceUnicodeCodePointEscapes, shouldCacheOrIsAssignable, sniffDirectives, some, starts, throwSyntaxError, unfoldSoak, unshiftAfterComments, utility, zeroWidthLocationDataFromEndLocation,
     indexOf = [].indexOf,
     splice = [].splice,
     slice1 = [].slice;
@@ -2167,10 +2167,10 @@
         })();
       }
 
-      eachName(iterator) {
+      eachName(iterator, {checkAssignability = true} = {}) {
         if (this.hasProperties()) {
           return iterator(this);
-        } else if (this.base.isAssignable()) {
+        } else if (!checkAssignability || this.base.isAssignable()) {
           return this.base.eachName(iterator);
         } else {
           return this.error('tried to assign to unassignable value');
@@ -2464,7 +2464,7 @@
 
       astProperties(o) {
         return {
-          expression: this.expression.ast(o)
+          expression: astAsBlockIfNeeded(this.expression, o)
         };
       }
 
@@ -7605,7 +7605,7 @@
               openingBrace: '#{',
               closingBrace: '}'
             }), emptyInterpolation) : expression.unwrapAll();
-            expressions.push(node.ast(o));
+            expressions.push(astAsBlockIfNeeded(node, o));
           }
         }
         return {expressions, quasis, quote: this.quote};
@@ -7923,10 +7923,14 @@
           return name.isDeclaration = !alreadyDeclared;
         };
         if ((ref1 = this.name) != null) {
-          ref1.eachName(addToScope);
+          ref1.eachName(addToScope, {
+            checkAssignability: false
+          });
         }
         if ((ref2 = this.index) != null) {
-          ref2.eachName(addToScope);
+          ref2.eachName(addToScope, {
+            checkAssignability: false
+          });
         }
         return super.astNode(o);
       }
@@ -8640,6 +8644,17 @@
       results1.push(index++);
     }
     return results1;
+  };
+
+  astAsBlockIfNeeded = function(node, o) {
+    var unwrapped;
+    unwrapped = node.unwrap();
+    if (unwrapped instanceof Block && unwrapped.expressions.length > 1) {
+      unwrapped.makeReturn(null, true);
+      return unwrapped.ast(o, LEVEL_TOP);
+    } else {
+      return node.ast(o, LEVEL_PAREN);
+    }
   };
 
   // Helpers for `mergeLocationData` and `mergeAstLocationData` below.

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -613,6 +613,28 @@ test "AST as expected for JSXTag node", ->
           type: 'JSXIdentifier'
           name: 'a'
 
+  testExpression '''
+    <div b={
+      c
+      d
+    } />
+  ''',
+    type: 'JSXElement'
+    openingElement:
+      attributes: [
+        value:
+          type: 'JSXExpressionContainer'
+          expression:
+            type: 'BlockStatement'
+            body: [
+              type: 'ExpressionStatement'
+            ,
+              type: 'ExpressionStatement'
+              expression:
+                returns: yes
+            ]
+      ]
+
 test "AST as expected for ComputedPropertyName node", ->
   testExpression '[fn]: ->',
     type: 'ObjectExpression'
@@ -3335,6 +3357,27 @@ test "AST as expected for StringWithInterpolations node", ->
     ]
     quote: '"'
 
+  testExpression '''
+    a "#{
+      b
+      c
+    }"
+  ''',
+    type: 'CallExpression'
+    arguments: [
+      type: 'TemplateLiteral'
+      expressions: [
+        type: 'BlockStatement'
+        body: [
+          type: 'ExpressionStatement'
+        ,
+          type: 'ExpressionStatement'
+          expression:
+            returns: yes
+        ]
+      ]
+    ]
+
 test "AST as expected for For node", ->
   testStatement 'for x, i in arr when x? then return',
     type: 'For'
@@ -3543,6 +3586,14 @@ test "AST as expected for For node", ->
     style: 'in'
     postfix: no
     await: no
+
+  testStatement '''
+    for [x..., y] in z
+      y()
+  ''',
+    type: 'For'
+    name:
+      type: 'ArrayPattern'
 
 #   # TODO: Figure out the purpose of `pattern` and `returns`.
 


### PR DESCRIPTION
@GeoffreyBooth I updated the Prettier plugin's Coffeescript dependency to the current `ast` branch and it surfaced a couple small things

So this PR addresses those and gets all tests passing again in the Prettier plugin