### PR TITLE
CI: Ensure browser tests are up-to-date

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,12 +30,11 @@ jobs:
     - run: node ./bin/cake build:parser
     # Build the browser compiler for the headless browser test
     - run: node ./bin/cake build:browser
+    # Build test.html, so that test:browser uses the latest tests
+    - run: node ./bin/cake doc:test
 
     # Check that the git diff is clean, to ensure that the updated build output was committed
     - run: git diff --exit-code
-
-    # Build test.html, so that test:browser uses the latest tests
-    - run: node ./bin/cake doc:test
 
     # Test
     - run: node ./bin/cake test

--- a/Cakefile
+++ b/Cakefile
@@ -310,7 +310,7 @@ buildDocTests = (watch = no) ->
   # Helpers
   testsInScriptBlocks = ->
     output = ''
-    for filename in fs.readdirSync testsSourceFolder
+    for filename in fs.readdirSync(testsSourceFolder).sort()
       if filename.indexOf('.coffee') isnt -1
         type = 'coffeescript'
       else if filename.indexOf('.litcoffee') isnt -1


### PR DESCRIPTION
Today I learned about the cake rule `doc:test` which builds the browser tests from the main tests (similar to `build:browser` but for the tests). This PR ensures that those tests are up-to-date before CI can succeed, similar to the other build operations we do.

As a side note, I find the name `doc:test` rather confusing, as it's about building tests not documenting or running them. But that's less important.
