### PR TITLE
Return Root from nodes()

### DIFF
--- a/lib/coffeescript/coffeescript.js
+++ b/lib/coffeescript/coffeescript.js
@@ -254,7 +254,7 @@
     if (typeof source === 'string') {
       source = lexer.tokenize(source, options);
     }
-    return parser.parse(source).body;
+    return parser.parse(source);
   });
 
   // This file used to export these methods; leave stubs that throw warnings

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -711,90 +711,97 @@
   //### Root
 
   // The root node of the node tree
-  exports.Root = Root = class Root extends Base {
-    constructor(body1) {
-      super();
-      this.body = body1;
-    }
-
-    // Wrap everything in a safety closure, unless requested not to. It would be
-    // better not to generate them in the first place, but for now, clean up
-    // obvious double-parentheses.
-    compileNode(o) {
-      var fragments;
-      o.indent = o.bare ? '' : TAB;
-      o.level = LEVEL_TOP;
-      o.compiling = true;
-      this.initializeScope(o);
-      fragments = this.body.compileRoot(o);
-      if (o.bare) {
-        return fragments;
+  exports.Root = Root = (function() {
+    class Root extends Base {
+      constructor(body1) {
+        super();
+        this.body = body1;
       }
-      return [].concat(this.makeCode("(function() {\n"), fragments, this.makeCode("\n}).call(this);\n"));
-    }
 
-    initializeScope(o) {
-      var j, len1, name, ref1, ref2, results1;
-      o.scope = new Scope(null, this.body, null, (ref1 = o.referencedVars) != null ? ref1 : []);
-      ref2 = o.locals || [];
-      results1 = [];
-      for (j = 0, len1 = ref2.length; j < len1; j++) {
-        name = ref2[j];
-        // Mark given local variables in the root scope as parameters so they don’t
-        // end up being declared on the root block.
-        results1.push(o.scope.parameter(name));
+      // Wrap everything in a safety closure, unless requested not to. It would be
+      // better not to generate them in the first place, but for now, clean up
+      // obvious double-parentheses.
+      compileNode(o) {
+        var fragments;
+        o.indent = o.bare ? '' : TAB;
+        o.level = LEVEL_TOP;
+        o.compiling = true;
+        this.initializeScope(o);
+        fragments = this.body.compileRoot(o);
+        if (o.bare) {
+          return fragments;
+        }
+        return [].concat(this.makeCode("(function() {\n"), fragments, this.makeCode("\n}).call(this);\n"));
       }
-      return results1;
-    }
 
-    commentsAst() {
-      var comment, commentToken, j, len1, ref1, results1;
-      if (this.allComments == null) {
-        this.allComments = (function() {
-          var j, len1, ref1, ref2, results1;
-          ref2 = (ref1 = this.allCommentTokens) != null ? ref1 : [];
-          results1 = [];
-          for (j = 0, len1 = ref2.length; j < len1; j++) {
-            commentToken = ref2[j];
-            if (!commentToken.heregex) {
-              if (commentToken.here) {
-                results1.push(new HereComment(commentToken));
-              } else {
-                results1.push(new LineComment(commentToken));
+      initializeScope(o) {
+        var j, len1, name, ref1, ref2, results1;
+        o.scope = new Scope(null, this.body, null, (ref1 = o.referencedVars) != null ? ref1 : []);
+        ref2 = o.locals || [];
+        results1 = [];
+        for (j = 0, len1 = ref2.length; j < len1; j++) {
+          name = ref2[j];
+          // Mark given local variables in the root scope as parameters so they don’t
+          // end up being declared on the root block.
+          results1.push(o.scope.parameter(name));
+        }
+        return results1;
+      }
+
+      commentsAst() {
+        var comment, commentToken, j, len1, ref1, results1;
+        if (this.allComments == null) {
+          this.allComments = (function() {
+            var j, len1, ref1, ref2, results1;
+            ref2 = (ref1 = this.allCommentTokens) != null ? ref1 : [];
+            results1 = [];
+            for (j = 0, len1 = ref2.length; j < len1; j++) {
+              commentToken = ref2[j];
+              if (!commentToken.heregex) {
+                if (commentToken.here) {
+                  results1.push(new HereComment(commentToken));
+                } else {
+                  results1.push(new LineComment(commentToken));
+                }
               }
             }
-          }
-          return results1;
-        }).call(this);
+            return results1;
+          }).call(this);
+        }
+        ref1 = this.allComments;
+        results1 = [];
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          comment = ref1[j];
+          results1.push(comment.ast());
+        }
+        return results1;
       }
-      ref1 = this.allComments;
-      results1 = [];
-      for (j = 0, len1 = ref1.length; j < len1; j++) {
-        comment = ref1[j];
-        results1.push(comment.ast());
+
+      astNode(o) {
+        o.level = LEVEL_TOP;
+        this.initializeScope(o);
+        return super.astNode(o);
       }
-      return results1;
-    }
 
-    astNode(o) {
-      o.level = LEVEL_TOP;
-      this.initializeScope(o);
-      return super.astNode(o);
-    }
+      astType() {
+        return 'File';
+      }
 
-    astType() {
-      return 'File';
-    }
+      astProperties(o) {
+        this.body.isRootBlock = true;
+        return {
+          program: Object.assign(this.body.ast(o), this.astLocationData()),
+          comments: this.commentsAst()
+        };
+      }
 
-    astProperties(o) {
-      this.body.isRootBlock = true;
-      return {
-        program: Object.assign(this.body.ast(o), this.astLocationData()),
-        comments: this.commentsAst()
-      };
-    }
+    };
 
-  };
+    Root.prototype.children = ['body'];
+
+    return Root;
+
+  }).call(this);
 
   //### Block
 

--- a/lib/coffeescript/repl.js
+++ b/lib/coffeescript/repl.js
@@ -29,7 +29,7 @@
     })(),
     historyMaxInputSize: 10240,
     eval: function(input, context, filename, cb) {
-      var Assign, Block, Call, Code, Literal, Value, ast, err, isAsync, js, ref, ref1, referencedVars, result, token, tokens;
+      var Assign, Block, Call, Code, Literal, Root, Value, ast, err, isAsync, js, ref, ref1, referencedVars, result, token, tokens;
       // XXX: multiline hack.
       input = input.replace(/\uFF00/g, '\n');
       // Node's REPL sends the input ending with a newline and then wrapped in
@@ -39,7 +39,7 @@
       // Unwrap that too.
       input = input.replace(/^\s*try\s*{([\s\S]*)}\s*catch.*$/m, '$1');
       // Require AST nodes to do some AST manipulation.
-      ({Block, Assign, Value, Literal, Call, Code} = require('./nodes'));
+      ({Block, Assign, Value, Literal, Call, Code, Root} = require('./nodes'));
       try {
         // Tokenize the clean input.
         tokens = CoffeeScript.tokens(input);
@@ -63,14 +63,14 @@
           return results;
         })();
         // Generate the AST of the tokens.
-        ast = CoffeeScript.nodes(tokens);
+        ast = CoffeeScript.nodes(tokens).body;
         // Add assignment to `__` variable to force the input to be an expression.
         ast = new Block([new Assign(new Value(new Literal('__')), ast, '=')]);
         // Wrap the expression in a closure to support top-level `await`.
         ast = new Code([], ast);
         isAsync = ast.isAsync;
         // Invoke the wrapping closure.
-        ast = new Block([new Call(ast)]);
+        ast = new Root(new Block([new Call(ast)]));
         js = ast.compile({
           bare: true,
           locals: Object.keys(context),

--- a/src/coffeescript.coffee
+++ b/src/coffeescript.coffee
@@ -209,7 +209,7 @@ exports.tokens = withPrettyErrors (code, options) ->
 # or traverse it by using `.traverseChildren()` with a callback.
 exports.nodes = withPrettyErrors (source, options) ->
   source = lexer.tokenize source, options if typeof source is 'string'
-  parser.parse(source).body
+  parser.parse source
 
 # This file used to export these methods; leave stubs that throw warnings
 # instead. These methods have been moved into `index.coffee` to provide

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -512,6 +512,8 @@ exports.Root = class Root extends Base
   constructor: (@body) ->
     super()
 
+  children: ['body']
+
   # Wrap everything in a safety closure, unless requested not to. It would be
   # better not to generate them in the first place, but for now, clean up
   # obvious double-parentheses.

--- a/test/location.coffee
+++ b/test/location.coffee
@@ -626,7 +626,7 @@ test 'Values with properties end up with a location that includes the properties
     a['b']
     a[b.c()].d
   '''
-  block = CoffeeScript.nodes source
+  {body: block} = CoffeeScript.nodes source
   [
     singleProperty
     twoProperties
@@ -656,7 +656,7 @@ test 'Values with properties end up with a location that includes the properties
 
 test 'StringWithInterpolations::fromStringLiteral() assigns correct location to tagged template literal', ->
   checkLocationData = (source, {stringWithInterpolationsLocationData, stringLocationData}) ->
-    block = CoffeeScript.nodes source
+    {body: block} = CoffeeScript.nodes source
     taggedTemplateLiteral = block.expressions[0].unwrap()
     {args: [stringWithInterpolations]} = taggedTemplateLiteral
     {body} = stringWithInterpolations

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -5,7 +5,7 @@ test "operator precedence for logical operators", ->
   source = '''
     a or b and c
   '''
-  block = CoffeeScript.nodes source
+  {body: block} = CoffeeScript.nodes source
   [expression] = block.expressions
   eq expression.first.base.value, 'a'
   eq expression.operator, '||'
@@ -17,7 +17,7 @@ test "operator precedence for bitwise operators", ->
   source = '''
     a | b ^ c & d
   '''
-  block = CoffeeScript.nodes source
+  {body: block} = CoffeeScript.nodes source
   [expression] = block.expressions
   eq expression.first.base.value, 'a'
   eq expression.operator, '|'
@@ -31,7 +31,7 @@ test "operator precedence for binary ? operator", ->
   source = '''
      a ? b and c
   '''
-  block = CoffeeScript.nodes source
+  {body: block} = CoffeeScript.nodes source
   [expression] = block.expressions
   eq expression.first.base.value, 'a'
   eq expression.operator, '?'
@@ -43,7 +43,7 @@ test "new calls have a range including the new", ->
   source = '''
     a = new B().c(d)
   '''
-  block = CoffeeScript.nodes source
+  {body: block} = CoffeeScript.nodes source
 
   assertColumnRange = (node, firstColumn, lastColumn) ->
     eq node.locationData.first_line, 0
@@ -65,7 +65,7 @@ test "location data is properly set for nested `new`", ->
   source = '''
     new new A()()
   '''
-  block = CoffeeScript.nodes source
+  {body: block} = CoffeeScript.nodes source
 
   assertColumnRange = (node, firstColumn, lastColumn) ->
     eq node.locationData.first_line, 0


### PR DESCRIPTION
@GeoffreyBooth per discussion in #5273, this PR updates `CoffeeScript.nodes()` to return the `Root` node class instance