### PR TITLE
Fix CI for Node 16.14.x

### DIFF
--- a/docs/v2/test.html
+++ b/docs/v2/test.html
@@ -25716,22 +25716,32 @@ test "the `baseFileName` helper returns the file name to write to", ->
 <script type="text/x-coffeescript" class="test" id="import_assertions">
 # This file is running in CommonJS (in Node) or as a classic Script (in the browser tests) so it can use import() within an async function, but not at the top level; and we can’t use static import.
 test "dynamic import assertion", ->
-  if typeof process is "undefined" or process.version?.startsWith("v17")
+  try
     { default: secret } = await import('data:application/json,{"ofLife":42}', { assert: { type: 'json' } })
     eq secret.ofLife, 42
+  catch e
+    # This parses on Node 16.14.x but throws an error async so the `skipUnless` feature detection won't catch it
+    # rethrow any other erorr
+    unless e.message is 'Invalid module "data:application/json,{"ofLife":42}" has an unsupported MIME type "application/json"'
+      throw e
 
 test "assert keyword", ->
-  if typeof process is "undefined" or process.version?.startsWith("v17")
-    assert = 1
+  assert = 1
 
+  try
     { default: assert } = await import('data:application/json,{"thatIAm":42}', { assert: { type: 'json' } })
     eq assert.thatIAm, 42
+  catch e
+    # This parses on Node 16.14.x but throws an error async so the `skipUnless` feature detection won't catch it
+    # rethrow any other erorr
+    unless e.message is 'Invalid module "data:application/json,{"thatIAm":42}" has an unsupported MIME type "application/json"'
+      throw e
 
-    eqJS """
-      import assert from 'regression-test'
-    """, """
-      import assert from 'regression-test';
-    """
+  eqJS """
+    import assert from 'regression-test'
+  """, """
+    import assert from 'regression-test';
+  """
 
 test "static import assertion", ->
   eqJS """

--- a/docs/v2/test.html
+++ b/docs/v2/test.html
@@ -25716,21 +25716,22 @@ test "the `baseFileName` helper returns the file name to write to", ->
 <script type="text/x-coffeescript" class="test" id="import_assertions">
 # This file is running in CommonJS (in Node) or as a classic Script (in the browser tests) so it can use import() within an async function, but not at the top level; and we can’t use static import.
 test "dynamic import assertion", ->
-  { default: secret } = await import('data:application/json,{"ofLife":42}', { assert: { type: 'json' } })
-  eq secret.ofLife, 42
+  if typeof process is "undefined" or process.version?.startsWith("v17")
+    { default: secret } = await import('data:application/json,{"ofLife":42}', { assert: { type: 'json' } })
+    eq secret.ofLife, 42
 
 test "assert keyword", ->
-  assert = 1
+  if typeof process is "undefined" or process.version?.startsWith("v17")
+    assert = 1
 
-  { default: assert } = await import('data:application/json,{"thatIAm":42}', { assert: { type: 'json' } })
-  eq assert.thatIAm, 42
+    { default: assert } = await import('data:application/json,{"thatIAm":42}', { assert: { type: 'json' } })
+    eq assert.thatIAm, 42
 
-  eqJS """
-    import assert from 'regression-test'
-  """, """
-    import assert from 'regression-test';
-  """
-
+    eqJS """
+      import assert from 'regression-test'
+    """, """
+      import assert from 'regression-test';
+    """
 
 test "static import assertion", ->
   eqJS """

--- a/docs/v2/test.html
+++ b/docs/v2/test.html
@@ -25719,11 +25719,10 @@ test "dynamic import assertion", ->
   try
     { default: secret } = await import('data:application/json,{"ofLife":42}', { assert: { type: 'json' } })
     eq secret.ofLife, 42
-  catch e
-    # This parses on Node 16.14.x but throws an error async so the `skipUnless` feature detection won't catch it
-    # rethrow any other erorr
-    unless e.message is 'Invalid module "data:application/json,{"ofLife":42}" has an unsupported MIME type "application/json"'
-      throw e
+  catch exception
+    # This parses on Node 16.14.x but throws an error because JSON modules aren’t unflagged there yet; remove this try/catch once the unflagging of `--experimental-json-modules` is backported (see https://github.com/nodejs/node/pull/41736#issuecomment-1086738670)
+    unless exception.message is 'Invalid module "data:application/json,{"ofLife":42}" has an unsupported MIME type "application/json"'
+      throw exception
 
 test "assert keyword", ->
   assert = 1
@@ -25731,11 +25730,10 @@ test "assert keyword", ->
   try
     { default: assert } = await import('data:application/json,{"thatIAm":42}', { assert: { type: 'json' } })
     eq assert.thatIAm, 42
-  catch e
-    # This parses on Node 16.14.x but throws an error async so the `skipUnless` feature detection won't catch it
-    # rethrow any other erorr
-    unless e.message is 'Invalid module "data:application/json,{"thatIAm":42}" has an unsupported MIME type "application/json"'
-      throw e
+  catch exception
+    # This parses on Node 16.14.x but throws an error because JSON modules aren’t unflagged there yet; remove this try/catch once the unflagging of `--experimental-json-modules` is backported (see https://github.com/nodejs/node/pull/41736#issuecomment-1086738670)
+    unless exception.message is 'Invalid module "data:application/json,{"thatIAm":42}" has an unsupported MIME type "application/json"'
+      throw exception
 
   eqJS """
     import assert from 'regression-test'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2254,14 +2254,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001257",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-      "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+      "version": "1.0.30001323",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001323.tgz",
+      "integrity": "sha512-e4BF2RlCVELKx8+RmklSEIVub1TWrmdhvA5kEUueummz1XyySW0DVk+3x9HyhU9MuWTa2BhqLgEuEmUwASAdCA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -5689,9 +5695,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001257",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-      "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+      "version": "1.0.30001323",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001323.tgz",
+      "integrity": "sha512-e4BF2RlCVELKx8+RmklSEIVub1TWrmdhvA5kEUueummz1XyySW0DVk+3x9HyhU9MuWTa2BhqLgEuEmUwASAdCA==",
       "dev": true
     },
     "chalk": {

--- a/test/import_assertions.coffee
+++ b/test/import_assertions.coffee
@@ -1,20 +1,21 @@
 # This file is running in CommonJS (in Node) or as a classic Script (in the browser tests) so it can use import() within an async function, but not at the top level; and we can’t use static import.
 test "dynamic import assertion", ->
-  { default: secret } = await import('data:application/json,{"ofLife":42}', { assert: { type: 'json' } })
-  eq secret.ofLife, 42
+  if typeof process is "undefined" or process.version?.startsWith("v17")
+    { default: secret } = await import('data:application/json,{"ofLife":42}', { assert: { type: 'json' } })
+    eq secret.ofLife, 42
 
 test "assert keyword", ->
-  assert = 1
+  if typeof process is "undefined" or process.version?.startsWith("v17")
+    assert = 1
 
-  { default: assert } = await import('data:application/json,{"thatIAm":42}', { assert: { type: 'json' } })
-  eq assert.thatIAm, 42
+    { default: assert } = await import('data:application/json,{"thatIAm":42}', { assert: { type: 'json' } })
+    eq assert.thatIAm, 42
 
-  eqJS """
-    import assert from 'regression-test'
-  """, """
-    import assert from 'regression-test';
-  """
-
+    eqJS """
+      import assert from 'regression-test'
+    """, """
+      import assert from 'regression-test';
+    """
 
 test "static import assertion", ->
   eqJS """

--- a/test/import_assertions.coffee
+++ b/test/import_assertions.coffee
@@ -3,11 +3,10 @@ test "dynamic import assertion", ->
   try
     { default: secret } = await import('data:application/json,{"ofLife":42}', { assert: { type: 'json' } })
     eq secret.ofLife, 42
-  catch e
-    # This parses on Node 16.14.x but throws an error async so the `skipUnless` feature detection won't catch it
-    # rethrow any other erorr
-    unless e.message is 'Invalid module "data:application/json,{"ofLife":42}" has an unsupported MIME type "application/json"'
-      throw e
+  catch exception
+    # This parses on Node 16.14.x but throws an error because JSON modules aren’t unflagged there yet; remove this try/catch once the unflagging of `--experimental-json-modules` is backported (see https://github.com/nodejs/node/pull/41736#issuecomment-1086738670)
+    unless exception.message is 'Invalid module "data:application/json,{"ofLife":42}" has an unsupported MIME type "application/json"'
+      throw exception
 
 test "assert keyword", ->
   assert = 1
@@ -15,11 +14,10 @@ test "assert keyword", ->
   try
     { default: assert } = await import('data:application/json,{"thatIAm":42}', { assert: { type: 'json' } })
     eq assert.thatIAm, 42
-  catch e
-    # This parses on Node 16.14.x but throws an error async so the `skipUnless` feature detection won't catch it
-    # rethrow any other erorr
-    unless e.message is 'Invalid module "data:application/json,{"thatIAm":42}" has an unsupported MIME type "application/json"'
-      throw e
+  catch exception
+    # This parses on Node 16.14.x but throws an error because JSON modules aren’t unflagged there yet; remove this try/catch once the unflagging of `--experimental-json-modules` is backported (see https://github.com/nodejs/node/pull/41736#issuecomment-1086738670)
+    unless exception.message is 'Invalid module "data:application/json,{"thatIAm":42}" has an unsupported MIME type "application/json"'
+      throw exception
 
   eqJS """
     import assert from 'regression-test'

--- a/test/import_assertions.coffee
+++ b/test/import_assertions.coffee
@@ -1,21 +1,31 @@
 # This file is running in CommonJS (in Node) or as a classic Script (in the browser tests) so it can use import() within an async function, but not at the top level; and we can’t use static import.
 test "dynamic import assertion", ->
-  if typeof process is "undefined" or process.version?.startsWith("v17")
+  try
     { default: secret } = await import('data:application/json,{"ofLife":42}', { assert: { type: 'json' } })
     eq secret.ofLife, 42
+  catch e
+    # This parses on Node 16.14.x but throws an error async so the `skipUnless` feature detection won't catch it
+    # rethrow any other erorr
+    unless e.message is 'Invalid module "data:application/json,{"ofLife":42}" has an unsupported MIME type "application/json"'
+      throw e
 
 test "assert keyword", ->
-  if typeof process is "undefined" or process.version?.startsWith("v17")
-    assert = 1
+  assert = 1
 
+  try
     { default: assert } = await import('data:application/json,{"thatIAm":42}', { assert: { type: 'json' } })
     eq assert.thatIAm, 42
+  catch e
+    # This parses on Node 16.14.x but throws an error async so the `skipUnless` feature detection won't catch it
+    # rethrow any other erorr
+    unless e.message is 'Invalid module "data:application/json,{"thatIAm":42}" has an unsupported MIME type "application/json"'
+      throw e
 
-    eqJS """
-      import assert from 'regression-test'
-    """, """
-      import assert from 'regression-test';
-    """
+  eqJS """
+    import assert from 'regression-test'
+  """, """
+    import assert from 'regression-test';
+  """
 
 test "static import assertion", ->
   eqJS """


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines:
https://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](https://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->

Guarding dynamic import tests based on Node version
These import assertions weren't actually running on older versions of
Node. They failed to parse so failed to run at all. Node 16.14.x added
support to parse the import assertion syntax but instead failed with
`Invalid module "data:application/json,..." has an unsupported MIME type "application/json"`

Node 17.8.x supports the syntax and supports the `application/json` mime
as well.

As a cleanup item also updated caniuse-lite.