### PR TITLE
Remove always true `if` check

### DIFF
--- a/lib/coffeescript/index.js
+++ b/lib/coffeescript/index.js
@@ -60,10 +60,8 @@
     // Save the options for compiling child imports.
     mainModule.options = options;
     // Compile.
-    if (!helpers.isCoffee(mainModule.filename) || require.extensions) {
-      answer = CoffeeScript.compile(code, options);
-      code = (ref = answer.js) != null ? ref : answer;
-    }
+    answer = CoffeeScript.compile(code, options);
+    code = (ref = answer.js) != null ? ref : answer;
     return mainModule._compile(code, mainModule.filename);
   };
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -53,9 +53,8 @@ CoffeeScript.run = (code, options = {}) ->
   mainModule.options = options
 
   # Compile.
-  if not helpers.isCoffee(mainModule.filename) or require.extensions
-    answer = CoffeeScript.compile code, options
-    code = answer.js ? answer
+  answer = CoffeeScript.compile code, options
+  code = answer.js ? answer
 
   mainModule._compile code, mainModule.filename
 


### PR DESCRIPTION
This check has always been true since Node 0.3.0. It was added here: https://github.com/jashkenas/coffeescript/commit/c4a3e170e230d7bf0a2513c1224d71f685dafb43 and seems to rely on the behavior of `Module#_compile` from before `require.extensions`. If `require.extensions` is ever removed (it is deprecated after all) then `CoffeeScript.run` will no longer work. It will pass CoffeeScript source code to `Module#_compile` which is doomed to fail.

Browser code doesn't touch this path at all and is unaffected.

<!--
Before making a PR please make sure to read our contributing guidelines:
https://coffeescript.org/#contributing

For issue references: Add a comma-separated list of a
[closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by
the ticket number fixed by the PR. It should be underlined in the preview if done correctly.

All new features require tests. All but the most trivial bug fixes should also have new or updated tests.

Ensure that all new code you add to the compiler can be run in the minimum version of Node listed in
`package.json`. New tests can require newer Node runtimes, but you may need to ensure that such tests
only run in supported runtimes; see `Cakefile` for examples of how to filter out certain tests in
runtimes that don’t support them.

Please follow the code style of the rest of the CoffeeScript codebase. Write comments in complete
sentences using Markdown, as the comments become the [annotated source](https://coffeescript.org/#annotated-source).
For tests proving a bug is fixed, please mention the issue number in the test description (see examples
in the codebase).

Describe your changes below in as much detail as possible.
-->
