### PR TITLE
WIP: Output JS-compatible line numbers

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -4,10 +4,10 @@
   // on Node.js/V8, or to run CoffeeScript directly in the browser. This module
   // contains the main entry functions for tokenizing, parsing, and compiling
   // source CoffeeScript into JavaScript.
-  var FILE_EXTENSIONS, Lexer, SourceMap, base64encode, checkShebangLine, compile, formatSourcePosition, getSourceMap, helpers, lexer, packageJson, parser, registerCompiled, sourceMaps, sources, withPrettyErrors,
+  var FILE_EXTENSIONS, LINEBREAK, Lexer, SourceMap, base64encode, checkShebangLine, compile, formatSourcePosition, getSourceMap, helpers, lexer, packageJson, parser, registerCompiled, sourceMaps, sources, withPrettyErrors,
     indexOf = [].indexOf;
 
-  ({Lexer} = require('./lexer'));
+  ({Lexer, LINEBREAK} = require('./lexer'));
 
   ({parser} = require('./parser'));
 
@@ -147,7 +147,7 @@
     // `clean` function in the lexer).
     if (options.ast) {
       nodes.allCommentTokens = helpers.extractAllCommentTokens(tokens);
-      sourceCodeNumberOfLines = (code.match(/\r?\n/g) || '').length + 1;
+      sourceCodeNumberOfLines = (code.match(LINEBREAK) || []).length + 1;
       sourceCodeLastLine = /.*$/.exec(code)[0];
       ast = nodes.ast(options);
       range = [0, code.length];

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -10,7 +10,7 @@
   // where locationData is {first_line, first_column, last_line, last_column, last_line_exclusive, last_column_exclusive}, which is a
   // format that can be fed directly into [Jison](https://github.com/zaach/jison).  These
   // are read by jison in the `parser.lexer` function defined in coffeescript.coffee.
-  var BOM, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARABLE_LEFT_SIDE, COMPARE, COMPOUND_ASSIGN, HERECOMMENT_ILLEGAL, HEREDOC_DOUBLE, HEREDOC_INDENT, HEREDOC_SINGLE, HEREGEX, HEREGEX_COMMENT, HERE_JSTOKEN, IDENTIFIER, INDENTABLE_CLOSERS, INDEXABLE, INSIDE_JSX, INVERSES, JSTOKEN, JSX_ATTRIBUTE, JSX_FRAGMENT_IDENTIFIER, JSX_IDENTIFIER, JSX_IDENTIFIER_PART, JSX_INTERPOLATION, JS_KEYWORDS, LINE_BREAK, LINE_CONTINUER, Lexer, MATH, MULTI_DENT, NOT_REGEX, NUMBER, OPERATOR, POSSIBLY_DIVISION, REGEX, REGEX_FLAGS, REGEX_ILLEGAL, REGEX_INVALID_ESCAPE, RELATION, RESERVED, Rewriter, SHIFT, STRICT_PROSCRIBED, STRING_DOUBLE, STRING_INVALID_ESCAPE, STRING_SINGLE, STRING_START, TRAILING_SPACES, UNARY, UNARY_MATH, UNFINISHED, VALID_FLAGS, WHITESPACE, addTokenData, attachCommentsToNode, compact, count, flatten, invertLiterate, isForFrom, isUnassignable, key, locationDataToString, merge, repeat, replaceUnicodeCodePointEscapes, starts, throwSyntaxError,
+  var BOM, BOOL, CALLABLE, CODE, COFFEE_ALIASES, COFFEE_ALIAS_MAP, COFFEE_KEYWORDS, COMMENT, COMPARABLE_LEFT_SIDE, COMPARE, COMPOUND_ASSIGN, HERECOMMENT_ILLEGAL, HEREDOC_DOUBLE, HEREDOC_INDENT, HEREDOC_SINGLE, HEREGEX, HEREGEX_COMMENT, HERE_JSTOKEN, IDENTIFIER, INDENTABLE_CLOSERS, INDEXABLE, INSIDE_JSX, INVERSES, JSTOKEN, JSX_ATTRIBUTE, JSX_FRAGMENT_IDENTIFIER, JSX_IDENTIFIER, JSX_IDENTIFIER_PART, JSX_INTERPOLATION, JS_KEYWORDS, LINEBREAK, LINE_BREAK, LINE_CONTINUER, Lexer, MATH, MULTI_DENT, NOT_REGEX, NUMBER, OPERATOR, POSSIBLY_DIVISION, REGEX, REGEX_FLAGS, REGEX_ILLEGAL, REGEX_INVALID_ESCAPE, RELATION, RESERVED, Rewriter, SHIFT, STRICT_PROSCRIBED, STRING_DOUBLE, STRING_INVALID_ESCAPE, STRING_SINGLE, STRING_START, TRAILING_SPACES, UNARY, UNARY_MATH, UNFINISHED, VALID_FLAGS, WHITESPACE, addTokenData, attachCommentsToNode, compact, count, flatten, invertLiterate, isForFrom, isUnassignable, key, locationDataToString, merge, repeat, replaceUnicodeCodePointEscapes, starts, throwSyntaxError,
     indexOf = [].indexOf,
     slice = [].slice;
 
@@ -1532,10 +1532,10 @@
       } else {
         string = this.chunk.slice(0, +(offset - 1) + 1 || 9e9);
       }
-      lineCount = count(string, '\n');
+      lineCount = (string.match(LINEBREAK) || []).length;
       column = this.chunkColumn;
       if (lineCount > 0) {
-        ref = string.split('\n'), [lastLine] = slice.call(ref, -1);
+        ref = string.split(LINEBREAK), [lastLine] = slice.call(ref, -1);
         column = lastLine.length;
         previousLinesCompensation = this.getLocationDataCompensation(this.chunkOffset, this.chunkOffset + offset - column);
         if (previousLinesCompensation < 0) {
@@ -1804,6 +1804,8 @@
   // range or splat
 
   WHITESPACE = /^[^\n\S]+/;
+
+  exports.LINEBREAK = LINEBREAK = /\r\n|[\r\n\u2028\u2029]/ug;
 
   COMMENT = /^(\s*)###([^#][\s\S]*?)(?:###([^\n\S]*)|###$)|^((?:\s*#(?!##[^#]).*)+)/;
 

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -3,7 +3,7 @@
 # contains the main entry functions for tokenizing, parsing, and compiling
 # source CoffeeScript into JavaScript.
 
-{Lexer}       = require './lexer'
+{Lexer, LINEBREAK} = require './lexer'
 {parser}      = require './parser'
 helpers       = require './helpers'
 SourceMap     = require './sourcemap'
@@ -114,7 +114,7 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
   # `clean` function in the lexer).
   if options.ast
     nodes.allCommentTokens = helpers.extractAllCommentTokens tokens
-    sourceCodeNumberOfLines = (code.match(/\r?\n/g) or '').length + 1
+    sourceCodeNumberOfLines = (code.match(LINEBREAK) or []).length + 1
     sourceCodeLastLine = /.*$/.exec(code)[0] # `.*` matches all but line break characters.
     ast = nodes.ast options
     range = [0, code.length]

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1056,11 +1056,11 @@ exports.Lexer = class Lexer
     else
       string = @chunk[..offset-1]
 
-    lineCount = count string, '\n'
+    lineCount = (string.match(LINEBREAK) or []).length
 
     column = @chunkColumn
     if lineCount > 0
-      [..., lastLine] = string.split '\n'
+      [..., lastLine] = string.split LINEBREAK
       column = lastLine.length
       previousLinesCompensation = @getLocationDataCompensation @chunkOffset, @chunkOffset + offset - column
       # Don't recompensate for initially inserted newline.
@@ -1313,6 +1313,8 @@ OPERATOR   = /// ^ (
 ) ///
 
 WHITESPACE = /^[^\n\S]+/
+
+exports.LINEBREAK = LINEBREAK = /\r\n|[\r\n\u2028\u2029]/ug
 
 COMMENT    = /^(\s*)###([^#][\s\S]*?)(?:###([^\n\S]*)|###$)|^((?:\s*#(?!##[^#]).*)+)/
 


### PR DESCRIPTION
@GeoffreyBooth this is an interesting one I came across while running the ESLint plugin against the Coffeescript repo source code:

It was crashing running ESLint against `test/regex.coffee` because of the literal U+2028/U+2029 (Unicode linebreak) characters in that file

Looking into it, it turns out our location data/line numbers aren't exactly JS-compatible - per eg [here](https://books.google.com/books?id=4RChxt67lvwC&pg=PA22&lpg=PA22&dq=javascript+unicode+2028+line+number&source=bl&ots=ti07EhOVm8&sig=ACfU3U0w1HIaXZyPpEtaiQzjfvK56gqylg&hl=en&sa=X&ved=2ahUKEwir5ae5hrvmAhWXbs0KHRraDNgQ6AEwB3oECAoQAQ#v=onepage&q=javascript%20unicode%202028%20line%20number&f=false), JS considers newline (`\n`), carriage return (`\r`), carriage return + newline (`\r\n`), U+2028 and U+2029 to be line terminators

Whereas we strip carriage returns and then just consider newlines to be line terminators

So what was happening is that in a file with "unusual" line terminators according to JS (eg the U+2028 and U+2029 in `test/regex.coffee`), ESLint was doing the JS version of counting linebreaks and then getting confused when a certain line didn't have the number of columns reported by our location data

So thus far this PR swaps in the JS-compatible regex for detecting linebreaks in the obvious places. Which did get ESLint working against `test/regex.coffee`

But I'm probably inclined to not try and get this merged before initial release, as (a) it should only cause problems in files where someone's got "fake linebreak" characters floating around and (b) I think it's worth thinking through more fully

For one thing, I think that if someone had a `\r` in their source code that wasn't "attached" to a following `\n`, it'd need to be accounted for - since we strip out `\r`'s, I think we'd need to go a step further than the `locationDataCompensations` (that we added into the lexer to get accurate location data despite things like `\r`'s having been stripped out) and do something like additionally "remember" the source offsets of any "unattached" `\r`'s and then take those into account when generating location data

But ultimately it seems like it'd be a good idea to be compatible with JS's definition of linebreaks in our location data?

Based on `ast-splat-param-location-data`, [here](https://github.com/helixbass/copheescript/compare/ast-splat-param-location-data...ast-js-compatible-line-numbers) is just the diff against that branch