### PR TITLE
Fixes #5480: clear  when re-inverting an 'in' Op

### DIFF
--- a/lib/coffeescript/nodes.js
+++ b/lib/coffeescript/nodes.js
@@ -6987,7 +6987,11 @@
       invert() {
         var allInvertable, curr, fst, op, ref1;
         if (this.isInOperator()) {
-          this.invertOperator = '!';
+          if (this.invertOperator) {
+            this.invertOperator = void 0;
+          } else {
+            this.invertOperator = '!';
+          }
           return this;
         }
         if (this.isChain()) {

--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -4686,7 +4686,10 @@ exports.Op = class Op extends Base
 
   invert: ->
     if @isInOperator()
-      @invertOperator = '!'
+      if @invertOperator
+        @invertOperator = undefined
+      else
+        @invertOperator = '!'
       return @
     if @isChain()
       allInvertable = yes

--- a/test/operators.coffee
+++ b/test/operators.coffee
@@ -466,11 +466,11 @@ test "#5480: 'when a not in b'", ->
   switch
     when needle not in needleStack then ok false
 
-  switch "with subject"
+  switch "with subject" and true
     when needle     in    hayStack then ok false
-  switch "with subject"
+  switch "with subject" and true
     when needle not in    hayStack then ok true
-  switch "with subject"
+  switch "with subject" and true
     when needle     in needleStack then ok true
-  switch "with subject"
+  switch "with subject" and true
     when needle not in needleStack then ok false

--- a/test/operators.coffee
+++ b/test/operators.coffee
@@ -451,3 +451,26 @@ test "'new' target", ->
 
   # classes must be called with `new`. In this case `new` applies to `get` only
   throws -> new get()()
+
+test "#5480: 'when a not in b'", ->
+  needle      = "needle"
+  hayStack    = []
+  needleStack = [needle]
+
+  switch
+    when needle     in    hayStack then ok false
+  switch
+    when needle not in    hayStack then ok true
+  switch
+    when needle     in needleStack then ok true
+  switch
+    when needle not in needleStack then ok false
+
+  switch "with subject"
+    when needle     in    hayStack then ok false
+  switch "with subject"
+    when needle not in    hayStack then ok true
+  switch "with subject"
+    when needle     in needleStack then ok true
+  switch "with subject"
+    when needle not in needleStack then ok false


### PR DESCRIPTION
fixes #5480

Please note that tests other than the one I added are failing and were already failing. I will address those in a future PR if nobody else gets to it first.

In `Op::invert` in `nodes.coffee`, there was no reverse mechanism, so `op.invert().invert() !== op`. I added a check for already being inverted and removed the inversion flag. It feels like a bad code smell to use a string as a boolean, but I'm not heart to change the code style. I made the simplest, most obvious edit I could. Code style is probably a v3 thing, if such an effort were ever to come about.

This fix seems to only be relevant to switch case expressions, so I used that in the test I added. The test checks all eight permutations of subject included, value is actually in the list and expression is inverted. The bug was not triggered when the switch expression included a subject because the case expressions don't get inverted then. I didn't quite understand the logic behind inverting the case expressions, but since that part was working I didn't touch it. I separated each case into its own switch expression so that the fallthrough on match wouldn't hide any permutations.

The only changed files are nodes.coffee for the four-line fix, nodes.js after the rebuild and test/operations.coffee to add the test for this bug.