### PR TITLE
Named exports for Node ESM for `coffeescript` package

### DIFF
--- a/lib/coffeescript/index.js
+++ b/lib/coffeescript/index.js
@@ -182,4 +182,35 @@
 
   module.exports = CoffeeScript;
 
+  // Explicitly define all named exports so that Node’s automatic detection of
+  // named exports from CommonJS packages finds all of them. This enables consuming
+  // packages to write code like `import { compile } from 'coffeescript'`.
+  // Don’t simplify this into a loop or similar; the `module.exports.name` part is
+  // essential for Node’s algorithm to successfully detect the name.
+  module.exports.VERSION = CoffeeScript.VERSION;
+
+  module.exports.FILE_EXTENSIONS = CoffeeScript.FILE_EXTENSIONS;
+
+  module.exports.helpers = CoffeeScript.helpers;
+
+  module.exports.registerCompiled = CoffeeScript.registerCompiled;
+
+  module.exports.compile = CoffeeScript.compile;
+
+  module.exports.tokens = CoffeeScript.tokens;
+
+  module.exports.nodes = CoffeeScript.nodes;
+
+  module.exports.register = CoffeeScript.register;
+
+  module.exports.eval = CoffeeScript.eval;
+
+  module.exports.run = CoffeeScript.run;
+
+  module.exports.transpile = CoffeeScript.transpile;
+
+  module.exports._compileRawFileContent = CoffeeScript._compileRawFileContent;
+
+  module.exports._compileFile = CoffeeScript._compileFile;
+
 }).call(this);

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -137,3 +137,22 @@ CoffeeScript._compileFile = (filename, options = {}) ->
   CoffeeScript._compileRawFileContent raw, filename, options
 
 module.exports = CoffeeScript
+
+# Explicitly define all named exports so that Node’s automatic detection of
+# named exports from CommonJS packages finds all of them. This enables consuming
+# packages to write code like `import { compile } from 'coffeescript'`.
+# Don’t simplify this into a loop or similar; the `module.exports.name` part is
+# essential for Node’s algorithm to successfully detect the name.
+module.exports.VERSION = CoffeeScript.VERSION
+module.exports.FILE_EXTENSIONS = CoffeeScript.FILE_EXTENSIONS
+module.exports.helpers = CoffeeScript.helpers
+module.exports.registerCompiled = CoffeeScript.registerCompiled
+module.exports.compile = CoffeeScript.compile
+module.exports.tokens = CoffeeScript.tokens
+module.exports.nodes = CoffeeScript.nodes
+module.exports.register = CoffeeScript.register
+module.exports.eval = CoffeeScript.eval
+module.exports.run = CoffeeScript.run
+module.exports.transpile = CoffeeScript.transpile
+module.exports._compileRawFileContent = CoffeeScript._compileRawFileContent
+module.exports._compileFile = CoffeeScript._compileFile


### PR DESCRIPTION
When writing ES module code in Node, the following doesn’t currently work:

```js
import { compile } from 'coffeescript';
```

This is because `coffeescript` is a CommonJS package that exports a single object (`module.exports = CoffeeScript`) and Node’s “best guess” algorithm for trying to detect named exports of CommonJS packages can’t find CoffeeScript’s exports. Currently only `import CoffeeScript from 'coffeescript'` works.

This PR simply adds several lines that explicitly define the named exports, which enables code like the first example to work. cc @guybedford

There are no tests for this, because the only way to currently run ESM code in Node from a CommonJS context is to either use an [experimental API](https://nodejs.org/api/vm.html#vm_class_vm_module) that’s moribund and likely to significantly change whenever it gets picked up again, or to spawn a child process of Node which is a bit too resource-intensive for our test suite. This code is extremely low risk, though, and doesn’t strike me as needing tests.