### PR TITLE
AST: Refactor marking nodes that return

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -378,9 +378,17 @@
       // Only override the component `ast*` methods as needed.
       ast(o, level) {
         var astNode;
+        // Merge `level` into `o` and perform other universal checks.
         o = this.astInitialize(o, level);
+        // Create serializable representation of this node.
         astNode = this.astNode(o);
-        return this.astAddReturns(astNode);
+        if ((this.astNode != null) && this.canBeReturned) {
+          // Mark AST nodes that correspond to expressions that (implicitly) return.
+          // We can’t do this as part of `astNode` because we need to assemble child
+          // nodes first before marking the parent being returned.
+          astNode.returns = true;
+        }
+        return astNode;
       }
 
       astInitialize(o, level) {
@@ -428,17 +436,6 @@
       // mutated into the structure that the Babel spec uses.
       astLocationData() {
         return jisonLocationDataToAstLocationData(this.locationData);
-      }
-
-      // Mark AST nodes that correspond to expressions that (implicitly) return.
-      astAddReturns(ast) {
-        if (ast == null) {
-          return ast;
-        }
-        if (this.canBeReturned) {
-          ast.returns = true;
-        }
-        return ast;
       }
 
       // Determines whether an AST node needs an `ExpressionStatement` wrapper.

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -281,9 +281,15 @@ exports.Base = class Base
   # **WARNING: DO NOT OVERRIDE THIS METHOD IN CHILD CLASSES.**
   # Only override the component `ast*` methods as needed.
   ast: (o, level) ->
+    # Merge `level` into `o` and perform other universal checks.
     o = @astInitialize o, level
+    # Create serializable representation of this node.
     astNode = @astNode o
-    @astAddReturns astNode
+    # Mark AST nodes that correspond to expressions that (implicitly) return.
+    # We can’t do this as part of `astNode` because we need to assemble child
+    # nodes first before marking the parent being returned.
+    astNode.returns = yes if @astNode? and @canBeReturned
+    astNode
 
   astInitialize: (o, level) ->
     o = Object.assign {}, o
@@ -317,12 +323,6 @@ exports.Base = class Base
   # mutated into the structure that the Babel spec uses.
   astLocationData: ->
     jisonLocationDataToAstLocationData @locationData
-
-  # Mark AST nodes that correspond to expressions that (implicitly) return.
-  astAddReturns: (ast) ->
-    return ast unless ast?
-    ast.returns = yes if @canBeReturned
-    ast
 
   # Determines whether an AST node needs an `ExpressionStatement` wrapper.
   # Typically matches our `isStatement()` logic but this allows overriding.

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -288,7 +288,8 @@ exports.Base = class Base
     # Mark AST nodes that correspond to expressions that (implicitly) return.
     # We can’t do this as part of `astNode` because we need to assemble child
     # nodes first before marking the parent being returned.
-    astNode.returns = yes if @astNode? and @canBeReturned
+    if @astNode? and @canBeReturned
+      Object.assign astNode, {returns: yes}
     astNode
 
   astInitialize: (o, level) ->


### PR DESCRIPTION
@helixbass what do you think of this minor refactor? We never override `astReturns`, so it doesn’t need to be its own method; and it seems more organized to me if that logic is in `ast`, which we also never override.

I still wish we could move the `returns` field to be set as part of `astNode`, and maybe I’ll make an attempt at trying to get that to work, but short of that I think this PR feels like an improvement in organization.

I also added some comments, please check that they’re correct. Is the returns thing because we need to wait for the children or the parents? Hopefully I got it right 😄