### PR TITLE
Add `patchStackTrace` export; test that all named exports are detected by Node

### DIFF
--- a/docs/v2/annotated-source/index.html
+++ b/docs/v2/annotated-source/index.html
@@ -485,6 +485,7 @@ module.<span class="hljs-built_in">exports</span>.register = CoffeeScript.regist
 module.<span class="hljs-built_in">exports</span>.<span class="hljs-built_in">eval</span> = CoffeeScript.<span class="hljs-built_in">eval</span>
 module.<span class="hljs-built_in">exports</span>.run = CoffeeScript.run
 module.<span class="hljs-built_in">exports</span>.transpile = CoffeeScript.transpile
+module.<span class="hljs-built_in">exports</span>.patchStackTrace = CoffeeScript.patchStackTrace
 module.<span class="hljs-built_in">exports</span>._compileRawFileContent = CoffeeScript._compileRawFileContent
 module.<span class="hljs-built_in">exports</span>._compileFile = CoffeeScript._compileFile</pre></div></div>
             

--- a/docs/v2/test.html
+++ b/docs/v2/test.html
@@ -31455,18 +31455,22 @@ banner text
 <script type="text/x-coffeescript" class="test" id="package">
 return if window? or testingBrowser?
 
-{EventEmitter} = require 'events'
-{join}         = require 'path'
-{cwd}          = require 'process'
+{EventEmitter}  = require 'events'
+{join}          = require 'path'
+{cwd}           = require 'process'
+{pathToFileURL} = require 'url'
+
+
+packageEntryPath = join cwd(), 'lib/coffeescript/index.js'
+packageEntryUrl  = pathToFileURL packageEntryPath
 
 
 test "the coffeescript package exposes all members as named exports in Node", ->
-  packageEntry = join cwd(), 'lib/coffeescript/index.js'
 
-  requiredPackage = require packageEntry
+  requiredPackage = require packageEntryPath
   requiredKeys = Object.keys requiredPackage
 
-  importedPackage = await import(packageEntry)
+  importedPackage = await import(packageEntryUrl)
   importedKeys = new Set Object.keys(importedPackage)
 
   # In `command.coffee`, CoffeeScript extends a `new EventEmitter`;

--- a/docs/v2/test.html
+++ b/docs/v2/test.html
@@ -31452,6 +31452,32 @@ banner text
   ok new OptionParser(flags).help() is expected
 
 </script>
+<script type="text/x-coffeescript" class="test" id="package">
+return if window? or testingBrowser?
+
+{EventEmitter} = require 'events'
+{join}         = require 'path'
+{cwd}          = require 'process'
+
+
+test "the coffeescript package exposes all members as named exports in Node", ->
+  packageEntry = join cwd(), 'lib/coffeescript/index.js'
+
+  requiredPackage = require packageEntry
+  requiredKeys = Object.keys requiredPackage
+
+  importedPackage = await import(packageEntry)
+  importedKeys = new Set Object.keys(importedPackage)
+
+  # In `command.coffee`, CoffeeScript extends a `new EventEmitter`;
+  # we want to ignore these additional added keys.
+  eventEmitterKeys = new Set Object.getOwnPropertyNames(Object.getPrototypeOf(new EventEmitter))
+
+  for key in requiredKeys when not eventEmitterKeys.has(key)
+    # Use `eq` test so that missing keys have their names printed in the error message.
+    eq (if importedKeys.has(key) then key else undefined), key
+
+</script>
 <script type="text/x-coffeescript" class="test" id="parser">
 # Parser
 # ---------

--- a/lib/coffeescript/index.js
+++ b/lib/coffeescript/index.js
@@ -208,6 +208,8 @@
 
   module.exports.transpile = CoffeeScript.transpile;
 
+  module.exports.patchStackTrace = CoffeeScript.patchStackTrace;
+
   module.exports._compileRawFileContent = CoffeeScript._compileRawFileContent;
 
   module.exports._compileFile = CoffeeScript._compileFile;

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -155,5 +155,6 @@ module.exports.register = CoffeeScript.register
 module.exports.eval = CoffeeScript.eval
 module.exports.run = CoffeeScript.run
 module.exports.transpile = CoffeeScript.transpile
+module.exports.patchStackTrace = CoffeeScript.patchStackTrace
 module.exports._compileRawFileContent = CoffeeScript._compileRawFileContent
 module.exports._compileFile = CoffeeScript._compileFile

--- a/test/package.coffee
+++ b/test/package.coffee
@@ -1,17 +1,21 @@
 return if window? or testingBrowser?
 
-{EventEmitter} = require 'events'
-{join}         = require 'path'
-{cwd}          = require 'process'
+{EventEmitter}  = require 'events'
+{join}          = require 'path'
+{cwd}           = require 'process'
+{pathToFileURL} = require 'url'
+
+
+packageEntryPath = join cwd(), 'lib/coffeescript/index.js'
+packageEntryUrl  = pathToFileURL packageEntryPath
 
 
 test "the coffeescript package exposes all members as named exports in Node", ->
-  packageEntry = join cwd(), 'lib/coffeescript/index.js'
 
-  requiredPackage = require packageEntry
+  requiredPackage = require packageEntryPath
   requiredKeys = Object.keys requiredPackage
 
-  importedPackage = await import(packageEntry)
+  importedPackage = await import(packageEntryUrl)
   importedKeys = new Set Object.keys(importedPackage)
 
   # In `command.coffee`, CoffeeScript extends a `new EventEmitter`;

--- a/test/package.coffee
+++ b/test/package.coffee
@@ -1,0 +1,23 @@
+return if window? or testingBrowser?
+
+{EventEmitter} = require 'events'
+{join}         = require 'path'
+{cwd}          = require 'process'
+
+
+test "the coffeescript package exposes all members as named exports in Node", ->
+  packageEntry = join cwd(), 'lib/coffeescript/index.js'
+
+  requiredPackage = require packageEntry
+  requiredKeys = Object.keys requiredPackage
+
+  importedPackage = await import(packageEntry)
+  importedKeys = new Set Object.keys(importedPackage)
+
+  # In `command.coffee`, CoffeeScript extends a `new EventEmitter`;
+  # we want to ignore these additional added keys.
+  eventEmitterKeys = new Set Object.getOwnPropertyNames(Object.getPrototypeOf(new EventEmitter))
+
+  for key in requiredKeys when not eventEmitterKeys.has(key)
+    # Use `eq` test so that missing keys have their names printed in the error message.
+    eq (if importedKeys.has(key) then key else undefined), key


### PR DESCRIPTION
Follow-up to #5403; this adds the new `patchStackTrace` export, so that `import { patchStackTrace } from 'coffeescript'` works in Node’s native ESM. I noticed this while writing up the changelog.

I also added a test so that we don’t miss these in the future. cc @STRd6 