### PR TITLE
AST: Fix lexing of BigInt and numbers with separators

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -96,7 +96,7 @@
     // returns, etc. If we’re lexing literate CoffeeScript, strip external Markdown
     // by removing all lines that aren’t indented by at least four spaces or a tab.
     clean(code) {
-      var base, thusFar;
+      var base1, thusFar;
       thusFar = 0;
       if (code.charCodeAt(0) === BOM) {
         code = code.slice(1);
@@ -106,8 +106,8 @@
       if (WHITESPACE.test(code)) {
         code = `\n${code}`;
         this.chunkLine--;
-        if ((base = this.locationDataCompensations)[0] == null) {
-          base[0] = 0;
+        if ((base1 = this.locationDataCompensations)[0] == null) {
+          base1[0] = 0;
         }
         this.locationDataCompensations[0] -= 1;
       }
@@ -296,7 +296,7 @@
     // Matches numbers, including decimals, hex, and exponential notation.
     // Be careful not to interfere with ranges in progress.
     numberToken() {
-      var lexedLength, match, number, parsedValue, tag, tokenData;
+      var base, lexedLength, match, number, parsedValue, tag, tokenData;
       if (!(match = NUMBER.exec(this.chunk))) {
         return 0;
       }
@@ -323,9 +323,21 @@
             length: lexedLength
           });
       }
-      parsedValue = Number(number);
+      base = (function() {
+        switch (number.charAt(1)) {
+          case 'b':
+            return 2;
+          case 'o':
+            return 8;
+          case 'x':
+            return 16;
+          default:
+            return null;
+        }
+      })();
+      parsedValue = base != null ? parseInt(number.slice(2), base) : parseFloat(number);
       tokenData = {parsedValue};
-      tag = Number.isFinite(parsedValue) ? 'NUMBER' : 'INFINITY';
+      tag = parsedValue === 2e308 ? 'INFINITY' : 'NUMBER';
       if (tag === 'INFINITY') {
         tokenData.original = number;
       }

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -272,10 +272,16 @@ exports.Lexer = class Lexer
       when /^0\d+/.test number
         @error "octal literal '#{number}' must be prefixed with '0o'", length: lexedLength
 
-    parsedValue = Number number
+    base = switch number.charAt 1
+      when 'b' then 2
+      when 'o' then 8
+      when 'x' then 16
+      else null
+
+    parsedValue = if base? then parseInt(number[2..], base) else parseFloat(number)
     tokenData = {parsedValue}
 
-    tag = if Number.isFinite(parsedValue) then 'NUMBER' else 'INFINITY'
+    tag = if parsedValue is Infinity then 'INFINITY' else 'NUMBER'
     if tag is 'INFINITY'
       tokenData.original = number
     @token tag, number,


### PR DESCRIPTION
@helixbass I merged `master` into `ast` locally and ran the tests, and a bunch were failing related to numbers, which isn’t surprising since the recent changes on `master` involve support for `BigInt` and numeric separators. Basically, I think we need to revert two simplifications you made to the lexer's `numberToken` method:

1. We can’t use `Number.isFinite` to tell apart `Infinity` from other numbers. `BigInt`s are not finite, as they’re not numbers at all in JS; yet they’re still `NumericLiteral`s in our grammar.

2. We can’t use the `Number()` constructor to parse numbers, as it doesn’t support numeric separators (`Number('123_456')` returns `NaN`, not the `123456` we want/expect). The previous more complicated logic of detecting the base and using `parseInt` or `parseFloat` works, however, so I brought that back.