### PR TITLE
Allow linebreak/indent in destructured for variable

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -722,7 +722,7 @@
       indent = match[0];
       prev = this.prev();
       backslash = (prev != null ? prev[0] : void 0) === '\\';
-      if (!(backslash || ((ref = this.seenFor) != null ? ref.endsLength : void 0) !== this.ends.length)) {
+      if (!(backslash || ((ref = this.seenFor) != null ? ref.endsLength : void 0) < this.ends.length)) {
         this.seenFor = false;
       }
       if (!((backslash && this.seenImport) || this.importSpecifierList)) {

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -722,7 +722,7 @@
       indent = match[0];
       prev = this.prev();
       backslash = (prev != null ? prev[0] : void 0) === '\\';
-      if (!(backslash || ((ref = this.seenFor) != null ? ref.endsLength : void 0) < this.ends.length)) {
+      if (!((backslash || ((ref = this.seenFor) != null ? ref.endsLength : void 0) < this.ends.length) && this.seenFor)) {
         this.seenFor = false;
       }
       if (!((backslash && this.seenImport) || this.importSpecifierList)) {

--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -192,7 +192,9 @@
         if (tag === 'WHEN' && (ref6 = this.tag(), indexOf.call(LINE_BREAK, ref6) >= 0)) {
           tag = 'LEADING_WHEN';
         } else if (tag === 'FOR') {
-          this.seenFor = true;
+          this.seenFor = {
+            endsLength: this.ends.length
+          };
         } else if (tag === 'UNLESS') {
           tag = 'IF';
         } else if (tag === 'IMPORT') {
@@ -713,14 +715,14 @@
     // Keeps track of the level of indentation, because a single outdent token
     // can close multiple indents, so we need to know how far in we happen to be.
     lineToken({chunk = this.chunk, offset = 0} = {}) {
-      var backslash, diff, indent, match, minLiteralLength, newIndentLiteral, noNewlines, prev, size;
+      var backslash, diff, indent, match, minLiteralLength, newIndentLiteral, noNewlines, prev, ref, size;
       if (!(match = MULTI_DENT.exec(chunk))) {
         return 0;
       }
       indent = match[0];
       prev = this.prev();
       backslash = (prev != null ? prev[0] : void 0) === '\\';
-      if (!(backslash && this.seenFor)) {
+      if (!(backslash || ((ref = this.seenFor) != null ? ref.endsLength : void 0) !== this.ends.length)) {
         this.seenFor = false;
       }
       if (!((backslash && this.seenImport) || this.importSpecifierList)) {

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -514,7 +514,7 @@ exports.Lexer = class Lexer
 
     prev = @prev()
     backslash = prev?[0] is '\\'
-    @seenFor = no unless backslash or @seenFor?.endsLength isnt @ends.length
+    @seenFor = no unless backslash or @seenFor?.endsLength < @ends.length
     @seenImport = no unless (backslash and @seenImport) or @importSpecifierList
     @seenExport = no unless (backslash and @seenExport) or @exportSpecifierList
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -182,7 +182,7 @@ exports.Lexer = class Lexer
       if tag is 'WHEN' and @tag() in LINE_BREAK
         tag = 'LEADING_WHEN'
       else if tag is 'FOR'
-        @seenFor = yes
+        @seenFor = {endsLength: @ends.length}
       else if tag is 'UNLESS'
         tag = 'IF'
       else if tag is 'IMPORT'
@@ -514,7 +514,7 @@ exports.Lexer = class Lexer
 
     prev = @prev()
     backslash = prev?[0] is '\\'
-    @seenFor = no unless backslash and @seenFor
+    @seenFor = no unless backslash or @seenFor?.endsLength isnt @ends.length
     @seenImport = no unless (backslash and @seenImport) or @importSpecifierList
     @seenExport = no unless (backslash and @seenExport) or @exportSpecifierList
 

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -514,7 +514,7 @@ exports.Lexer = class Lexer
 
     prev = @prev()
     backslash = prev?[0] is '\\'
-    @seenFor = no unless backslash or @seenFor?.endsLength < @ends.length
+    @seenFor = no unless (backslash or @seenFor?.endsLength < @ends.length) and @seenFor
     @seenImport = no unless (backslash and @seenImport) or @importSpecifierList
     @seenExport = no unless (backslash and @seenExport) or @exportSpecifierList
 

--- a/test/comprehensions.coffee
+++ b/test/comprehensions.coffee
@@ -576,3 +576,40 @@ test "#3778: Consistently always cache for loop range boundaries and steps, even
   a = 3; arrayEq [1, 2, 3], (for n in [1..+a]         then a = 4; n)
   a = 1; arrayEq [1, 2, 3], (for n in [1..3] by  a    then a = 4; n)
   a = 1; arrayEq [1, 2, 3], (for n in [1..3] by +a    then a = 4; n)
+
+test "for pattern variables can linebreak/indent", ->
+  listOfObjects = [a: 1]
+  sum = 0
+  for {
+    a
+    somethingElse
+    anotherProperty
+  } in listOfObjects
+    sum += a
+  eq a, 1
+
+  sum = 0
+  sum += a for {
+    a,
+    somethingElse,
+    anotherProperty,
+  } in listOfObjects
+  eq a, 1
+
+  listOfArrays = [[2]]
+  sum = 0
+  for [
+    a
+    nonexistentElement
+    anotherNonexistentElement
+  ] in listOfArrays
+    sum += a
+  eq a, 2
+
+  sum = 0
+  sum += a for [
+    a,
+    nonexistentElement,
+    anotherNonexistentElement
+  ] in listOfArrays
+  eq a, 2


### PR DESCRIPTION
@GeoffreyBooth I ran into this when running the Prettier plugin against the Coffeescript codebase:

Things like this (with linebreaks inside the destructured variable of a `for` loop) currently aren't parsing:
```
for {
  something,
  somethingElse
}, y in z
  d
```

The grammar is already set up to accept this, it was just an issue of extending the logic for tagging tokens as eg `FORIN`