### PR TITLE
AST: allow assignment to nontrailing splat

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3599,7 +3599,7 @@
         this.objects = this.properties = props || [];
       }
 
-      isAssignable() {
+      isAssignable(opts) {
         var j, len1, message, prop, ref1, ref2;
         ref1 = this.properties;
         for (j = 0, len1 = ref1.length; j < len1; j++) {
@@ -3612,7 +3612,7 @@
           if (prop instanceof Assign && prop.context === 'object' && !(((ref2 = prop.value) != null ? ref2.base : void 0) instanceof Arr)) {
             prop = prop.value;
           }
-          if (!prop.isAssignable()) {
+          if (!prop.isAssignable(opts)) {
             return false;
           }
         }
@@ -3851,7 +3851,7 @@
             // Shorthand property with default, e.g. `{a = 1} = b`.
             results1.push(property.nestedLhs = true);
           } else if (property instanceof Splat) {
-            results1.push(property.lhs = true);
+            results1.push(property.propagateLhs(true));
           } else {
             results1.push(void 0);
           }
@@ -5188,7 +5188,7 @@
         return unfoldSoak(o, this, 'variable');
       }
 
-      addScopeVariables(o, {allowAssignmentToExpansion = false, allowAssignmentToNontrailingSplat = false, allowAssignmentToEmptyArray = false} = {}) {
+      addScopeVariables(o, {allowAssignmentToExpansion = false, allowAssignmentToNontrailingSplat = false, allowAssignmentToEmptyArray = false, allowAssignmentToComplexSplat = false} = {}) {
         var varBase;
         if (!(!this.context || this.context === '**=')) {
           return;
@@ -5197,7 +5197,8 @@
         if (!varBase.isAssignable({
           allowExpansion: allowAssignmentToExpansion,
           allowNontrailingSplat: allowAssignmentToNontrailingSplat,
-          allowEmptyArray: allowAssignmentToEmptyArray
+          allowEmptyArray: allowAssignmentToEmptyArray,
+          allowComplexSplat: allowAssignmentToComplexSplat
         })) {
           this.variable.error(`'${this.variable.compile(o)}' can't be assigned`);
         }
@@ -5716,7 +5717,8 @@
         this.addScopeVariables(o, {
           allowAssignmentToExpansion: true,
           allowAssignmentToNontrailingSplat: true,
-          allowAssignmentToEmptyArray: true
+          allowAssignmentToEmptyArray: true,
+          allowAssignmentToComplexSplat: true
         });
         return super.astNode(o);
       }
@@ -6596,9 +6598,9 @@
         return false;
       }
 
-      isAssignable() {
+      isAssignable({allowComplexSplat = false} = {}) {
         if (this.name instanceof Obj || this.name instanceof Parens) {
-          return false;
+          return allowComplexSplat;
         }
         return this.name.isAssignable() && (!this.name.isAtomic || this.name.isAtomic());
       }
@@ -6618,6 +6620,17 @@
 
       unwrap() {
         return this.name;
+      }
+
+      propagateLhs(setLhs) {
+        var base1;
+        if (setLhs) {
+          this.lhs = true;
+        }
+        if (!this.lhs) {
+          return;
+        }
+        return typeof (base1 = this.name).propagateLhs === "function" ? base1.propagateLhs(true) : void 0;
       }
 
       astType() {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -5188,6 +5188,9 @@
         return unfoldSoak(o, this, 'variable');
       }
 
+      // During AST generation, we need to allow assignment to these constructs
+      // that are considered “unassignable” during compile-to-JS, while still
+      // flagging things like `[null] = b`.
       addScopeVariables(o, {allowAssignmentToExpansion = false, allowAssignmentToNontrailingSplat = false, allowAssignmentToEmptyArray = false, allowAssignmentToComplexSplat = false} = {}) {
         var varBase;
         if (!(!this.context || this.context === '**=')) {

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3965,7 +3965,7 @@
         return false;
       }
 
-      isAssignable({allowExpansion} = {}) {
+      isAssignable({allowExpansion, allowNontrailingSplat} = {}) {
         var i, j, len1, obj, ref1;
         if (!this.objects.length) {
           return false;
@@ -3973,7 +3973,7 @@
         ref1 = this.objects;
         for (i = j = 0, len1 = ref1.length; j < len1; i = ++j) {
           obj = ref1[i];
-          if (obj instanceof Splat && i + 1 !== this.objects.length) {
+          if (!allowNontrailingSplat && obj instanceof Splat && i + 1 !== this.objects.length) {
             return false;
           }
           if (!((allowExpansion && obj instanceof Expansion) || (obj.isAssignable() && (!obj.isAtomic || obj.isAtomic())))) {
@@ -5188,14 +5188,15 @@
         return unfoldSoak(o, this, 'variable');
       }
 
-      addScopeVariables(o, {allowAssignmentToExpansion = false} = {}) {
+      addScopeVariables(o, {allowAssignmentToExpansion = false, allowAssignmentToNontrailingSplat = false} = {}) {
         var varBase;
         if (!(!this.context || this.context === '**=')) {
           return;
         }
         varBase = this.variable.unwrapAll();
         if (!varBase.isAssignable({
-          allowExpansion: allowAssignmentToExpansion
+          allowExpansion: allowAssignmentToExpansion,
+          allowNontrailingSplat: allowAssignmentToNontrailingSplat
         })) {
           this.variable.error(`'${this.variable.compile(o)}' can't be assigned`);
         }
@@ -5712,7 +5713,8 @@
           }
         }
         this.addScopeVariables(o, {
-          allowAssignmentToExpansion: true
+          allowAssignmentToExpansion: true,
+          allowAssignmentToNontrailingSplat: true
         });
         return super.astNode(o);
       }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3965,10 +3965,10 @@
         return false;
       }
 
-      isAssignable({allowExpansion, allowNontrailingSplat} = {}) {
+      isAssignable({allowExpansion, allowNontrailingSplat, allowEmptyArray = false} = {}) {
         var i, j, len1, obj, ref1;
         if (!this.objects.length) {
-          return false;
+          return allowEmptyArray;
         }
         ref1 = this.objects;
         for (i = j = 0, len1 = ref1.length; j < len1; i = ++j) {
@@ -5188,7 +5188,7 @@
         return unfoldSoak(o, this, 'variable');
       }
 
-      addScopeVariables(o, {allowAssignmentToExpansion = false, allowAssignmentToNontrailingSplat = false} = {}) {
+      addScopeVariables(o, {allowAssignmentToExpansion = false, allowAssignmentToNontrailingSplat = false, allowAssignmentToEmptyArray = false} = {}) {
         var varBase;
         if (!(!this.context || this.context === '**=')) {
           return;
@@ -5196,7 +5196,8 @@
         varBase = this.variable.unwrapAll();
         if (!varBase.isAssignable({
           allowExpansion: allowAssignmentToExpansion,
-          allowNontrailingSplat: allowAssignmentToNontrailingSplat
+          allowNontrailingSplat: allowAssignmentToNontrailingSplat,
+          allowEmptyArray: allowAssignmentToEmptyArray
         })) {
           this.variable.error(`'${this.variable.compile(o)}' can't be assigned`);
         }
@@ -5714,7 +5715,8 @@
         }
         this.addScopeVariables(o, {
           allowAssignmentToExpansion: true,
-          allowAssignmentToNontrailingSplat: true
+          allowAssignmentToNontrailingSplat: true,
+          allowAssignmentToEmptyArray: true
         });
         return super.astNode(o);
       }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -3455,7 +3455,15 @@ exports.Assign = class Assign extends Base
   unfoldSoak: (o) ->
     unfoldSoak o, this, 'variable'
 
-  addScopeVariables: (o, {allowAssignmentToExpansion = no, allowAssignmentToNontrailingSplat = no, allowAssignmentToEmptyArray = no, allowAssignmentToComplexSplat = no} = {}) ->
+  addScopeVariables: (o, {
+    # During AST generation, we need to allow assignment to these constructs
+    # that are considered “unassignable” during compile-to-JS, while still
+    # flagging things like `[null] = b`.
+    allowAssignmentToExpansion = no,
+    allowAssignmentToNontrailingSplat = no,
+    allowAssignmentToEmptyArray = no,
+    allowAssignmentToComplexSplat = no
+  } = {}) ->
     return unless not @context or @context is '**='
 
     varBase = @variable.unwrapAll()

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2661,8 +2661,8 @@ exports.Arr = class Arr extends Base
     return yes for obj in @objects when obj instanceof Elision
     no
 
-  isAssignable: ({allowExpansion, allowNontrailingSplat} = {}) ->
-    return no unless @objects.length
+  isAssignable: ({allowExpansion, allowNontrailingSplat, allowEmptyArray = no} = {}) ->
+    return allowEmptyArray unless @objects.length
 
     for obj, i in @objects
       return no if not allowNontrailingSplat and obj instanceof Splat and i + 1 isnt @objects.length
@@ -3455,11 +3455,15 @@ exports.Assign = class Assign extends Base
   unfoldSoak: (o) ->
     unfoldSoak o, this, 'variable'
 
-  addScopeVariables: (o, {allowAssignmentToExpansion = no, allowAssignmentToNontrailingSplat = no} = {}) ->
+  addScopeVariables: (o, {allowAssignmentToExpansion = no, allowAssignmentToNontrailingSplat = no, allowAssignmentToEmptyArray = no} = {}) ->
     return unless not @context or @context is '**='
 
     varBase = @variable.unwrapAll()
-    if not varBase.isAssignable allowExpansion: allowAssignmentToExpansion, allowNontrailingSplat: allowAssignmentToNontrailingSplat
+    if not varBase.isAssignable {
+      allowExpansion: allowAssignmentToExpansion
+      allowNontrailingSplat: allowAssignmentToNontrailingSplat
+      allowEmptyArray: allowAssignmentToEmptyArray
+    }
       @variable.error "'#{@variable.compile o}' can't be assigned"
 
     varBase.eachName (name) =>
@@ -3805,7 +3809,7 @@ exports.Assign = class Assign extends Base
       variable = @variable.unwrap()
       if variable instanceof IdentifierLiteral and not o.scope.check variable.value
         @throwUnassignableConditionalError variable.value
-    @addScopeVariables o, allowAssignmentToExpansion: yes, allowAssignmentToNontrailingSplat: yes
+    @addScopeVariables o, allowAssignmentToExpansion: yes, allowAssignmentToNontrailingSplat: yes, allowAssignmentToEmptyArray: yes
     super o
 
   astType: ->

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2275,6 +2275,20 @@ test "AST as expected for Assign node", ->
       operator: '?='
     ]
 
+  testExpression '[a..., b] = c',
+    type: 'AssignmentExpression'
+    left:
+      type: 'ArrayPattern'
+      elements: [
+        type: 'RestElement'
+        argument: ID 'a', declaration: yes
+        postfix: yes
+      ,
+        ID 'b'
+      ]
+    right:
+      ID 'c'
+
 test "AST as expected for Code node", ->
   testExpression '=>',
     type: 'ArrowFunctionExpression'

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2297,6 +2297,63 @@ test "AST as expected for Assign node", ->
     right:
       ID 'c'
 
+  testExpression '{{a...}...} = b',
+    type: 'AssignmentExpression'
+    left:
+      type: 'ObjectPattern'
+      properties: [
+        type: 'RestElement'
+        argument:
+          type: 'ObjectPattern'
+          properties: [
+            type: 'RestElement'
+            argument: ID 'a'
+          ]
+        postfix: yes
+      ]
+    right: ID 'b'
+
+  testExpression '{a..., b} = c',
+    type: 'AssignmentExpression'
+    left:
+      type: 'ObjectPattern'
+      properties: [
+        type: 'RestElement'
+        argument: ID 'a'
+        postfix: yes
+      ,
+        type: 'ObjectProperty'
+      ]
+    right: ID 'c'
+
+  testExpression '{a.b...} = c',
+    type: 'AssignmentExpression'
+    left:
+      type: 'ObjectPattern'
+      properties: [
+        type: 'RestElement'
+        argument:
+          type: 'MemberExpression'
+        postfix: yes
+      ]
+    right: ID 'c'
+
+  testExpression '{{a}...} = b',
+    type: 'AssignmentExpression'
+    left:
+      type: 'ObjectPattern'
+      properties: [
+        type: 'RestElement'
+        argument:
+          type: 'ObjectPattern'
+          properties: [
+            type: 'ObjectProperty'
+            shorthand: yes
+          ]
+        postfix: yes
+      ]
+    right: ID 'b'
+
 test "AST as expected for Code node", ->
   testExpression '=>',
     type: 'ArrowFunctionExpression'

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2289,6 +2289,14 @@ test "AST as expected for Assign node", ->
     right:
       ID 'c'
 
+  testExpression '[] = c',
+    type: 'AssignmentExpression'
+    left:
+      type: 'ArrayPattern'
+      elements: []
+    right:
+      ID 'c'
+
 test "AST as expected for Code node", ->
   testExpression '=>',
     type: 'ArrowFunctionExpression'


### PR DESCRIPTION
@GeoffreyBooth here's another issue that applying the ESLint plugin to the Coffeescript codebase surfaced:

Assignment to a nontrailing splat (eg `[a..., b] = c`) was failing, so needed to extend the logic for the differences in what's "assignable" during AST generation vs compile-to-JS

Based on `ast-fix-interpolated-regex-tokens`, [here](https://github.com/helixbass/copheescript/compare/ast-fix-interpolated-regex-tokens...ast-allow-assignment-to-nontrailing-splat) is just the diff against that branch