### PR TITLE
AST: splat param location data

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -2001,8 +2001,8 @@
         return this.hasProperties() || this.base.shouldCache();
       }
 
-      isAssignable() {
-        return this.hasProperties() || this.base.isAssignable();
+      isAssignable(opts) {
+        return this.hasProperties() || this.base.isAssignable(opts);
       }
 
       isNumber() {
@@ -3965,8 +3965,9 @@
         return false;
       }
 
-      isAssignable({allowExpansion, allowNontrailingSplat, allowEmptyArray = false} = {}) {
-        var i, j, len1, obj, ref1;
+      isAssignable(opts) {
+        var allowEmptyArray, allowExpansion, allowNontrailingSplat, i, j, len1, obj, ref1;
+        ({allowExpansion, allowNontrailingSplat, allowEmptyArray = false} = opts != null ? opts : {});
         if (!this.objects.length) {
           return allowEmptyArray;
         }
@@ -3976,7 +3977,7 @@
           if (!allowNontrailingSplat && obj instanceof Splat && i + 1 !== this.objects.length) {
             return false;
           }
-          if (!((allowExpansion && obj instanceof Expansion) || (obj.isAssignable() && (!obj.isAtomic || obj.isAtomic())))) {
+          if (!((allowExpansion && obj instanceof Expansion) || (obj.isAssignable(opts) && (!obj.isAtomic || obj.isAtomic())))) {
             return false;
           }
         }

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -6326,7 +6326,7 @@
           return new Splat(name, {
             lhs: true,
             postfix: splat.postfix
-          }).withLocationDataFrom(name);
+          }).withLocationDataFrom(param);
         } else if (value != null) {
           return new Assign(name, value, null, {
             param: true

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -1360,7 +1360,7 @@ exports.Value = class Value extends Base
   isArray        : -> @bareLiteral(Arr)
   isRange        : -> @bareLiteral(Range)
   shouldCache    : -> @hasProperties() or @base.shouldCache()
-  isAssignable   : -> @hasProperties() or @base.isAssignable()
+  isAssignable   : (opts) -> @hasProperties() or @base.isAssignable opts
   isNumber       : -> @bareLiteral(NumberLiteral)
   isString       : -> @bareLiteral(StringLiteral)
   isRegex        : -> @bareLiteral(RegexLiteral)
@@ -2661,12 +2661,13 @@ exports.Arr = class Arr extends Base
     return yes for obj in @objects when obj instanceof Elision
     no
 
-  isAssignable: ({allowExpansion, allowNontrailingSplat, allowEmptyArray = no} = {}) ->
+  isAssignable: (opts) ->
+    {allowExpansion, allowNontrailingSplat, allowEmptyArray = no} = opts ? {}
     return allowEmptyArray unless @objects.length
 
     for obj, i in @objects
       return no if not allowNontrailingSplat and obj instanceof Splat and i + 1 isnt @objects.length
-      return no unless (allowExpansion and obj instanceof Expansion) or (obj.isAssignable() and (not obj.isAtomic or obj.isAtomic()))
+      return no unless (allowExpansion and obj instanceof Expansion) or (obj.isAssignable(opts) and (not obj.isAtomic or obj.isAtomic()))
     yes
 
   shouldCache: ->

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -4234,7 +4234,7 @@ exports.Code = class Code extends Base
     {name, value, splat} = param
     if splat
       new Splat name, lhs: yes, postfix: splat.postfix
-      .withLocationDataFrom name
+      .withLocationDataFrom param
     else if value?
       new Assign name, value, null, param: yes
       .withLocationDataFrom locationData: mergeLocationData name.locationData, value.locationData

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2354,6 +2354,14 @@ test "AST as expected for Assign node", ->
       ]
     right: ID 'b'
 
+  testExpression '[u, [v, ...w, x], ...{...y}, z] = a',
+    left:
+      type: 'ArrayPattern'
+
+  testExpression '{...{a: [...b, c]}} = d',
+    left:
+      type: 'ObjectPattern'
+
 test "AST as expected for Code node", ->
   testExpression '=>',
     type: 'ArrowFunctionExpression'

--- a/test/abstract_syntax_tree_location_data.coffee
+++ b/test/abstract_syntax_tree_location_data.coffee
@@ -4556,6 +4556,82 @@ test "AST location data as expected for Code node", ->
         line: 1
         column: 2
 
+  testAstLocationData '''
+    (a...) ->
+  ''',
+    type: 'FunctionExpression'
+    params: [
+      argument:
+        start: 1
+        end: 2
+        range: [1, 2]
+        loc:
+          start:
+            line: 1
+            column: 1
+          end:
+            line: 1
+            column: 2
+      start: 1
+      end: 5
+      range: [1, 5]
+      loc:
+        start:
+          line: 1
+          column: 1
+        end:
+          line: 1
+          column: 5
+    ]
+    start: 0
+    end: 9
+    range: [0, 9]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 9
+
+  testAstLocationData '''
+    (...a) ->
+  ''',
+    type: 'FunctionExpression'
+    params: [
+      argument:
+        start: 4
+        end: 5
+        range: [4, 5]
+        loc:
+          start:
+            line: 1
+            column: 4
+          end:
+            line: 1
+            column: 5
+      start: 1
+      end: 5
+      range: [1, 5]
+      loc:
+        start:
+          line: 1
+          column: 1
+        end:
+          line: 1
+          column: 5
+    ]
+    start: 0
+    end: 9
+    range: [0, 9]
+    loc:
+      start:
+        line: 1
+        column: 0
+      end:
+        line: 1
+        column: 9
+
 test "AST location data as expected for Return node", ->
   testAstLocationData 'return no',
     type: 'ReturnStatement'


### PR DESCRIPTION
@GeoffreyBooth PR to assign correct location data (including the `...`) to splat params

Based on `ast-nested-nontrailing-splat-assignment`, [here](https://github.com/helixbass/copheescript/compare/ast-nested-nontrailing-splat-assignment...ast-splat-param-location-data) is just the diff against that branch