### PR TITLE
Browser compiler call parsing fix

### DIFF
--- a/lib/coffeescript/grammar.js
+++ b/lib/coffeescript/grammar.js
@@ -1090,19 +1090,19 @@
       function() {
         return new TaggedTemplateCall($1,
       $3,
-      $2);
+      $2.soak);
       }),
       o('Value OptFuncExist Arguments',
       function() {
         return new Call($1,
       $3,
-      $2);
+      $2.soak);
       }),
       o('SUPER OptFuncExist Arguments',
       function() {
         return new SuperCall(LOC(1)(new Super()),
       $3,
-      $2,
+      $2.soak,
       $1);
       }),
       o('DYNAMIC_IMPORT Arguments',
@@ -1115,11 +1115,15 @@
     OptFuncExist: [
       o('',
       function() {
-        return false;
+        return {
+          soak: false
+        };
       }),
       o('FUNC_EXIST',
       function() {
-        return true;
+        return {
+          soak: true
+        };
       })
     ],
     // The list of arguments to a function call.

--- a/lib/coffeescript/parser.js
+++ b/lib/coffeescript/parser.js
@@ -664,24 +664,28 @@ break;
 case 210:
 this.$ = yy.addDataToNode(yy, _$[$0-2], $$[$0-2], _$[$0], $$[$0], true)(new yy.TaggedTemplateCall($$[$0-2],
       $$[$0],
-      $$[$0-1]));
+      $$[$0-1].soak));
 break;
 case 211:
 this.$ = yy.addDataToNode(yy, _$[$0-2], $$[$0-2], _$[$0], $$[$0], true)(new yy.Call($$[$0-2],
       $$[$0],
-      $$[$0-1]));
+      $$[$0-1].soak));
 break;
 case 212:
 this.$ = yy.addDataToNode(yy, _$[$0-2], $$[$0-2], _$[$0], $$[$0], true)(new yy.SuperCall(yy.addDataToNode(yy, _$[$0-2], $$[$0-2], null, null, true)(new yy.Super()),
       $$[$0],
-      $$[$0-1],
+      $$[$0-1].soak,
       $$[$0-2]));
 break;
 case 214:
-this.$ = yy.addDataToNode(yy, _$[$0], $$[$0], _$[$0], $$[$0], true)(false);
+this.$ = yy.addDataToNode(yy, _$[$0], $$[$0], _$[$0], $$[$0], true)({
+          soak: false
+        });
 break;
 case 215:
-this.$ = yy.addDataToNode(yy, _$[$0], $$[$0], _$[$0], $$[$0], true)(true);
+this.$ = yy.addDataToNode(yy, _$[$0], $$[$0], _$[$0], $$[$0], true)({
+          soak: true
+        });
 break;
 case 216:
 this.$ = yy.addDataToNode(yy, _$[$0-1], $$[$0-1], _$[$0], $$[$0], true)([]);

--- a/src/grammar.coffee
+++ b/src/grammar.coffee
@@ -524,16 +524,16 @@ grammar =
 
   # Ordinary function invocation, or a chained series of calls.
   Invocation: [
-    o 'Value OptFuncExist String',              -> new TaggedTemplateCall $1, $3, $2
-    o 'Value OptFuncExist Arguments',           -> new Call $1, $3, $2
-    o 'SUPER OptFuncExist Arguments',           -> new SuperCall LOC(1)(new Super), $3, $2, $1
+    o 'Value OptFuncExist String',              -> new TaggedTemplateCall $1, $3, $2.soak
+    o 'Value OptFuncExist Arguments',           -> new Call $1, $3, $2.soak
+    o 'SUPER OptFuncExist Arguments',           -> new SuperCall LOC(1)(new Super), $3, $2.soak, $1
     o 'DYNAMIC_IMPORT Arguments',               -> new DynamicImportCall LOC(1)(new DynamicImport), $2
   ]
 
   # An optional existence check on a function.
   OptFuncExist: [
-    o '',                                       -> no
-    o 'FUNC_EXIST',                             -> yes
+    o '',                                       -> soak: no
+    o 'FUNC_EXIST',                             -> soak: yes
   ]
 
   # The list of arguments to a function call.


### PR DESCRIPTION
@GeoffreyBooth this PR should fix the browser compiler issue you described in #5284

This was related to the workaround we used to avoid forking Jison, see [this comment](https://github.com/jashkenas/coffeescript/pull/5156#pullrequestreview-201353764) - interestingly, it looks like I even called out `OptFuncExist` (which was the culprit here) as violating the workaround but I didn't think it mattered... I didn't bother digging into why it in fact *did* matter when run in the browser compiler context, I just altered the `OptFuncExist` grammar rule to not violate the workaround

I ran `bin/cake build:browser` locally and was able to successfully compile function calls via the Try section of `docs/v2/index.html`