### PR TITLE
Add more explicit sourceType in options and return of compile

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -103,7 +103,7 @@
   // object, where sourceMap is a sourcemap.coffee#SourceMap object, handy for
   // doing programmatic lookups.
   exports.compile = compile = withPrettyErrors(function(code, options = {}) {
-    var currentColumn, currentLine, encoded, filename, fragment, fragments, generateSourceMap, header, i, j, js, len, len1, map, newLines, ref, ref1, sourceMapDataURI, sourceURL, token, tokens, transpiler, transpilerOptions, transpilerOutput, v3SourceMap;
+    var currentColumn, currentLine, encoded, filename, fragment, fragments, generateSourceMap, header, i, j, js, len, len1, map, newLines, ref, ref1, ref2, sourceMapDataURI, sourceType, sourceURL, token, tokens, transpiler, transpilerOptions, transpilerOutput, v3SourceMap;
     // Clone `options`, to avoid mutating the `options` object passed in.
     options = Object.assign({}, options);
     // Always generate a source map if no filename is passed in, since without a
@@ -130,14 +130,19 @@
       return results;
     })();
     // Check for import or export; if found, force bare mode.
-    if (!((options.bare != null) && options.bare === true)) {
+    sourceType = (ref = options.sourceType) != null ? ref : 'unambiguous';
+    if (sourceType === 'unambiguous') {
+      sourceType = 'script';
       for (i = 0, len = tokens.length; i < len; i++) {
         token = tokens[i];
-        if ((ref = token[0]) === 'IMPORT' || ref === 'EXPORT') {
-          options.bare = true;
+        if ((ref1 = token[0]) === 'IMPORT' || ref1 === 'EXPORT') {
+          sourceType = 'module';
           break;
         }
       }
+    }
+    if (sourceType === 'module') {
+      options.bare = true;
     }
     fragments = parser.parse(tokens).compileToFragments(options);
     currentLine = 0;
@@ -203,13 +208,14 @@
     if (options.inlineMap) {
       encoded = base64encode(JSON.stringify(v3SourceMap));
       sourceMapDataURI = `//# sourceMappingURL=data:application/json;base64,${encoded}`;
-      sourceURL = `//# sourceURL=${(ref1 = options.filename) != null ? ref1 : 'coffeescript'}`;
+      sourceURL = `//# sourceURL=${(ref2 = options.filename) != null ? ref2 : 'coffeescript'}`;
       js = `${js}\n${sourceMapDataURI}\n${sourceURL}`;
     }
     registerCompiled(filename, code, map);
-    if (options.sourceMap) {
+    if (options.sourceMap || options.sourceType) {
       return {
         js,
+        sourceType,
         sourceMap: map,
         v3SourceMap: JSON.stringify(v3SourceMap, null, 2)
       };

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -100,11 +100,15 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
   )
 
   # Check for import or export; if found, force bare mode.
-  unless options.bare? and options.bare is yes
+  sourceType = options.sourceType ? 'unambiguous'
+  if sourceType is 'unambiguous'
+    sourceType = 'script'
     for token in tokens
       if token[0] in ['IMPORT', 'EXPORT']
-        options.bare = yes
+        sourceType = 'module'
         break
+
+  options.bare = yes if sourceType is 'module'
 
   fragments = parser.parse(tokens).compileToFragments options
 
@@ -170,9 +174,10 @@ exports.compile = compile = withPrettyErrors (code, options = {}) ->
 
   registerCompiled filename, code, map
 
-  if options.sourceMap
+  if options.sourceMap or options.sourceType
     {
       js
+      sourceType
       sourceMap: map
       v3SourceMap: JSON.stringify v3SourceMap, null, 2
     }

--- a/test/compilation.coffee
+++ b/test/compilation.coffee
@@ -177,3 +177,24 @@ test "#3306: trailing comma in a function call in the last line", ->
   ''', '''
   foo(bar);
   '''
+
+test 'sourceType is returned if requested', ->
+  result = CoffeeScript.compile '''
+  console.log 'is a script'
+  ''', sourceType: 'unambiguous'
+  eq result.sourceType, 'script'
+
+  result = CoffeeScript.compile '''
+  export default 'is a module'
+  ''', sourceType: 'unambiguous'
+  eq result.sourceType, 'module'
+
+  # sourceType: 'module' implies bare
+  result = CoffeeScript.compile '''
+  console.log 'is a module'
+  ''', sourceType: 'module'
+  eq result.sourceType, 'module'
+  eq result.js, '''
+  console.log('is a module');
+
+  '''


### PR DESCRIPTION
This allows code passing the output on to other tools to correctly identify the `sourceType` of the output.

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.4)_