### PR TITLE
Improve documentation of `jumps` in comments

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -616,11 +616,12 @@
     // has special awareness of how to handle comments within its output.
     Base.prototype.includeCommentFragments = NO;
 
-    // `jumps` tells you if an expression, or an internal part of an expression
-    // has a flow control construct (like `break`, or `continue`, or `return`,
-    // or `throw`) that jumps out of the normal flow of control and can’t be
-    // used as a value. This is important because things like this make no sense;
-    // we have to disallow them.
+    // `jumps` tells you if an expression, or an internal part of an expression,
+    // has a flow control construct (like `break`, `continue`, or `return`)
+    // that jumps out of the normal flow of control and can’t be used as a value.
+    // (Note that `throw` is not considered a flow control construct.)
+    // This is important because flow control in the middle of an expression
+    // make no sense; we have to disallow them.
     Base.prototype.jumps = NO;
 
     // If `node.shouldCache() is false`, it is safe to use `node` more than once.

--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -621,7 +621,7 @@
     // that jumps out of the normal flow of control and can’t be used as a value.
     // (Note that `throw` is not considered a flow control construct.)
     // This is important because flow control in the middle of an expression
-    // make no sense; we have to disallow them.
+    // makes no sense; we have to disallow it.
     Base.prototype.jumps = NO;
 
     // If `node.shouldCache() is false`, it is safe to use `node` more than once.

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -392,11 +392,12 @@ exports.Base = class Base
   # has special awareness of how to handle comments within its output.
   includeCommentFragments: NO
 
-  # `jumps` tells you if an expression, or an internal part of an expression
-  # has a flow control construct (like `break`, or `continue`, or `return`,
-  # or `throw`) that jumps out of the normal flow of control and can’t be
-  # used as a value. This is important because things like this make no sense;
-  # we have to disallow them.
+  # `jumps` tells you if an expression, or an internal part of an expression,
+  # has a flow control construct (like `break`, `continue`, or `return`)
+  # that jumps out of the normal flow of control and can’t be used as a value.
+  # (Note that `throw` is not considered a flow control construct.)
+  # This is important because flow control in the middle of an expression
+  # make no sense; we have to disallow them.
   jumps: NO
 
   # If `node.shouldCache() is false`, it is safe to use `node` more than once.
@@ -4996,7 +4997,7 @@ exports.Catch = class Catch extends Base
 
   isStatement: YES
 
-  jumps: (o) -> @recovery.jumps(o)
+  jumps: (o) -> @recovery.jumps o
 
   makeReturn: (results, mark) ->
     ret = @recovery.makeReturn results, mark

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -397,7 +397,7 @@ exports.Base = class Base
   # that jumps out of the normal flow of control and can’t be used as a value.
   # (Note that `throw` is not considered a flow control construct.)
   # This is important because flow control in the middle of an expression
-  # make no sense; we have to disallow them.
+  # makes no sense; we have to disallow it.
   jumps: NO
 
   # If `node.shouldCache() is false`, it is safe to use `node` more than once.


### PR DESCRIPTION
This extracts the comment fixes from #5348, plus some additional rewording, to make clear that `x = (throw 1)` is allowed, while `x = (break)` isn't.  A small thing, but at least I can get something useful out of #5348. 🙂 