### PR TITLE
AST: interpolated string is computed key

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -3926,7 +3926,7 @@
 
     astProperties(o) {
       var isComputedPropertyName, keyAst, ref1, ref2;
-      isComputedPropertyName = this.key instanceof Value && this.key.base instanceof ComputedPropertyName;
+      isComputedPropertyName = (this.key instanceof Value && this.key.base instanceof ComputedPropertyName) || this.key.unwrap() instanceof StringWithInterpolations;
       keyAst = this.key.ast(o, LEVEL_LIST);
       return {
         key: (keyAst != null ? keyAst.declaration : void 0) ? Object.assign({}, keyAst, {
@@ -4744,7 +4744,7 @@
         return {
           key: this.name.ast(o, LEVEL_LIST),
           value: this.value.ast(o, LEVEL_LIST),
-          computed: this.name instanceof ComputedPropertyName
+          computed: this.name instanceof ComputedPropertyName || this.name instanceof StringWithInterpolations
         };
       }
 
@@ -6342,9 +6342,6 @@
         var getIsComputed, ref1, ref2, ref3, ref4;
         getIsComputed = () => {
           if (this.name instanceof Index) {
-            if (this.name.index instanceof StringWithInterpolations) {
-              return false;
-            }
             return true;
           }
           if (this.name instanceof ComputedPropertyName) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -2632,7 +2632,7 @@ exports.ObjectProperty = class ObjectProperty extends Base
       @locationData = key.locationData
 
   astProperties: (o) ->
-    isComputedPropertyName = @key instanceof Value and @key.base instanceof ComputedPropertyName
+    isComputedPropertyName = (@key instanceof Value and @key.base instanceof ComputedPropertyName) or @key.unwrap() instanceof StringWithInterpolations
     keyAst = @key.ast o, LEVEL_LIST
 
     return
@@ -3177,7 +3177,7 @@ exports.ClassPrototypeProperty = class ClassPrototypeProperty extends Base
     return
       key: @name.ast o, LEVEL_LIST
       value: @value.ast o, LEVEL_LIST
-      computed: @name instanceof ComputedPropertyName
+      computed: @name instanceof ComputedPropertyName or @name instanceof StringWithInterpolations
 
 #### Import and Export
 
@@ -4243,9 +4243,7 @@ exports.Code = class Code extends Base
 
   methodAstProperties: (o) ->
     getIsComputed = =>
-      if @name instanceof Index
-        return no if @name.index instanceof StringWithInterpolations
-        return yes
+      return yes if @name instanceof Index
       return yes if @name instanceof ComputedPropertyName
       return yes if @name.name instanceof ComputedPropertyName
       no

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -1534,6 +1534,23 @@ test "AST as expected for Obj node", ->
     ]
     implicit: yes
 
+  testExpression '"#{a}": 1',
+    type: 'ObjectExpression'
+    properties: [
+      type: 'ObjectProperty'
+      key:
+        type: 'TemplateLiteral'
+        expressions: [
+          ID 'a'
+        ]
+      value:
+        type: 'NumericLiteral'
+        value: 1
+      shorthand: no
+      computed: yes
+    ]
+    implicit: yes
+
 test "AST as expected for Arr node", ->
   testExpression '[]',
     type: 'ArrayExpression'
@@ -1837,6 +1854,9 @@ test "AST as expected for Class node", ->
       @[b] = ->
       "#{c}": ->
       @[d] = 1
+      [e]: 2
+      "#{f}": 3
+      @[g]: 4
   ''',
     type: 'ClassDeclaration'
     body:
@@ -1845,7 +1865,16 @@ test "AST as expected for Class node", ->
         computed: yes
       ,
         type: 'ClassMethod'
-        computed: no
+        computed: yes
+      ,
+        type: 'ClassProperty'
+        computed: yes
+      ,
+        type: 'ClassPrototypeProperty'
+        computed: yes
+      ,
+        type: 'ClassPrototypeProperty'
+        computed: yes
       ,
         type: 'ClassProperty'
         computed: yes

--- a/test/abstract_syntax_tree.coffee
+++ b/test/abstract_syntax_tree.coffee
@@ -2391,6 +2391,19 @@ test "AST as expected for Assign node", ->
     left:
       type: 'ObjectPattern'
 
+  testExpression '{"#{a}": b} = c',
+    left:
+      type: 'ObjectPattern'
+      properties: [
+        type: 'ObjectProperty'
+        key:
+          type: 'TemplateLiteral'
+          expressions: [
+            ID 'a'
+          ]
+        computed: yes
+      ]
+
 test "AST as expected for Code node", ->
   testExpression '=>',
     type: 'ArrowFunctionExpression'


### PR DESCRIPTION
@GeoffreyBooth PR to mark interpolated strings as object/class method keys (eg `"#{a}": 1`) as `computed`

Looking at some bugs I've seen applying the ESLint plugin to the Coffeescript codebase, it became clear that even though interpolated strings as keys may syntactically "look" more like normal string keys than typical computed keys (eg `[a]: 1`), they in fact should be conceptually treated as being "computed"