### PR TITLE
Avoid excess breaks within switch (fix #5344)

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -617,11 +617,17 @@
     Base.prototype.includeCommentFragments = NO;
 
     // `jumps` tells you if an expression, or an internal part of an expression
-    // has a flow control construct (like `break`, or `continue`, or `return`,
-    // or `throw`) that jumps out of the normal flow of control and can’t be
-    // used as a value. This is important because things like this make no sense;
-    // we have to disallow them.
+    // has a flow control construct (like `break`, `continue`, or `return`)
+    // that jumps out of the normal flow of control and can’t be used as a value.
+    // This is important because things like this make no sense;
+    // we have to disallow them.  Note that `throw` *is* allowed here though.
     Base.prototype.jumps = NO;
+
+    // `alwaysJumps` tells you whether this node *always* has a flow control
+    // construct (like `break`, `continue`, `return`, or `throw`) that jumps out
+    // of the normal flow of control, so that the immediately following node
+    // definitely won't execute.
+    Base.prototype.alwaysJumps = NO;
 
     // If `node.shouldCache() is false`, it is safe to use `node` more than once.
     // Otherwise you need to store the value of `node` in a variable and output
@@ -867,6 +873,20 @@
             return jumpNode;
           }
         }
+      }
+
+      // Block is executed in sequence, so if any statement always jumps,
+      // then so does the block.
+      alwaysJumps(o) {
+        var exp, j, len1, ref1;
+        ref1 = this.expressions;
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          exp = ref1[j];
+          if (exp.alwaysJumps(o)) {
+            return true;
+          }
+        }
+        return false;
       }
 
       // A Block node does not return its entire body, rather it
@@ -1714,6 +1734,10 @@
         }
       }
 
+      alwaysJumps(o) {
+        return Boolean(this.jumps(o));
+      }
+
       compileNode(o) {
         return [this.makeCode(`${this.tab}${this.value};`)];
       }
@@ -1901,6 +1925,8 @@
 
     Return.prototype.jumps = THIS;
 
+    Return.prototype.alwaysJumps = YES;
+
     return Return;
 
   }).call(this);
@@ -2073,6 +2099,10 @@
 
       jumps(o) {
         return !this.properties.length && this.base.jumps(o);
+      }
+
+      alwaysJumps(o) {
+        return !this.properties.length && this.base.alwaysJumps(o);
       }
 
       isObject(onlyGenerated) {
@@ -4810,6 +4840,8 @@
 
     ModuleDeclaration.prototype.jumps = THIS;
 
+    ModuleDeclaration.prototype.alwaysJumps = NO;
+
     ModuleDeclaration.prototype.makeReturn = THIS;
 
     return ModuleDeclaration;
@@ -6425,6 +6457,8 @@
 
     Code.prototype.jumps = NO;
 
+    Code.prototype.alwaysJumps = NO;
+
     return Code;
 
   }).call(this);
@@ -6808,6 +6842,23 @@
             loop: true
           })) {
             return jumpNode;
+          }
+        }
+        return false;
+      }
+
+      alwaysJumps() {
+        var expressions, j, len1, node;
+        ({expressions} = this.body);
+        if (!expressions.length) {
+          return false;
+        }
+        for (j = 0, len1 = expressions.length; j < len1; j++) {
+          node = expressions[j];
+          if (node.alwaysJumps({
+            loop: true
+          })) {
+            return true;
           }
         }
         return false;
@@ -7394,6 +7445,11 @@
         return this.attempt.jumps(o) || ((ref1 = this.catch) != null ? ref1.jumps(o) : void 0);
       }
 
+      alwaysJumps(o) {
+        var ref1, ref2;
+        return (this.attempt.alwaysJumps(o) && ((ref1 = this.catch) != null ? ref1.alwaysJumps(o) : void 0)) || ((ref2 = this.ensure) != null ? ref2.alwaysJumps(o) : void 0);
+      }
+
       makeReturn(results, mark) {
         var ref1, ref2;
         if (mark) {
@@ -7470,6 +7526,10 @@
 
       jumps(o) {
         return this.recovery.jumps(o);
+      }
+
+      alwaysJumps(o) {
+        return this.recovery.alwaysJumps(o);
       }
 
       makeReturn(results, mark) {
@@ -7577,6 +7637,8 @@
     Throw.prototype.isStatement = YES;
 
     Throw.prototype.jumps = NO;
+
+    Throw.prototype.alwaysJumps = YES;
 
     // A **Throw** is already a return, of sorts...
     Throw.prototype.makeReturn = THIS;
@@ -8290,6 +8352,23 @@
         return (ref2 = this.otherwise) != null ? ref2.jumps(o) : void 0;
       }
 
+      alwaysJumps(o = {
+          block: true
+        }) {
+        var block, j, len1, ref1;
+        if (!this.cases.length) {
+          return false;
+        }
+        ref1 = this.cases;
+        for (j = 0, len1 = ref1.length; j < len1; j++) {
+          ({block} = ref1[j]);
+          if (!block.alwaysJumps(o)) {
+            return false;
+          }
+        }
+        return true;
+      }
+
       makeReturn(results, mark) {
         var block, j, len1, ref1, ref2;
         ref1 = this.cases;
@@ -8307,7 +8386,7 @@
       }
 
       compileNode(o) {
-        var block, body, cond, conditions, expr, fragments, i, idt1, idt2, j, k, len1, len2, ref1, ref2;
+        var block, body, cond, conditions, fragments, i, idt1, idt2, j, k, len1, len2, ref1, ref2;
         idt1 = o.indent + TAB;
         idt2 = o.indent = idt1 + TAB;
         fragments = [].concat(this.makeCode(this.tab + "switch ("), (this.subject ? this.subject.compileToFragments(o, LEVEL_PAREN) : this.makeCode("false")), this.makeCode(") {\n"));
@@ -8328,8 +8407,8 @@
           if (i === this.cases.length - 1 && !this.otherwise) {
             break;
           }
-          expr = this.lastNode(block.expressions);
-          if (expr instanceof Return || expr instanceof Throw || (expr instanceof Literal && expr.jumps() && expr.value !== 'debugger')) {
+          if (block.alwaysJumps()) {
+            //expr = @lastNode block.expressions
             continue;
           }
           fragments.push(cond.makeCode(idt2 + 'break;\n'));
@@ -8509,6 +8588,11 @@
       jumps(o) {
         var ref1;
         return this.body.jumps(o) || ((ref1 = this.elseBody) != null ? ref1.jumps(o) : void 0);
+      }
+
+      alwaysJumps(o) {
+        var ref1;
+        return this.body.alwaysJumps(o) && ((ref1 = this.elseBody) != null ? ref1.alwaysJumps(o) : void 0);
       }
 
       compileNode(o) {

--- a/lib/coffeescript/rewriter.js
+++ b/lib/coffeescript/rewriter.js
@@ -496,7 +496,6 @@
                   } else {
                     return startIndex;
                   }
-                  break;
                 case this.tag(i - 2) !== '@':
                   return i - 2;
                 default:

--- a/test/control_flow.coffee
+++ b/test/control_flow.coffee
@@ -440,6 +440,22 @@ test "Issue #997. Switch doesn't fallthrough.", ->
 
   eq val, 1
 
+test "Issue #5344. Switch doesn't generate unnecessary break statements.", ->
+  js = CoffeeScript.compile '''
+    identify = (n) ->
+      switch n
+        when 1, 2, 3, 4, 5
+          if n % 2 == 0
+            'small even'
+          else
+            'small odd'
+        when 0
+          'perfect'
+        else
+          null
+  '''
+  ok not js.includes 'break'
+
 # Throw
 
 test "Throw should be usable as an expression.", ->


### PR DESCRIPTION
* Fix #5344: no longer generate `break` when the case body exits on its own, typically by a forced `return` being pushed within `if` blocks.
* Add new `alwaysJumps` node method to detect when a switch case can
safely drop its `break`.  Similar to `jumps` but ANDing instead of OR.
* Fix some documentation describing `jumps`, which ignores `throw`; it turns out `x = (throw 1)` is valid CoffeeScript.