### PR TITLE
AST: handle assignment to nested nontrailing splat

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2001,8 +2001,8 @@
         return this.hasProperties() || this.base.shouldCache();
       }
 
-      isAssignable() {
-        return this.hasProperties() || this.base.isAssignable();
+      isAssignable(opts) {
+        return this.hasProperties() || this.base.isAssignable(opts);
       }
 
       isNumber() {
@@ -3965,8 +3965,9 @@
         return false;
       }
 
-      isAssignable({allowExpansion, allowNontrailingSplat, allowEmptyArray = false} = {}) {
-        var i, j, len1, obj, ref1;
+      isAssignable(opts) {
+        var allowEmptyArray, allowExpansion, allowNontrailingSplat, i, j, len1, obj, ref1;
+        ({allowExpansion, allowNontrailingSplat, allowEmptyArray = false} = opts != null ? opts : {});
         if (!this.objects.length) {
           return allowEmptyArray;
         }
@@ -3976,7 +3977,7 @@
           if (!allowNontrailingSplat && obj instanceof Splat && i + 1 !== this.objects.length) {
             return false;
           }
-          if (!((allowExpansion && obj instanceof Expansion) || (obj.isAssignable() && (!obj.isAtomic || obj.isAtomic())))) {
+          if (!((allowExpansion && obj instanceof Expansion) || (obj.isAssignable(opts) && (!obj.isAtomic || obj.isAtomic())))) {
             return false;
           }
         }

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1360,7 +1360,7 @@ exports.Value = class Value extends Base
   isArray        : -> @bareLiteral(Arr)
   isRange        : -> @bareLiteral(Range)
   shouldCache    : -> @hasProperties() or @base.shouldCache()
-  isAssignable   : -> @hasProperties() or @base.isAssignable()
+  isAssignable   : (opts) -> @hasProperties() or @base.isAssignable opts
   isNumber       : -> @bareLiteral(NumberLiteral)
   isString       : -> @bareLiteral(StringLiteral)
   isRegex        : -> @bareLiteral(RegexLiteral)
@@ -2661,12 +2661,13 @@ exports.Arr = class Arr extends Base
     return yes for obj in @objects when obj instanceof Elision
     no
 
-  isAssignable: ({allowExpansion, allowNontrailingSplat, allowEmptyArray = no} = {}) ->
+  isAssignable: (opts) ->
+    {allowExpansion, allowNontrailingSplat, allowEmptyArray = no} = opts ? {}
     return allowEmptyArray unless @objects.length
 
     for obj, i in @objects
       return no if not allowNontrailingSplat and obj instanceof Splat and i + 1 isnt @objects.length
-      return no unless (allowExpansion and obj instanceof Expansion) or (obj.isAssignable() and (not obj.isAtomic or obj.isAtomic()))
+      return no unless (allowExpansion and obj instanceof Expansion) or (obj.isAssignable(opts) and (not obj.isAtomic or obj.isAtomic()))
     yes
 
   shouldCache: ->

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2354,6 +2354,14 @@ test "AST as expected for Assign node", ->
       ]
     right: ID 'b'
 
+  testExpression '[u, [v, ...w, x], ...{...y}, z] = a',
+    left:
+      type: 'ArrayPattern'
+
+  testExpression '{...{a: [...b, c]}} = d',
+    left:
+      type: 'ObjectPattern'
+
 test "AST as expected for Code node", ->
   testExpression '=>',
     type: 'ArrowFunctionExpression'


### PR DESCRIPTION
@GeoffreyBooth I ran into one more complex case where something was still being flagged as unassignable during AST generation

Specifically, assignment to a nested nontrailing splat eg:
```
[u, [v, ...w, x]] = y
```