### PR TITLE
Improve performance of location data compensation

### DIFF
--- a/lib/coffeescript/lexer.js
+++ b/lib/coffeescript/lexer.js
@@ -1504,20 +1504,22 @@
       // Compensate for the things we strip out initially (e.g. carriage returns)
     // so that location data stays accurate with respect to the original source file.
     getLocationDataCompensation(start, end) {
-      var compensation, index, initialEnd, length, ref;
-      compensation = 0;
+      var compensation, current, initialEnd, totalCompensation;
+      totalCompensation = 0;
       initialEnd = end;
-      ref = this.locationDataCompensations;
-      for (index in ref) {
-        length = ref[index];
-        index = parseInt(index, 10);
-        if (!(start <= index && (index < end || index === end && start === initialEnd))) {
-          continue;
+      current = start;
+      while (current <= end) {
+        if (current === end && start !== initialEnd) {
+          break;
         }
-        compensation += length;
-        end += length;
+        compensation = this.locationDataCompensations[current];
+        if (compensation != null) {
+          totalCompensation += compensation;
+          end += compensation;
+        }
+        current++;
       }
-      return compensation;
+      return totalCompensation;
     }
 
     // Returns the line and column number from an offset into the current chunk.

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -1033,14 +1033,17 @@ exports.Lexer = class Lexer
   # Compensate for the things we strip out initially (e.g. carriage returns)
   # so that location data stays accurate with respect to the original source file.
   getLocationDataCompensation: (start, end) ->
-    compensation = 0
+    totalCompensation = 0
     initialEnd = end
-    for index, length of @locationDataCompensations
-      index = parseInt index, 10
-      continue unless start <= index and (index < end or index is end and start is initialEnd)
-      compensation += length
-      end += length
-    compensation
+    current = start
+    while current <= end
+      break if current is end and start isnt initialEnd
+      compensation = @locationDataCompensations[current]
+      if compensation?
+        totalCompensation += compensation
+        end += compensation
+      current++
+    return totalCompensation
 
   # Returns the line and column number from an offset into the current chunk.
   #


### PR DESCRIPTION
Fixes #5290 

As discussed in that issue, performance for files with lots of "location data compensations" (eg stripped carriage returns, so all files on Windows) was blowing up because the algorithm used for calculating location data compensation was very inefficient

So this PR improves that algorithm to one that shouldn't have significant performance implications

To test, I made a copy of a decent-size source file eg `src/lexer.coffee` and converted it to have Windows-style line endings (`\r\n`), and ran `bin/coffee -b -p [converted-filename.coffee]`

Before this fix, compilation was taking many seconds, and with this fix, it took less than a second

I haven't done specific performance comparisons of a file with Windows line endings when you omit the location data compensation calculation entirely vs with this new algorithm, that might be interesting as a baseline