### PR TITLE
Also declare async function, if an  await was found in function's body

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -11,7 +11,7 @@ Error.stackTraceLimit = Infinity
 # Import the helpers we plan to use.
 {compact, flatten, extend, merge, del, starts, ends, some,
 addDataToNode, attachCommentsToNode, locationDataToString,
-throwSyntaxError, replaceUnicodeCodePointEscapes,
+throwSyntaxError, replaceUnicodeCodePointEscapes, count,
 isFunction, isPlainObject, isNumber, parseNumber} = require './helpers'
 
 # Functions required by parser.
@@ -3911,6 +3911,8 @@ exports.Code = class Code extends Base
       if (node instanceof Op and node.isAwait()) or node instanceof AwaitReturn
         @isAsync = yes
       if node instanceof For and node.isAwait()
+        @isAsync = yes
+      if node instanceof Function and count @body, 'await' > 0
         @isAsync = yes
 
     @propagateLhs()


### PR DESCRIPTION
**Solves the error** '_Unexpected reserved word_ "await"':
````
      dir = (await opendir(this.path));
             ^^^^^

SyntaxError: Unexpected reserved word
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:152:18)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:298:14)

Node.js v18.19.1````
