### PR TITLE
Fix comments after colons getting lost

### DIFF
--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -1116,6 +1116,6 @@
   // `STRING_START` isn’t on this list because its `locationData` matches that of
   // the node that becomes `StringWithInterpolations`, and therefore
   // `addDataToNode` attaches `STRING_START`’s tokens to that node.
-  DISCARDED = ['(', ')', '[', ']', '{', '}', '.', '..', '...', ',', '=', '++', '--', '?', 'AS', 'AWAIT', 'CALL_START', 'CALL_END', 'DEFAULT', 'DO', 'DO_IIFE', 'ELSE', 'EXTENDS', 'EXPORT', 'FORIN', 'FOROF', 'FORFROM', 'IMPORT', 'INDENT', 'INDEX_SOAK', 'INTERPOLATION_START', 'INTERPOLATION_END', 'LEADING_WHEN', 'OUTDENT', 'PARAM_END', 'REGEX_START', 'REGEX_END', 'RETURN', 'STRING_END', 'THROW', 'UNARY', 'YIELD'].concat(IMPLICIT_UNSPACED_CALL.concat(IMPLICIT_END.concat(CALL_CLOSERS.concat(CONTROL_IN_IMPLICIT))));
+  DISCARDED = ['(', ')', '[', ']', '{', '}', ':', '.', '..', '...', ',', '=', '++', '--', '?', 'AS', 'AWAIT', 'CALL_START', 'CALL_END', 'DEFAULT', 'DO', 'DO_IIFE', 'ELSE', 'EXTENDS', 'EXPORT', 'FORIN', 'FOROF', 'FORFROM', 'IMPORT', 'INDENT', 'INDEX_SOAK', 'INTERPOLATION_START', 'INTERPOLATION_END', 'LEADING_WHEN', 'OUTDENT', 'PARAM_END', 'REGEX_START', 'REGEX_END', 'RETURN', 'STRING_END', 'THROW', 'UNARY', 'YIELD'].concat(IMPLICIT_UNSPACED_CALL.concat(IMPLICIT_END.concat(CALL_CLOSERS.concat(CONTROL_IN_IMPLICIT))));
 
 }).call(this);

--- a/src/rewriter.coffee
+++ b/src/rewriter.coffee
@@ -837,7 +837,7 @@ CONTROL_IN_IMPLICIT = ['IF', 'TRY', 'FINALLY', 'CATCH', 'CLASS', 'SWITCH']
 # `STRING_START` isn’t on this list because its `locationData` matches that of
 # the node that becomes `StringWithInterpolations`, and therefore
 # `addDataToNode` attaches `STRING_START`’s tokens to that node.
-DISCARDED = ['(', ')', '[', ']', '{', '}', '.', '..', '...', ',', '=', '++', '--', '?',
+DISCARDED = ['(', ')', '[', ']', '{', '}', ':', '.', '..', '...', ',', '=', '++', '--', '?',
   'AS', 'AWAIT', 'CALL_START', 'CALL_END', 'DEFAULT', 'DO', 'DO_IIFE', 'ELSE',
   'EXTENDS', 'EXPORT', 'FORIN', 'FOROF', 'FORFROM', 'IMPORT', 'INDENT', 'INDEX_SOAK',
   'INTERPOLATION_START', 'INTERPOLATION_END', 'LEADING_WHEN', 'OUTDENT', 'PARAM_END',

--- a/test/comments.coffee
+++ b/test/comments.coffee
@@ -1003,7 +1003,7 @@ test "#4706: Flow comments after class name", ->
   var Container;
 
   Container = class Container/*::<T> */ {
-    method() {
+    method/*::<U> */() {
       return true;
     }
 
@@ -1119,4 +1119,17 @@ test "#4756: Comment before ? operation", ->
     /* Comment */
     return (ref = this.foo) != null ? ref : 42;
   })();
+  '''
+
+test "#5241: Comment after :", ->
+  eqJS '''
+  return
+    a: # Comment
+      b: 1
+  ''', '''
+  return {
+    a: { // Comment
+      b: 1
+    }
+  };
   '''


### PR DESCRIPTION
Colons are apparently another token type that doesn't survive passing through the parser, so rescue any comments attached to colons. Fixes #5241. cc @Asc2011