### PR TITLE
ci: Check that build steps didn’t change any files

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,3 +43,6 @@ jobs:
     - run: node ./bin/cake build:parser
     - run: node ./bin/cake build:full
     - run: node ./bin/cake build:browser
+
+    - run: git diff --exit-code
+      if: matrix.node-version != '6.x' && matrix.node-version != '8.x'


### PR DESCRIPTION
@GeoffreyBooth wrote:

> We should add a CI step that rebuilds everything and then checks that there’s nothing different from the last git commit (which, if there was a difference, would mean that the author forgot to rebuild and commit one of the outputs).

This PR adds this CI step, which turned out to be easy, because all the building was already getting tested.

For some reason, the browser build is different on Node 6.x and 8.x (in my CI testing). So we don't run the diff in those cases, which seems OK to me.