### PR TITLE
Fix: comprehension as postfix conditional

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -6761,10 +6761,14 @@
   // flexibility or more speed than a comprehension can provide.
   exports.While = While = (function() {
     class While extends Base {
-      constructor(condition1, {invert, guard, isLoop} = {}) {
+      constructor(condition1, {
+          invert: inverted,
+          guard,
+          isLoop
+        } = {}) {
         super();
         this.condition = condition1;
-        this.invert = invert;
+        this.inverted = inverted;
         this.guard = guard;
         this.isLoop = isLoop;
       }
@@ -6839,7 +6843,7 @@
       }
 
       processedCondition() {
-        return this.processedConditionCache != null ? this.processedConditionCache : this.processedConditionCache = this.invert ? this.condition.invert() : this.condition;
+        return this.processedConditionCache != null ? this.processedConditionCache : this.processedConditionCache = this.inverted ? this.condition.invert() : this.condition;
       }
 
       astType() {
@@ -6852,7 +6856,7 @@
           test: this.condition.ast(o, LEVEL_PAREN),
           body: this.body.ast(o, LEVEL_TOP),
           guard: (ref1 = (ref2 = this.guard) != null ? ref2.ast(o) : void 0) != null ? ref1 : null,
-          inverted: !!this.invert,
+          inverted: !!this.inverted,
           postfix: !!this.postfix,
           loop: !!this.isLoop
         };

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -4527,7 +4527,7 @@ exports.Elision = class Elision extends Base
 # it, all other loops can be manufactured. Useful in cases where you need more
 # flexibility or more speed than a comprehension can provide.
 exports.While = class While extends Base
-  constructor: (@condition, {@invert, @guard, @isLoop} = {}) ->
+  constructor: (@condition, {invert: @inverted, @guard, @isLoop} = {}) ->
     super()
 
   children: ['condition', 'guard', 'body']
@@ -4578,7 +4578,7 @@ exports.While = class While extends Base
     answer
 
   processedCondition: ->
-    @processedConditionCache ?= if @invert then @condition.invert() else @condition
+    @processedConditionCache ?= if @inverted then @condition.invert() else @condition
 
   astType: -> 'WhileStatement'
 
@@ -4587,7 +4587,7 @@ exports.While = class While extends Base
       test: @condition.ast o, LEVEL_PAREN
       body: @body.ast o, LEVEL_TOP
       guard: @guard?.ast(o) ? null
-      inverted: !!@invert
+      inverted: !!@inverted
       postfix: !!@postfix
       loop: !!@isLoop
 

--- a/test/comprehensions.coffee
+++ b/test/comprehensions.coffee
@@ -613,3 +613,8 @@ test "for pattern variables can linebreak/indent", ->
     anotherNonexistentElement
   ] in listOfArrays
   eq a, 2
+
+test "#5309: comprehension as postfix condition", ->
+  doesNotThrowCompileError """
+    throw new Error "DOOM was called with a null element" unless elm? for elm in elms
+  """


### PR DESCRIPTION
Fixes #5309 

@GeoffreyBooth this fixes the reported bug. The issue was that I introduced an `@invert` property on `While` (and thus `For`) to defer inverting the condition of an `until` (in order to preserve the original condition for AST purposes). But that inadvertently clashed with `Base::invert()`