### PR TITLE
Remove Google Analytics

### DIFF
--- a/documentation/site/docs.coffee
+++ b/documentation/site/docs.coffee
@@ -1,17 +1,6 @@
 unless window.location.origin # Polyfill `location.origin` for IE < 11
   window.location.origin = "#{window.location.protocol}//#{window.location.hostname}"
 
-
-# Initialize Google Analytics
-window.GA_TRACKING_ID = 'UA-106156830-1'
-window.dataLayer ?= []
-window.gtag = ->
-  window.dataLayer.push arguments
-  return
-window.gtag 'js', new Date()
-window.gtag 'config', window.GA_TRACKING_ID
-
-
 # Initialize the CoffeeScript docs interactions
 $(document).ready ->
   # Format dates for the user’s locale, e.g. 'December 24, 2009' or '24 décembre 2009'


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/

<!--
Before making a PR please make sure to read our contributing guidelines:
https://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](https://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->
