### PR TITLE
Fix line-height change from hover

### DIFF
--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -50,6 +50,7 @@
   white-space: pre-wrap;
 }
 .CodeMirror pre,
+.CodeMirror pre.CodeMirror-line,
 pre.placeholder-code {
   line-height: 1.4em;
 }

--- a/documentation/site/code.css
+++ b/documentation/site/code.css
@@ -30,6 +30,7 @@
   white-space: pre-wrap;
 }
 .CodeMirror pre,
+.CodeMirror pre.CodeMirror-line,
 pre.placeholder-code {
   line-height: 1.4em;
 }


### PR DESCRIPTION
Partial solution to #5448, fixing the line height change when switching to CodeMirror mode.  But there are still tiny discrepancies in overall size which might be due to a single `<pre>` vs. multiple line `<div>`s (or something else; I'm not certain). Still, this fixes most of the issue.