### PR TITLE
Report browser test errors

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -515,33 +515,33 @@ task 'test:browser', 'run the test suite against the modern browser compiler in 
     else
       res.statusCode = 404
       res.end()
-  server.listen 8080
 
-  puppeteer = require 'puppeteer'
-  browser   = await puppeteer.launch()
-  page      = await browser.newPage()
-  result    = null
+  server.listen 8080, ->
+    puppeteer = require 'puppeteer'
+    browser   = await puppeteer.launch()
+    page      = await browser.newPage()
+    result    = null
 
-  try
-    await page.goto 'http://localhost:8080/'
+    try
+      await page.goto 'http://localhost:8080/'
 
-    element = await page.waitForSelector '#result',
-      visible: yes
-      polling: 'mutation'
-      timeout: 60000
+      element = await page.waitForSelector '#result',
+        visible: yes
+        polling: 'mutation'
+        timeout: 60000
 
-    result = await page.evaluate ((el) => el.textContent), element
-  catch e
-    log e, red
-  finally
-    try browser.close()
-    server.close()
+      result = await page.evaluate ((el) => el.textContent), element
+    catch e
+      log e, red
+    finally
+      try browser.close()
+      server.close()
 
-  if result and not result.includes('failed')
-    log result, green
-  else
-    log result, red
-    process.exit 1
+    if result and not result.includes('failed')
+      log result, green
+    else
+      log result, red
+      process.exit 1
 
 
 task 'test:browser:node', 'run the test suite against the legacy browser compiler in Node', ->

--- a/Cakefile
+++ b/Cakefile
@@ -520,7 +520,7 @@ task 'test:browser', 'run the test suite against the modern browser compiler in 
     puppeteer = require 'puppeteer'
     browser   = await puppeteer.launch()
     page      = await browser.newPage()
-    result    = null
+    result    = ""
 
     try
       await page.goto 'http://localhost:8080/'

--- a/Cakefile
+++ b/Cakefile
@@ -531,23 +531,26 @@ task 'test:browser', 'run the test suite against the modern browser compiler in 
   puppeteer = require 'puppeteer'
   browser = page = result = null
   puppeteer.launch()
-  .then((browserHandle) ->
+  .then (browserHandle) ->
     browser = browserHandle
     browser.newPage()
-  ).then((pageHandle) ->
+  .then (pageHandle) ->
     page = pageHandle
     page.goto 'http://localhost:8080/'
-  ).then(->
+  .then ->
     page.waitForSelector '#result',
       visible: yes
       polling: 'mutation'
-  ).then((element) ->
+      timeout: 60000
+  .then (element) ->
     page.evaluate ((el) => el.textContent), element
-  ).then((elementText) ->
+  .then (elementText) ->
     result = elementText
-  ).finally(->
+  .catch (e) ->
+    log e, red
+  .finally ->
     browser.close()
-  ).finally ->
+  .finally ->
     server.close()
     if result and not result.includes('failed')
       log result, green


### PR DESCRIPTION
When running browser tests sometimes they would fail and only print `null`. I added a `.catch` to log any error that is thrown (could be a timeout or intermittent error). I also removed extra parentheses and increased the timeout to 60s.
